### PR TITLE
Hide tags for now since they aren't being used.

### DIFF
--- a/app/views/groups/_membership.html.haml
+++ b/app/views/groups/_membership.html.haml
@@ -7,7 +7,7 @@
     =link_to "remove", membership, method: :delete,
       confirm: "Are you sure you wish to remove #{membership.user_email} from the group?"
     %br
-    %b Tags:
-    -#=membership.group_tags.join(", ") if membership.group_tags
-    %input{:id => "user-tags-" + membership.user_id.to_s}
-    .clear-both
+    -# Hide tags for now
+    -#%b Tags:
+    -#%input{:id => "user-tags-" + membership.user_id.to_s}
+    -#.clear-both

--- a/app/views/groups/_users.haml
+++ b/app/views/groups/_users.haml
@@ -5,6 +5,5 @@
     %ul.unstyled
       =render :partial => 'membership_request', :collection => @group.membership_requests
 %h3 Users:
-%p Autocomplete will help find existing tags, or enter a comma at the end to make a new tag.
 %ul.unstyled{:id => "users-list"}
   =render :partial => 'membership', :collection => @group.memberships


### PR DESCRIPTION
We're about to deploy, so I'm hiding the tags feature from the groups page since it's implementation currently isn't finished.
