### PR TITLE
Improve mailers

### DIFF
--- a/app/mailers/group_mailer.rb
+++ b/app/mailers/group_mailer.rb
@@ -5,6 +5,7 @@ class GroupMailer < ActionMailer::Base
     @user = membership.user
     @group = membership.group
     @admins = @group.admins.map(&:email)
-    mail(:to => @admins, :subject => "[Loomio: #{@group.name}] Membership waiting approval")
+    mail(:to => @admins, :subject => "[Loomio: #{@group.name}] New membership" +
+      " request from #{membership.user.name}")
   end
 end

--- a/app/mailers/motion_mailer.rb
+++ b/app/mailers/motion_mailer.rb
@@ -8,7 +8,7 @@ class MotionMailer < ActionMailer::Base
     #@group.users.each do |user|
       #email_addresses << user.email unless motion.author == user
     #end
-    mail(to: email, subject: "[Loomio: #{@group.name}] New motion")
+    mail(to: email, subject: "[Loomio: #{@group.name}] New motion - #{@motion.name}")
   end
 
   def motion_blocked(vote)
@@ -17,6 +17,6 @@ class MotionMailer < ActionMailer::Base
     @motion = vote.motion
     @group = @motion.group
     mail(to: @motion.author.email,
-         subject: "[Loomio: #{@group.name}] Motion has been blocked")
+         subject: "[Loomio: #{@group.name}] Motion blocked - #{@motion.name}")
   end
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -4,6 +4,6 @@ class UserMailer < ActionMailer::Base
   def group_membership_approved(user, group)
     @user = user
     @group = group
-    mail(:to => user.email, :subject => "[Loomio: #{group.name}] Membership approved.")
+    mail(:to => user.email, :subject => "[Loomio: #{group.name}] Membership approved")
   end
 end

--- a/app/views/motion_mailer/new_motion_created.text.haml
+++ b/app/views/motion_mailer/new_motion_created.text.haml
@@ -5,8 +5,7 @@ A new motion was created in a Loomio group that you belong to.
 :plain
 
 
-= "Motion Name: #{@motion.name}"
+= "Motion: #{@motion.name}"
 = "Group: #{@motion.group.name}"
 - if @motion.description.present?
-  Description:
-  = @motion.description
+  = "Description: " + @motion.description

--- a/lib/tasks/quality.rake
+++ b/lib/tasks/quality.rake
@@ -5,7 +5,7 @@ begin
   require 'support/best_practices_threshold'
 
   METRIC_THRESHOLDS = {
-    :coverage => 86.8,
+    :coverage => 88.0,
     :flay => 300,
     :complexity => 10,
     :line_length => 120,

--- a/spec/mailers/group_mailer_spec.rb
+++ b/spec/mailers/group_mailer_spec.rb
@@ -5,13 +5,14 @@ describe GroupMailer do
   describe 'sends email on membership request' do
     before(:all) do
       @group = Group.make!
-      membership = @group.add_request!(User.make!)
-      @mail = GroupMailer.new_membership_request(membership)
+      @membership = @group.add_request!(User.make!)
+      @mail = GroupMailer.new_membership_request(@membership)
     end
 
     #ensure that the subject is correct
     it 'renders the subject' do
-      @mail.subject.should == "[Loomio: #{@group.name}] Membership waiting approval"
+      @mail.subject.should ==
+        "[Loomio: #{@group.name}] New membership request from #{@membership.user.name}"
     end
 
     it "sends email to group admins" do

--- a/spec/mailers/motion_mailer_spec.rb
+++ b/spec/mailers/motion_mailer_spec.rb
@@ -16,7 +16,7 @@ describe MotionMailer do
 
     #ensure that the subject is correct
     it 'renders the subject' do
-      @email.subject.should == "[Loomio: #{group.name}] New motion"
+      @email.subject.should == "[Loomio: #{group.name}] New motion - #{motion.name}"
     end
 
     #ensure that the sender is correct
@@ -47,7 +47,7 @@ describe MotionMailer do
 
     #ensure that the subject is correct
     it 'renders the subject' do
-      @email.subject.should match(/Motion has been blocked/)
+      @email.subject.should match(/Motion blocked - #{motion.name}/)
     end
 
     #ensure that the sender is correct

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -10,7 +10,7 @@ describe UserMailer do
 
     #ensure that the subject is correct
     it 'renders the subject' do
-      @mail.subject.should == "[Loomio: #{@group.name}] Membership approved."
+      @mail.subject.should == "[Loomio: #{@group.name}] Membership approved"
     end
 
     #ensure that the receiver is correct


### PR DESCRIPTION
Updated email notification subjects so that they are unique for each motion (per Josh's request). This way they don't all end up in the same gmail thread.
