### PR TITLE
Bugfix: Trying to view a private group should redirect to login

### DIFF
--- a/app/controllers/group_base_controller.rb
+++ b/app/controllers/group_base_controller.rb
@@ -4,7 +4,11 @@ class GroupBaseController < BaseController
   private
     def check_group_read_permissions
       unless group.can_be_viewed_by? current_user
-        render 'groups/private_or_not_found'
+        if current_user
+          render 'groups/private_or_not_found'
+        else
+          authenticate_user!
+        end
       end
     end
 end

--- a/app/views/groups/private_or_not_found.html.haml
+++ b/app/views/groups/private_or_not_found.html.haml
@@ -1,4 +1,6 @@
 .general-form
   #private-message
+    %br
     %h2 Group not found.
-    %h2 This group may be private, you may need to be invited. Please contact someone within the group with the necessary permissions.
+    %br
+    %h2 This group might be private. If someone gave you this link, they may need to invite you to one of their groups so that you can see this page.

--- a/spec/controllers/groups_controller_spec.rb
+++ b/spec/controllers/groups_controller_spec.rb
@@ -77,7 +77,7 @@ describe GroupsController do
           @previous_url = root_url
           request.env["HTTP_REFERER"] = @previous_url
         end
-        it "viewing a group should redirect to private message page" do
+        it "viewing a group should redirect to 'group not found' page" do
           get :show, :id => @group.id
           response.should render_template('private_or_not_found')
         end
@@ -139,6 +139,18 @@ describe GroupsController do
 
       group.users.should include(user2)
       group.users.should include(user3)
+    end
+  end
+
+  context "logged out user" do
+    context "viewing a private group" do
+      before :each do
+        @group = Group.make!(viewable_by: :members)
+      end
+      it "should redirect to log-in page" do
+        get :show, :id => @group.id
+        response.should redirect_to(new_user_session_url)
+      end
     end
   end
 end

--- a/spec/requests/groups_spec.rb
+++ b/spec/requests/groups_spec.rb
@@ -130,13 +130,15 @@ describe "Groups" do
       end
     end
 
-    it "doesn't let us view a group the user does not belongs to" do
-      @group2 = Group.make(name: 'Test Group2', viewable_by: :members)
-      @group2.save
-      @group2.add_member!(User.make!)
-      visit group_path(@group2)
-      should have_content("This group may be private")
-      should have_no_content("Users")
+    context "group non-member viewing a private group" do
+      it "displays 'group not found' page" do
+        @group2 = Group.make(name: 'Test Group2', viewable_by: :members)
+        @group2.save
+        @group2.add_member!(User.make!)
+        visit group_path(@group2)
+        should have_content("Group not found")
+        should have_no_content("Users")
+      end
     end
   end
 
@@ -152,6 +154,19 @@ describe "Groups" do
       visit group_path(@group)
 
       should have_content("Test Group")
+    end
+
+    it "viewing a private group redirects to log-in" do
+      @user = User.make!
+      @group = Group.make!(name: 'Test Group', viewable_by: :members)
+      @group.add_member!(@user)
+      @discussion = create_discussion(group: @group, author: @user)
+      @motion = create_motion(name: 'Test Motion',
+                              discussion: @discussion,
+                              author: @user, facilitator: @user)
+      visit group_path(@group)
+
+      should have_css("body.sessions.new")
     end
   end
 end


### PR DESCRIPTION
Bugfix: Trying to view a private group should redirect to login (if user is logged-out)
