### PR TITLE
Motion template: remove edit timestamp.

### DIFF
--- a/app/models/motion.rb
+++ b/app/models/motion.rb
@@ -42,7 +42,7 @@ class Motion < ActiveRecord::Base
       transitions :to => :voting, :from => [:closed]
     end
 
-    event :close_voting, before: :before_close, after: :after_close do
+    event :close_voting, before: :before_close do
       transitions :to => :closed, :from => [:voting]
     end
   end
@@ -201,13 +201,8 @@ class Motion < ActiveRecord::Base
     end
 
     def before_close
-      Motion.record_timestamps = false
       store_users_that_didnt_vote
       self.close_date = Time.now
-    end
-
-    def after_close
-      Motion.record_timestamps = true
     end
 
     def store_users_that_didnt_vote

--- a/app/views/motions/_motion.html.haml
+++ b/app/views/motions/_motion.html.haml
@@ -13,8 +13,6 @@
       No close date
   .proposed-by
     = "Proposed #{time_ago_in_words(motion.created_at)} ago by #{motion.author_name}"
-    - if motion.updated_at != motion.created_at
-      = "(edited: #{time_ago_in_words(motion.updated_at)} ago)"
   .description
     - too_long = true if motion.description && motion.description.length > 200
     .short-description

--- a/spec/models/motion_spec.rb
+++ b/spec/models/motion_spec.rb
@@ -169,10 +169,6 @@ describe Motion do
       @motion.no_vote_count.should == 1
     end
 
-    it "should not update :updated_at" do
-      @motion.updated_at.should == @updated_at
-    end
-
     it "users_who_did_not_vote should return users who did not vote" do
       @motion.users_who_did_not_vote.should include(@user3)
     end


### PR DESCRIPTION
This is mainly to fix the travis bug. Also, we are going to be removing the "edit motion" option very shortly so it shouldn't be a problem removing this timestamp.
