### PR TITLE
improvement/discussion-notifications-reply-to-author

### DIFF
--- a/app/mailers/discussion_mailer.rb
+++ b/app/mailers/discussion_mailer.rb
@@ -7,7 +7,7 @@ class DiscussionMailer < ActionMailer::Base
     @group = discussion.group
     mail(
       to: user.email,
-      reply_to: discussion.author.email,
+      reply_to: discussion.author_email,
       subject: "#{email_subject_prefix(@group.full_name)} New discussion - #{@discussion.title}")
   end
 

--- a/app/mailers/motion_mailer.rb
+++ b/app/mailers/motion_mailer.rb
@@ -6,7 +6,7 @@ class MotionMailer < ActionMailer::Base
     @motion = motion
     @group = motion.group
     mail( to: email, 
-          reply_to: motion.author.email,
+          reply_to: motion.author_email,
           subject: "#{email_subject_prefix(@group.full_name)} New proposal - #{@motion.name}")
   end
 
@@ -16,7 +16,7 @@ class MotionMailer < ActionMailer::Base
     @motion = vote.motion
     @discussion = @motion.discussion
     @group = @motion.group
-    mail( to: @motion.author.email,
+    mail( to: @motion.author_email,
           reply_to: @group.admin_email,
           subject: "#{email_subject_prefix(@group.full_name)} Proposal blocked - #{@motion.name}")
   end

--- a/app/models/discussion.rb
+++ b/app/models/discussion.rb
@@ -24,6 +24,7 @@ class Discussion < ActiveRecord::Base
 
   delegate :users, :to => :group, :prefix => :group
   delegate :full_name, :to => :group, :prefix => :group
+  delegate :email, :to => :author, :prefix => :author
 
   attr_accessible :group_id, :group, :title
 

--- a/spec/mailers/discussion_mailer_spec.rb
+++ b/spec/mailers/discussion_mailer_spec.rb
@@ -18,7 +18,7 @@ describe DiscussionMailer do
     end
 
     it 'sends email to group members but not author' do
-      @email.to.should == [discussion.author.email]
+      @email.to.should == [discussion.author_email]
     end
 
     it 'assigns url_for discussion' do
@@ -26,7 +26,7 @@ describe DiscussionMailer do
     end
 
     it 'assigns reply to' do
-      @email.reply_to.should == [discussion.author.email]
+      @email.reply_to.should == [discussion.author_email]
     end
   end
 

--- a/spec/mailers/motion_mailer_spec.rb
+++ b/spec/mailers/motion_mailer_spec.rb
@@ -23,7 +23,7 @@ describe MotionMailer do
     
     #ensure that reply to is correct
     it 'assigns reply to' do
-      @email.reply_to.should == [motion.author.email]
+      @email.reply_to.should == [motion.author_email]
     end
 
     it 'sends email to group members but not author' do
@@ -61,7 +61,7 @@ describe MotionMailer do
     end
 
     it 'sends to the motion author' do
-      @email.to.should == [motion.author.email]
+      @email.to.should == [motion.author_email]
     end
     
     #ensure that reply to is correct


### PR DESCRIPTION
Changed motions and specs to reply to author rather than group admin email address.
