### PR TITLE
bug/new-motion-mailer-description-fix

### DIFF
--- a/app/views/motion_mailer/new_motion_created.text.haml
+++ b/app/views/motion_mailer/new_motion_created.text.haml
@@ -9,9 +9,8 @@ A new motion was created in a Loomio group that you belong to.
 != "Group: #{@motion.group.name}"
 != "Author: #{@motion.author.name}"
 - if @motion.has_close_date?
-  != "Closes in: #{time_ago_in_words @motion.close_date} (#{@motion.close_date.localtime.strftime('%a %d %b %Y, %I:%M%p, %Z')})"
-:plain
+  != "Closes in: #{time_ago_in_words @motion.close_date}" + "(#{@motion.close_date.localtime.strftime('%a %d %b %Y, %I:%M%p, %Z')})"
+\
 
 - if @motion.description.present?
   != "Description: \n#{@motion.description}"
-


### PR DESCRIPTION
- removed :plain haml filter, added \ for linebreak instead.
