### PR TITLE
Make modals not hide when clicking on greyed out background

### DIFF
--- a/app/assets/javascripts/bootstrap-custom.js.coffee
+++ b/app/assets/javascripts/bootstrap-custom.js.coffee
@@ -2,3 +2,7 @@ $ ->
   $(".topbar-wrapper").dropdown()
 $ ->
   $(".alert-message").alert()
+$ ->
+  $(".modal").modal
+    show: false
+    backdrop: "static"


### PR DESCRIPTION
Modals now do not hide when clicking on greyed out background behind the modal
