### PR TITLE
Allow to skip newrelic_rpm gem for dev environment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,6 @@ gem 'kaminari'
 gem 'activeadmin'
 gem 'nokogiri'
 gem 'redcarpet', :git => 'https://github.com/vmg/redcarpet.git'
-gem 'newrelic_rpm'
 
 # NOTE: sass-rails should be inside :assets group, but currently there is an issue with activeadmin
 #       which does not allow us to do this
@@ -82,3 +81,6 @@ group :test do
   gem 'email_spec'
 end
 
+group :production do
+  gem 'newrelic_rpm'
+end


### PR DESCRIPTION
Just a hotfix, not associated with any trello ticket, that allows to `bundle install` without the newrelic_rpm gem.
This is to prevent the annoying message :

> Unable to load configuration from config/newrelic.yml

To build your gemset without newrelic, just do `bundle install --without production` once, and then bundle will remember that you don't want to use the group production on your setup.
