### PR TITLE
Temporarily disable "see more" on IE7

### DIFF
--- a/app/views/application/_description.html.haml
+++ b/app/views/application/_description.html.haml
@@ -1,11 +1,20 @@
 .description-container
   .description-body
     - too_long = true if model.description && model.description.length > 500
+
+    <!--[if IE 7]>
+    .long-description.model-description
+      ~ markdown(model.description)
+    <![endif]-->
+    
+    <!--[if !IE 7]><!-->
     .short-description.model-description
       ~ markdown(truncate(model.description, length: 500, omission: '...', separator: ' '))
     .long-description.model-description{style: "display: none"}
       ~ markdown(model.description)
     = link_to "Show More", "#", class: 'see-more' if too_long
+    <!--<![endif]-->
+    
     - if can? :edit_description, model
       = link_to "Edit #{model_name} info", "#", class: "edit-description edit-#{model_name}-description"
 

--- a/app/views/motions/_motion.html.haml
+++ b/app/views/motions/_motion.html.haml
@@ -16,12 +16,21 @@
   .proposed-by
     = "Proposed #{time_ago_in_words(motion.created_at)} ago by #{motion.author_name}"
   .description
+  
+    <!--[if IE 7]>
+    .long-description{style: "display: none"}
+      ~ markdown(motion.description)
+    <![endif]-->
+
+    <!--[if !IE 7]><!-->
     - too_long = true if motion.description && motion.description.length > 200
     .short-description
       ~ markdown(truncate(motion.description, length: 200, omission: '...', separator: ' '))
     .long-description{style: "display: none"}
       ~ markdown(motion.description)
     = link_to "Show More", "#", class: 'see-more' if too_long
+    <!--<![endif]-->
+
   .pie{id: "graph_#{motion.id}"}
   .percentage-to-vote
     = "#{motion.percent_voted}% of members "


### PR DESCRIPTION
Just until we can sort out the display bug related to clicking "see more" on IE7.
