### PR TITLE
Do not notify non-group members when at-mentioned.

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -103,7 +103,10 @@ class Comment < ActiveRecord::Base
     usernames = extract_mentioned_screen_names(self.body)
     usernames.each do |name|
       user = User.find_by_username(name)
-      users.push(user) if user
+      # Only users that belong to this discussion's group
+      if user && user.group_ids.include?(discussion.group_id)
+        users.push(user)
+      end
     end
     users
   end

--- a/app/models/discussion.rb
+++ b/app/models/discussion.rb
@@ -50,12 +50,6 @@ class Discussion < ActiveRecord::Base
       comment.save
       if comment.valid?
         Event.new_comment!(comment)
-        mentions = comment.parse_mentions
-        if mentions.present?
-          mentions.each do |mentioned_user|
-            Event.user_mentioned!(comment, mentioned_user)
-          end
-        end
       end
       comment
     end

--- a/features/mention_user.feature
+++ b/features/mention_user.feature
@@ -6,12 +6,24 @@ Background:
   Given a group "demo-group" with "furry@example.com" as admin
   And I am logged in as "furry@example.com"
 
-Scenario: Mention user in comment
+Scenario: Mention user when writing a comment
   Given "harry@example.com" is a member of "demo-group"
   And I am viewing a discussion titled "hello" in "demo-group"
   When I am adding a comment and type in "@h"
   And I click on "@harry" in the menu that pops up
   Then I should see "@harry" added to the "new-comment" field
+
+Scenario: Submit a comment mentioning a group member
+  Given "harry@example.com" is a member of "demo-group"
+  And I am viewing a discussion titled "hello" in "demo-group"
+  When I submit a comment mentioning "@harry"
+  Then the user should be notified that they were mentioned
+
+Scenario: Submit a comment mentioning a group non-member
+  Given "harry@example.com" is a member of "a different group"
+  And I am viewing a discussion titled "hello" in "demo-group"
+  When I submit a comment mentioning "@harry"
+  Then the user should not be notified that they were mentioned
 
 Scenario: View comment with mentions
   Given "harry@example.com" is a member of "demo-group"

--- a/features/step_definitions/group_steps.rb
+++ b/features/step_definitions/group_steps.rb
@@ -14,20 +14,24 @@ Given /^I visit create subgroup page for group named "(.*?)"$/ do |arg1|
   click_link("subgroup-new")
 end
 
-Given /^"(.*?)" is a(?: non-admin)?(?: member)? of(?: group)? "(.*?)"$/ do |email, group|
+Given /^"(.*?)" is a(?: non-admin)?(?: member)? of(?: group)? "(.*?)"$/ do |email, group_name|
   @user = User.find_by_email(email)
-  if !@user 
+  if !@user
     @user = FactoryGirl.create(:user, :name => email.split("@").first, :email => email)
-  end 
-  Group.find_by_name(group).add_member!(@user)
+  end
+  group = Group.find_by_name(group_name)
+  group ||= FactoryGirl.create(:group, :name => group_name)
+  group.add_member!(@user)
 end
 
-Given /^"(.*?)" is a[n]? admin(?: member)? of(?: group)? "(.*?)"$/ do |email, group|
+Given /^"(.*?)" is an admin of(?: group)? "(.*?)"$/ do |email, group_name|
   user = User.find_by_email(email)
-  if !user 
+  if !user
     user = FactoryGirl.create(:user, :email => email)
-  end 
-  Group.find_by_name(group).add_admin!(user)
+  end
+  group = Group.find_by_name(group_name)
+  group ||= FactoryGirl.create(:group, :name => group_name)
+  group.add_admin!(user)
 end
 
 When /^I fill details for the subgroup$/ do

--- a/features/step_definitions/mention_user_steps.rb
+++ b/features/step_definitions/mention_user_steps.rb
@@ -10,16 +10,29 @@ When /^I click on "(.*?)" in the menu that pops up$/ do |arg1|
   end
 end
 
+When /^a comment exists mentioning "(.*?)"$/ do |text|
+  @discussion.add_comment @user, "Hey #{text}"
+end
+
+When /^I submit a comment mentioning "(.*?)"$/ do |mention|
+  fill_in 'new-comment', with: mention
+  click_button "post-new-comment"
+end
+
 Then /^I should see "(.*?)" added to the "(.*?)" field$/ do |text, field|
   input = find_field(field)
   input.value.should =~ /#{text}/
 end
 
-When /^a comment exists mentioning "(.*?)"$/ do |text|
-  @discussion.add_comment @user, "Hey #{text}"
-end
-
-Then /^I should see a link to "(.*?)"'s user$/ do |user|
+Then /^I should see a link to "(.*?)"\'s user$/ do |user|
   visit(current_path)
   page.should have_link("@#{user}")
+end
+
+Then /^the user should be notified that they were mentioned$/ do
+  Event.where(:kind => "user_mentioned").count.should == 1
+end
+
+Then /^the user should not be notified that they were mentioned$/ do
+  Event.where(:kind => "user_mentioned").count.should == 0
 end

--- a/spec/models/discussion_spec.rb
+++ b/spec/models/discussion_spec.rb
@@ -28,7 +28,7 @@ describe Discussion do
       @user = create(:user)
       @discussion.group.add_member! @user
     end
-    
+
     it "fires new_comment event if comment was created successfully" do
       Event.should_receive(:new_comment!)
       @discussion.add_comment(@user, "this is a test comment")
@@ -69,7 +69,7 @@ describe Discussion do
       @discussion.should have(@version_count + 1).versions
     end
   end
-  
+
   describe "#never_read_by(user)" do
     before do
       @discussion = create :discussion


### PR DESCRIPTION
This commit makes it so that at-mentions do not notify users who are not
members of the group.

I've also prevented mentioned users from receiving "new comment"
notifications, since they are already receiving at-mention notifications
for the comment. However, the code is a bit sloppy. It will need to be
refactored with Rob's upcoming event model refactor.
