### PR TITLE
fix small typo, so remember_me binding works

### DIFF
--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -7,7 +7,7 @@
     = f.password_field :password
     - if devise_mapping.rememberable?
       = f.check_box :remember_me
-      = f.label :remeber_me, "Remember me", class: "checkbox-label"
+      = f.label :remember_me, "Remember me", class: "checkbox-label"
     .sign-in-button
       = f.submit "Sign in", class: "btn btn-info small", :id => "sign-in-btn"
   = render :partial => "devise/shared/links"


### PR DESCRIPTION
Hi guys,
have been using loomio for a while, and it's great!
One little thing that was annoying me was that the "Remember me" label wasn't  binded to the checkbox in the login view, turns out it was just a typo.
Cheers!
