### PR TITLE
Do not email invited but not accepted users.

### DIFF
--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -33,7 +33,8 @@ class Group < ActiveRecord::Base
     :conditions => {:access_level => 'admin'},
     :class_name => 'Membership',
     :dependent => :destroy
-  has_many :users, :through => :memberships # TODO: rename to members
+  has_many :users, :through => :memberships, # TODO: rename to members
+           :conditions => { :invitation_token => nil }
   has_many :requested_users, :through => :membership_requests, source: :user
   has_many :admins, through: :admin_memberships, source: :user
   has_many :discussions, :dependent => :destroy

--- a/app/views/motion_mailer/new_motion_created.html.haml
+++ b/app/views/motion_mailer/new_motion_created.html.haml
@@ -11,9 +11,10 @@
   %br
   Author:
   = @motion.author.name
-  / - if @motion.has_close_date?
-  /   Closes in:
-  /   = time_ago_in_words(@motion.close_date + @motion.close_date.localtime.strftime('%a %d %b %Y, %I:%M%p, %Z'))
+  %br
+  - if @motion.has_close_date?
+    Closes in:
+    = time_ago_in_words(@motion.close_date) + " (" + @motion.close_date.localtime.strftime('%a %d %b %Y, %I:%M%p, %Z') + ")"
 
   %p
   - if @motion.description.present?

--- a/features/create_discussion.feature
+++ b/features/create_discussion.feature
@@ -23,12 +23,15 @@ Feature: User creates discussion
   Scenario: Members get emailed when a discussion is created
     Given "Ben" is a member of the group
     And "Hannah" is a member of the group
+    And "newuser@example.org" has been invited to the group but has not accepted
     And no emails have been sent
     And "Ben" has chosen to be emailed about new discussions and decisions for the group
     And "Hannah" has chosen not to be emailed about new discussions and decisions for the group
     When I visit the group page
     And I choose to create a discussion
     And I fill in the discussion details and submit the form
-    Then "Ben" should be emailed about the new discussion
+    And "ben@example.org" should receive an email
+    When "ben@example.org" opens the email
     And clicking the link in the email should take him to the discussion
-    And "Hannah" should not be emailed about the new discussion
+    And "hannah@example.org" should receive no email
+    And "newuser@example.org" should receive no email

--- a/features/create_proposal.feature
+++ b/features/create_proposal.feature
@@ -16,15 +16,17 @@ Feature: User creates proposal
     And I should see the proposal details
 
   Scenario: Members get emailed when a proposal is created
-   Given "Ben" is a member of the group
+    Given "Ben" is a member of the group
     And "Hannah" is a member of the group
+    And "newuser@example.org" has been invited to the group but has not accepted
     And no emails have been sent
     And "Ben" has chosen to be emailed about new discussions and decisions for the group
     And "Hannah" has chosen not to be emailed about new discussions and decisions for the group
     When I visit the discussion page
     And I click "Create new proposal"
     And fill in the proposal details and submit the form
-    Then "Ben" should be emailed about the new proposal
+    Then "ben@example.org" should have an email
+    When "ben@example.org" opens the email
     And clicking the link in the email should take him to the proposal
-    And "Hannah" should not be emailed about the new proposal
-    And the email should tell him when the proposal closes
+    Then "hannah@example.org" should receive no email
+    And "newuser@example.org" should receive no email

--- a/features/mention_user.feature
+++ b/features/mention_user.feature
@@ -8,10 +8,12 @@ Background:
 
 Scenario: Mention user when writing a comment
   Given "harry@example.com" is a member of "demo-group"
+  And "harrysfriend@example.com" has been invited to the group "demo-group" but has not accepted
   And I am viewing a discussion titled "hello" in "demo-group"
   When I am adding a comment and type in "@h"
+  Then I should not see "@harrysfriend" in the menu that pops up
   And I click on "@harry" in the menu that pops up
-  Then I should see "@harry" added to the "new-comment" field
+  And I should see "@harry" added to the "new-comment" field
 
 Scenario: Mentioned user gets emailed
   Given "harry@example.com" is a member of "demo-group"

--- a/features/proposal_closing_soon_email.feature
+++ b/features/proposal_closing_soon_email.feature
@@ -8,6 +8,8 @@ Feature: Proposal closing soon email
     And "Ben" is subscribed to proposal closing soon notification emails
     And there is a group "Pals"
     And "Ben" belongs to "Pals"
+    Given "newuser@example.com" has been invited to the group "Pals" but has not accepted
+    And no emails have been sent
     And there is a discussion "I'm Lonely" in "Pals"
     And there is a proposal "Party on Saturday" from the discussion "I'm Lonely"
     And the motion "Party on Saturday" is closing in 24 hours
@@ -15,3 +17,4 @@ Feature: Proposal closing soon email
     And no emails have been sent
     When we run the rake task to check for closing proposals, 24 hours before it closes.
     Then "Ben" gets a proposal closing soon email
+    And "newuser@example.com" should receive no email

--- a/features/step_definitions/accept_invitation_to_group_steps.rb
+++ b/features/step_definitions/accept_invitation_to_group_steps.rb
@@ -1,3 +1,12 @@
+Given /^"(.*?)" has been invited to the group but has not accepted$/ do |email|
+  User.invite_and_notify!({ :email => email }, @user, @group)
+end
+
+Given /^"(.*?)" has been invited to the group "(.*?)" but has not accepted$/ do |email, group_name|
+  @group = Group.find_by_name(group_name)
+  User.invite_and_notify!({ :email => email }, @user, @group)
+end
+
 Given /^I have been invited to join a loomio group and I am a new user$/ do
   @group = FactoryGirl.create :group
   @inviter = FactoryGirl.create :user

--- a/features/step_definitions/create_discussion_steps.rb
+++ b/features/step_definitions/create_discussion_steps.rb
@@ -43,7 +43,3 @@ Then /^clicking the link in the email should take him to the discussion$/ do
   click_first_link_in_email
   page.should have_content(@discussion_title)
 end
-
-Then /^"(.*?)" should not be emailed about the new discussion$/ do |arg1|
-  mailbox_for(@unnotified_user).size.should == 0
-end

--- a/features/step_definitions/create_proposal_steps.rb
+++ b/features/step_definitions/create_proposal_steps.rb
@@ -6,18 +6,9 @@ When /^fill in the proposal details and submit the form$/ do
   click_on 'Create proposal'
 end
 
-Then /^"(.*?)" should be emailed about the new proposal$/ do |arg1|
-  open_email(@notified_user.email, :with_subject => "New proposal")
-  current_email.default_part_body.to_s.should include(@proposal_name && "unsubscribe")
-end
-
 Then /^clicking the link in the email should take him to the proposal$/ do
   click_first_link_in_email
   page.should have_content(@proposal_name)
-end
-
-Then /^"(.*?)" should not be emailed about the new proposal$/ do |arg1|
-  mailbox_for(@unnotified_user).size.should == 0
 end
 
 Then /^a new proposal is created$/ do
@@ -28,10 +19,6 @@ When /^I am on a group page$/ do
   pending "is this needed?"
   group = Group.all.first
   visit "/groups/" + group.id.to_s
-end
-
-Then /^the email should tell him when the proposal closes$/ do
-  pending "this is a reminder to add motion closing time to new_motion_created.html.haml"
 end
 
 Then /^I should see the proposal details$/ do

--- a/features/step_definitions/mention_user_steps.rb
+++ b/features/step_definitions/mention_user_steps.rb
@@ -11,6 +11,14 @@ When /^I click on "(.*?)" in the menu that pops up$/ do |arg1|
   end
 end
 
+When /^I should not see "(.*?)" in the menu that pops up$/ do |arg1|
+  # this is failing intermittently (on Poltergeist at least)
+  wait_until { find("#at-view", visible: true) }
+  within('#at-view') do
+    page.should_not have_content(arg1)
+  end
+end
+
 When /^a comment exists mentioning "(.*?)"$/ do |text|
   @discussion.add_comment @user, "Hey #{text}"
 end


### PR DESCRIPTION
Improve test coverage; change group.users to exclude users who have not yet accepted
their invitations.
