### PR TITLE
Feature/user stats

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,7 @@ gem 'rack-canonical-host'
 gem 'delayed_job_active_record'
 gem 'hirefireapp'
 gem 'foreman'
+gem 'aws-sdk'
 
 # NOTE: sass-rails should be inside :assets group, but currently there is an issue with activeadmin
 #       which does not allow us to do this

--- a/app/admin/users.rb
+++ b/app/admin/users.rb
@@ -15,6 +15,7 @@ ActiveAdmin.register User do
     column :created_at
     column :last_sign_in_at
     column :is_admin
+    column "No. of groups", :memberships_count
     default_actions
   end
 

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -18,7 +18,7 @@ class Membership < ActiveRecord::Base
   validates_uniqueness_of :user_id, :scope => :group_id
 
   belongs_to :group, :counter_cache => true
-  belongs_to :user
+  belongs_to :user, :counter_cache => true
   belongs_to :inviter, :class_name => "User"
   has_many :events, :as => :eventable, :dependent => :destroy
 

--- a/config/initializers/aws.rb
+++ b/config/initializers/aws.rb
@@ -1,0 +1,4 @@
+AWS.config({
+	:access_key_id => ENV['AWS_ACCESS_KEY_ID'],
+	:secret_access_key => ENV['AWS_SECRET_ACCESS_KEY'],
+})

--- a/db/migrate/20121219081051_add_memberships_count.rb
+++ b/db/migrate/20121219081051_add_memberships_count.rb
@@ -1,0 +1,9 @@
+class AddMembershipsCount < ActiveRecord::Migration
+  def up
+  	add_column :users, :memberships_count, :integer, :default => 0, :null => false
+  end
+
+  def down
+  	remove_column :users, :memberships_count
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -272,6 +272,7 @@ ActiveRecord::Schema.define(:version => 20130114223848) do
     t.string   "authentication_token"
     t.string   "unsubscribe_token"
     t.boolean  "uses_markdown",                                               :default => false
+    t.integer  "memberships_count",                                           :default => 0,     :null => false
   end
 
   add_index "users", ["email"], :name => "index_users_on_email", :unique => true

--- a/lib/tasks/stats.rake
+++ b/lib/tasks/stats.rake
@@ -1,22 +1,43 @@
 namespace :stats do
-  task :groups => :environment do    # Export all public groups
+  task :all => [:environment, :group_requests, :users, :groups,   :events] do
+  end
+
+  task :group_requests => :environment do
+    export_model_to_s3 GroupRequest, ["id", "name", "admin_email", "created_at", "group_id"]
+  end
+
+  task :groups => :environment do    # Export all groups, scramble details of private ones
     require 'csv'
-    CSV.open("tmp/groups.csv", "w") do |csv|
+    file = CSV.generate do |csv|
       csv << ["id", "name", "created_at", "viewable_by", "parent_id", "description", "memberships_count", "archived_at"]
       Group.all.each do |group|
         if group.viewable_by == :everyone
           csv << [group.id, group.name, group.created_at, group.viewable_by, group.parent_id, group.description, group.memberships_count, group.archived_at]
         else
-          csv << [Digest::MD5.hexdigest(group.id.to_s), "Private", group.created_at, group.viewable_by, group.parent_id, "Private", group.memberships_count, group.archived_at]
+          csv << [scramble(group.id), "Private", group.created_at, group.viewable_by, group.parent_id, "Private", group.memberships_count, group.archived_at]
         end
       end
     end
+
+    s3file('groups.csv').write file
+  end
+
+  task :users => :environment do   # Export all users' create dates
+    require 'csv'
+    file = CSV.generate do |csv|
+      csv << ["id", "created_at", "memberships_count"]
+      User.all.each do |user|
+        csv << [scramble(user.id), user.created_at, user.memberships_count]
+      end
+    end
+
+    s3file('users.csv').write file
   end
 
 task :events => :environment do    # Export all events, scramble users, scramble private groups & subgroups
     require 'csv'
 
-    CSV.open("tmp/events.csv", "w") do |csv|
+    file = CSV.generate do |csv|
       csv << ["id", "user", "group", "parent_group", "kind", "created_at"]
       Event.all.each do |event|
         id = event.id
@@ -27,7 +48,7 @@ task :events => :environment do    # Export all events, scramble users, scramble
         when "new_discussion", "new_motion"
           user = eventable.author if eventable
           group = eventable.group if eventable
-        when "new_comment", "new_vote", "motion_blocked", "membership_requested", "comment_liked"
+        when "new_comment", "new_vote", "motion_blocked", "membership_requested", "comment_liked", "mentioned_user"
           begin
             user = eventable.user if eventable
             group = eventable.group if eventable
@@ -52,26 +73,46 @@ task :events => :environment do    # Export all events, scramble users, scramble
 
         # scramble users, and (private) groups & subgroups
 
-        user_id = Digest::MD5.hexdigest(user_id.to_s)
-
         if group
           if group.viewable_by == :everyone
             group_id = group.id
           else
-            group_id = Digest::MD5.hexdigest(group.id.to_s)
+            group_id = scramble(group.id)
           end
 
           if group.parent and group.viewable_by == :everyone
             parent_group_id = group.parent.id.to_s
           elsif group.parent  # i.e. the group is not public
-            parent_group_id = Digest::MD5.hexdigest(group.parent.id.to_s)
+            parent_group_id = scramble(group.parent.id)
           else
             parent_group_id =  ""
           end
         end
 
-        csv << [id, user_id, group_id, parent_group_id, kind, created_at]
+        csv << [id, scramble(user_id), group_id, parent_group_id, kind, created_at]
       end
     end
+
+    s3file('events.csv').write file
+  end
+
+  def export_model_to_s3(model, fields)
+    require 'csv'
+    file = CSV.generate do |csv|
+      csv << fields
+      model.all.each do |m|
+        csv << fields.map { |x| eval('m.' + x) }
+      end
+    end
+
+    s3file(model.name + '.csv').write file
+  end
+
+  def scramble(method)
+    Digest::MD5.hexdigest(method.to_s)
+  end
+
+  def s3file (filename)
+    AWS::S3.new.buckets['loomio-metrics'].objects.create filename
   end
 end


### PR DESCRIPTION
- Adds a rake task to export a csv listing the users, with names (MD5'd), creation date, and number of groups belonged to. 
- Adds number of groups belonged to to admin users panel
- Makes the stats tasks export csvs to an S3 bucket rather than to the tmp folder (tested on http://loomio-mhjb.herokuapp.com). This needs a aws.yml added to config with access keys. It looks like we could share the bucket (associated with my own s3 account) with loomio's s3 account (http://stackoverflow.com/questions/6412702/is-it-possible-to-share-a-amazon-s3-bucket-between-amazon-s3-users). Or might make more sense just to change stats.rake to use a bucket that already belongs to loomio's s3.

Still a total junior so all of the above likely to have been done wrong.
