### PR TITLE
line-break not working in new_motion mailer

### DIFF
--- a/app/views/motion_mailer/new_motion_created.html.haml
+++ b/app/views/motion_mailer/new_motion_created.html.haml
@@ -11,9 +11,10 @@
   %br
   Author:
   = @motion.author.name
-  / - if @motion.has_close_date?
-  /   Closes in:
-  /   = time_ago_in_words(@motion.close_date + @motion.close_date.localtime.strftime('%a %d %b %Y, %I:%M%p, %Z'))
+  %br
+  - if @motion.has_close_date?
+    Closes in:
+    = time_ago_in_words(@motion.close_date) + " (" + @motion.close_date.localtime.strftime('%a %d %b %Y, %I:%M%p, %Z') + ")"
 
   %p
   - if @motion.description.present?


### PR DESCRIPTION
Cannot reproduce this bug using mail catcher.  Have attached a screenshot to the trello card.

I have re-instanciated close_date into mailer as @rdbartlett had commented this out?  I noticed this was producing an error and fixed it. I don't know if this was needed.

Feel free to close this pull request if it is not needed
