### PR TITLE
count line-breaks and add them to character-counter

### DIFF
--- a/app/assets/javascripts/main.js.coffee
+++ b/app/assets/javascripts/main.js.coffee
@@ -182,7 +182,8 @@ $ ->
   $(".limit-250").keyup(() ->
     $(".error-message").hide()
     chars = $(this).val().length
-    left = 250 - chars
+    breaks = $(this).val().split(/\n|\f/).length
+    left = 250 - chars - breaks
     display_count(left, $(this))
   )
 
@@ -191,7 +192,8 @@ $ ->
   $(".limit-150").keyup(() ->
     $(".error-message").hide()
     chars = $(this).val().length
-    left = 150 - chars
+    breaks = $(this).val().split(/\n|\f/).length
+    left = 150 - chars - breaks
     display_count(left, $(this))
   )
 


### PR DESCRIPTION
The javascript character counter code was counting '/n' in the string as a single character as thus allowing a string greater in size than expected to the database.

This code simply adds and extra count per line break to the total.
