### PR TITLE
fix 'dismiss this message' link

### DIFF
--- a/app/views/application/_flash_messages.html.haml
+++ b/app/views/application/_flash_messages.html.haml
@@ -26,4 +26,4 @@
       P.S. If you're interested in giving feedback or contributing to the future development of Loomio, join the
       =link_to "Loomio Community group", "https://www.loomio.org/groups/3"
     %p
-      =link_to "Click here to dismiss this message", dismiss_system_notice_for_user_path, :class => "dismiss-help-notice", "data-dismiss" => "alert"
+      =link_to "Click here to dismiss this message", dismiss_system_notice_for_user_path, :class => "close dismiss-help-notice", "data-dismiss" => "alert"


### PR DESCRIPTION
hotfix for a little whoopsie that meant the 'click here to dismiss this message' wasn't working.
