### PR TITLE
Feature update message

### DIFF
--- a/app/views/application/_flash_messages.html.haml
+++ b/app/views/application/_flash_messages.html.haml
@@ -25,5 +25,4 @@
     %p
       P.S. If you're interested in giving feedback or contributing to the future development of Loomio, join the
       =link_to "Loomio Community group", "https://www.loomio.org/groups/3"
-    %p
-      =link_to "Click here to dismiss this message", dismiss_system_notice_for_user_path, :class => "close dismiss-help-notice", "data-dismiss" => "alert"
+    =link_to "Click here to dismiss this message", dismiss_system_notice_for_user_path, :class => "dismiss-help-notice", "data-dismiss" => "alert"


### PR DESCRIPTION
Hotfix: 'dismiss' link wasn't AJAX-closing the message. Fixed now.
