### PR TITLE
add meta tag for facebook insights statistics

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -9,6 +9,7 @@
     %link{:href => "https://ajax.googleapis.com/ajax/libs/jqueryui/1.8.17/themes/flick/jquery-ui.css", :rel => "stylesheet", :type => "text/css"}
     %meta{'name' => 'description', :content => 'Loomio is a free and open-source web application that helps groups make better decisions together.'}
 
+    %meta{property:"fb:admins", content:"219748918130373"}
     =render 'google_analytics'
 
   %body{class: "#{controller_name} #{action_name}"}

--- a/app/views/layouts/frontpage.html.haml
+++ b/app/views/layouts/frontpage.html.haml
@@ -7,6 +7,8 @@
     = csrf_meta_tags
     %meta{'name' => 'description', :content => 'Loomio is a free and open-source web application that helps groups make better decisions together.'}
 
+    %meta{property:"fb:admins", content:"219748918130373"}
+
   %body{class: "#{controller_name} #{action_name}"}
     .container.home-flash
       = render 'flash_messages', :flash => flash


### PR DESCRIPTION
this is a minor feature which just adds the same fb admin meta tag from Loomio's fb account to 2 pages.
Have tried on my heroku setup and instantly pulled some quite interesting data.

following this will be the full opengraph feature which will tidily display all the correct data.

PLEASE deploy, i'm gagging to see what this can do for the project
