### PR TITLE
Stats export improvements

### DIFF
--- a/lib/tasks/stats.rake
+++ b/lib/tasks/stats.rake
@@ -118,7 +118,7 @@ task :events => :environment do    # Export all events, scramble users, scramble
   end
 
   def s3file (filename)
-    raise "Please set environment variable LOOMIO_INSTANCE" if ENV["LOOMIO_INSTANCE"].blank?
-    AWS::S3.new.buckets['loomio-metrics'].objects.create ENV["LOOMIO_INSTANCE"] + '-' + filename
+    raise "Please set environment variable CANONICAL_HOST" if ENV["CANONICAL_HOST"].blank?
+    AWS::S3.new.buckets['loomio-metrics'].objects.create ENV["CANONICAL_HOST"] + '-' + filename
   end
 end


### PR DESCRIPTION
Groups export: adds distribution_metric
Users export: adds last_sign_in_at (empty if they never have)
Events export: 
- adds 'top_group', which is the top-level group associated with each event (i.e. the parent group if it's a subgroup)
- scrambles parent_group properly (correcting a little bug)

Save to S3: Now looks for an environment variable 'LOOMIO_INSTANCE' to differentiate on S3 between stats csvs generated by different copies of Loomio
