### PR TITLE
fix frontpage scrollTo effect

### DIFF
--- a/app/assets/javascripts/frontpage.js
+++ b/app/assets/javascripts/frontpage.js
@@ -2,3 +2,4 @@
 //= require scrollTo
 //= require bootstrap
 //= require frontpage_validations
+//= require frontpage_scrollTo

--- a/app/assets/javascripts/frontpage_scrollTo.js.coffee
+++ b/app/assets/javascripts/frontpage_scrollTo.js.coffee
@@ -1,0 +1,11 @@
+# homepage scroll effect
+$ ->
+  $(".scroll-nav").click((event)->
+    target = this.hash
+    offsetIE7 = 0;
+    if ($.browser.msie  && parseInt($.browser.version, 10) == 7)
+      offsetIE7 = -34;
+    event.preventDefault()
+    $.scrollTo(target, 1000, {offset: offsetIE7})
+    location.hash = target
+  )

--- a/app/assets/javascripts/main.js.coffee
+++ b/app/assets/javascripts/main.js.coffee
@@ -333,15 +333,3 @@ $ ->
 # homepage accordion
 $ ->
   $(".collapse").collapse()
-
-# homepage scroll effect
-$ ->
-  $(".scroll-nav").click((event)->
-    target = this.hash
-    offsetIE7 = 0;
-    if ($.browser.msie  && parseInt($.browser.version, 10) == 7)
-      offsetIE7 = -34;
-    event.preventDefault()
-    $.scrollTo(target, 1000, {offset: offsetIE7})
-    location.hash = target
-  )

--- a/app/views/application/_marketing_header.html.haml
+++ b/app/views/application/_marketing_header.html.haml
@@ -1,19 +1,23 @@
 - if params[:id] == 'home'
-  - scroll_trigger = "scroll-nav"
+  - path_var = ''
+  - scroll_trigger = 'scroll-nav'
+- else
+  - path_var = '/pages/home'
+  - scroll_trigger = ''
 
 .navbar.navbar-fixed-top
   .navbar-inner
     .container
-      %a.brand{href: "/#top", class: scroll_trigger}
+      %a.brand{href: "#{path_var}#top", class: scroll_trigger}
         =image_tag("top-bar-loomio.png")
       .nav-collapse
         %ul.nav
           %li
-            %a{href: "/#why", class: scroll_trigger} Why
+            %a{href: "#{path_var}#why", class: scroll_trigger} Why
           %li
-            %a{href: "/#how", class: scroll_trigger} How
+            %a{href: "#{path_var}#how", class: scroll_trigger} How
           %li
-            %a{href: "/#who", class: scroll_trigger} Who
+            %a{href: "#{path_var}#who", class: scroll_trigger} Who
         %ul.nav.pull-right
           %li
             %a{href: user_session_path} Sign In

--- a/app/views/layouts/frontpage.html.haml
+++ b/app/views/layouts/frontpage.html.haml
@@ -10,6 +10,6 @@
   %body{class: "#{controller_name} #{action_name}"}
     .container.home-flash
       = render 'flash_messages', :flash => flash
-    = render "header_logged_out"
+    = render "marketing_header"
     = yield
   = javascript_include_tag "frontpage"

--- a/app/views/pages/blog.html.haml
+++ b/app/views/pages/blog.html.haml
@@ -1,4 +1,4 @@
-= render "header_logged_out"
+= render "marketing_header"
 
 .container
   .section


### PR DESCRIPTION
This should fix the scroll effect on the front page.

Note I also changed "header_logged_out" to "marketing_header", because it was confusing. e.g. before this change, we were rendering header_logged_out on say /request_new_group, whether or not the user was logged out. Confusing!
