### PR TITLE
add fb:app_id meta tag

### DIFF
--- a/app/views/application/_social_metadata.html.haml
+++ b/app/views/application/_social_metadata.html.haml
@@ -10,5 +10,4 @@
 %meta{ property: 'og:image:width', content: '800' }
 %meta{ property: 'og:image:height', content: '800' }
 
-%meta{property:'fb:admins', content:ENV['FB_ADMIN_META']}
 %meta{property:'fb:app_id', content:ENV['FB_APP_ID_META']}

--- a/features/step_definitions/populate_social_metadata_steps.rb
+++ b/features/step_definitions/populate_social_metadata_steps.rb
@@ -1,5 +1,4 @@
 Then /^facebook meta-data should be present$/ do
-  page.should have_xpath("//head/meta[@property=\"fb:admins\"]")
   page.should have_xpath("//head/meta[@property=\"fb:app_id\"]")
 end
 


### PR DESCRIPTION
a minor commit, need a different meta tag to be able to activate facebooks insights AND be have everyone involved be able to see it without binding it to my account.

solution i've read about online is to create a FB APP D:   and include that app_id
this is also the first step down the road to fb authentication/ sign in should we want to go that way.

please add ENV var  
FB_APP_ID_META = 457851034283863 
