### PR TITLE
Add GA tracking code to error pages

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -56,5 +56,19 @@
       </a>
     </div>
   </div>
+<script type="text/javascript">
+
+  var _gaq = _gaq || [];
+  _gaq.push(['_setAccount', 'UA-31046122-1']);
+  _gaq.push(['_setDomainName', 'loomio.org']);
+  _gaq.push(['_trackPageview']);
+
+  (function() {
+    var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
+    ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+    var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
+  })();
+
+</script>
 </body>
 </html>

--- a/public/422.html
+++ b/public/422.html
@@ -56,5 +56,19 @@
       </a>
     </div>
   </div>
+  <script type="text/javascript">
+
+    var _gaq = _gaq || [];
+    _gaq.push(['_setAccount', 'UA-31046122-1']);
+    _gaq.push(['_setDomainName', 'loomio.org']);
+    _gaq.push(['_trackPageview']);
+
+    (function() {
+      var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
+      ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+      var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
+    })();
+
+  </script>
 </body>
 </html>

--- a/public/500.html
+++ b/public/500.html
@@ -56,5 +56,19 @@
       </a>
     </div>
   </div>
+  <script type="text/javascript">
+
+    var _gaq = _gaq || [];
+    _gaq.push(['_setAccount', 'UA-31046122-1']);
+    _gaq.push(['_setDomainName', 'loomio.org']);
+    _gaq.push(['_trackPageview']);
+
+    (function() {
+      var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
+      ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+      var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
+    })();
+
+  </script>
 </body>
 </html>


### PR DESCRIPTION
Struck me that it would be useful to get info on referrers of 404 errors. Not DRY but I get the impression that the error pages want to be minimally complicated? 
