### PR TITLE
verification added to invitation process

### DIFF
--- a/app/controllers/group_requests_controller.rb
+++ b/app/controllers/group_requests_controller.rb
@@ -1,5 +1,5 @@
 class GroupRequestsController < BaseController
-  before_filter :authenticate_user!, except: [:start, :start_new_group, :new, :create, :confirmation]
+  before_filter :authenticate_user!, except: [:start, :verify, :start_new_group, :new, :create, :confirmation]
 
   def new
     @group_request = GroupRequest.new
@@ -15,6 +15,16 @@ class GroupRequestsController < BaseController
   end
 
   def confirmation
+  end
+
+  def verify
+    group_request = GroupRequest.find_by_token(params[:token])
+    if group_request && group_request.unverified?
+      group_request.verify!
+      render "verify"
+    else
+      render "invitation_accepted_error_page"
+    end
   end
 
   def start_new_group

--- a/app/mailers/start_group_mailer.rb
+++ b/app/mailers/start_group_mailer.rb
@@ -7,6 +7,14 @@ class StartGroupMailer < ActionMailer::Base
   #   en.group_invitation_mailer.invite_member.subject
   #
 
+  def verification(group_request)
+    @group_request = group_request
+    @token = group_request.token
+
+    mail to: group_request.admin_email,
+         subject: "Please confirm your Loomio group request"
+  end
+
   def invite_admin_to_start_group(group_request)
     @group_request = group_request
     @group = group_request.group

--- a/app/views/group_requests/confirmation.html.haml
+++ b/app/views/group_requests/confirmation.html.haml
@@ -6,6 +6,6 @@
     .row
       .span6.offset2
         %p &nbsp;
-        %p We're taking care to not grow too quickly, so we're manually approving each request. We’ll be in contact soon to let you know what to do next.
+        %p Please check your email for a verification link so that we know communication with you is getting through. Make sure to click the link inside the email to finalise your request. Contact us at <a href=mailto:contact@loomio.org>contact@loomio.org</a> if you don't receive an email.
       .span2
         =image_tag("mascot-medium-lefthand.gif")

--- a/app/views/group_requests/verify.html.haml
+++ b/app/views/group_requests/verify.html.haml
@@ -1,0 +1,13 @@
+.page-container
+  =image_tag("loomio-orange.png")
+  .row
+    .span6.offset2
+      %h1 Success!
+
+      %p Your request has been received. Our friendly humans will review it and we'll get back to you within 48 hours.
+
+      %br
+
+      %Strong While you're waiting...
+
+      %p Now it's a good time to talk to your group about Loomio. Here's a one-pager about how Loomio works and how what it can offer your group.

--- a/app/views/start_group_mailer/verification.html.haml
+++ b/app/views/start_group_mailer/verification.html.haml
@@ -1,0 +1,9 @@
+%h2 Your almost done!
+
+%p Please click this verification link to finalise your request:
+
+%strong
+  - link_url = verify_group_request_url(@group_request, token: @token)
+  %p= link_to link_url, link_url
+
+%p If you did not request to join Loomio please ignore this email.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Loomio::Application.routes.draw do
   devise_for :users, controllers: { sessions: 'users/sessions', invitations: 'users/invitations' }
 
   resources :group_requests, only: [:create, :new] do
+    get :verify, on: :member
     get :start_new_group, on: :member
   end
   match "/request_new_group", to: "group_requests#start", as: :request_new_group

--- a/db/migrate/20130321035625_update_to_verified_and_defered_group_requests.rb
+++ b/db/migrate/20130321035625_update_to_verified_and_defered_group_requests.rb
@@ -1,0 +1,11 @@
+class AddUnverifiedStatusToGroupRequests < ActiveRecord::Migration
+  def up
+    GroupRequest.where(status: 'awaiting_approval').update_all(status: 'verified')
+    GroupRequest.where(status: 'ignored').update_all(status: 'defered')
+  end
+
+  def down
+    GroupRequest.where(status: 'verified').update_all(status: 'awaiting_approval')
+    GroupRequest.where(status: 'defered').update_all(status: 'ignored')
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20130318033458) do
+ActiveRecord::Schema.define(:version => 20130321035625) do
 
   create_table "active_admin_comments", :force => true do |t|
     t.string   "resource_id",   :null => false

--- a/features/admin/approve_group_request.feature
+++ b/features/admin/approve_group_request.feature
@@ -6,7 +6,7 @@ Feature: Loomio admin approves group request to join Loomio
   Background:
     Given I am a Loomio super-admin
     And I am logged in
-    And there is a request to join Loomio
+    And there is a verified request to join Loomio
 
   Scenario: Loomio admin sets the maximum group size
     When I visit the Group Requests page on the admin panel
@@ -19,13 +19,13 @@ Feature: Loomio admin approves group request to join Loomio
     And I approve the request
     Then the group request should be marked as approved
     And the group should be created
-    And an invitation email should be sent to the group admin
+    And an invitation to start a new group should be sent to the group admin
     And I should be redirected to the Group Requests page
     And I should no longer see the request
 
-  Scenario: Loomio admin ignores a group request
+  Scenario: Loomio admin defers a group request
     When I visit the Group Requests page on the admin panel
-    And I ignore the request
-    Then the group request should be marked as ignored
+    And I defer the request
+    Then the group request should be marked as defered
     And I should be redirected to the Group Requests page
     And I should no longer see the request

--- a/features/admin/view_group_requests.feature
+++ b/features/admin/view_group_requests.feature
@@ -8,9 +8,14 @@ Feature: Loomio admin views group requests
     And I am logged in
     And there are many group requests
 
-  Scenario: Loomio admin views group requests
+  Scenario: Loomio admin views verified group requests
     When I visit the Group Requests page on the admin panel
-    Then I should only see the unapproved group requests
+    Then I should only see the verified group requests
+
+  Scenario: Loomio admin views unverified group requests
+    When I visit the Group Requests page on the admin panel
+    And I click to see unverified group requests
+    Then I should only see the unverified group requests
 
   Scenario: Loomio admin views approved group requests
     When I visit the Group Requests page on the admin panel

--- a/features/groups/request_new_group.feature
+++ b/features/groups/request_new_group.feature
@@ -7,7 +7,11 @@ Feature: User requests to create a group on Loomio
     When I visit the Request New Group page
     And I fill in and submit the Request New Group Form
     Then a new Loomio group request should be created
-    And I should be told that my request will be reviewed shortly
+    And I should be told to check my inbox for a verification email
+    When I open the verification email sent to me
+    And I click the verification link
+    Then I should be told that my request will be reviewed shortly
+    And the group request should be marked as verified
 
   Scenario: User submits an incorrect Request New Group Form
     When I visit the Request New Group page
@@ -19,4 +23,4 @@ Feature: User requests to create a group on Loomio
     When I visit the Request New Group page
     And I fill in and submit the Request New Group Form as a Robot
     Then a new Loomio group request should be created and marked as spam
-    And I should be told that my request will be reviewed shortly
+    And I should be told to check my inbox for a verification email

--- a/features/step_definitions/accept_invitation_to_start_group_steps.rb
+++ b/features/step_definitions/accept_invitation_to_start_group_steps.rb
@@ -1,6 +1,7 @@
 Given /^I have requested to start a loomio group$/ do
   @admin_email = @user ? @user.email : "test@example.org"
-  @group_request = FactoryGirl.create :group_request, admin_email: @admin_email
+  @group_request = FactoryGirl.create :group_request, admin_email: @admin_email, status: 'verified'
+  reset_mailer
 end
 
 Given /^the group request has been approved$/ do

--- a/features/step_definitions/approve_group_request_steps.rb
+++ b/features/step_definitions/approve_group_request_steps.rb
@@ -2,8 +2,9 @@ Given /^I am a Loomio super\-admin$/ do
   @user = FactoryGirl.create :user, :is_admin => true
 end
 
-Given /^there is a request to join Loomio$/ do
-  @group_request = FactoryGirl.create :group_request
+Given /^there is a verified request to join Loomio$/ do
+  @group_request = FactoryGirl.create :group_request, status: 'verified'
+  reset_mailer
 end
 
 When /^I visit the Group Requests page on the admin panel$/ do
@@ -14,8 +15,8 @@ When /^I approve the request$/ do
   click_link("approve_group_request_#{@group_request.id}")
 end
 
-When /^I ignore the request$/ do
-  click_link("ignore_group_request_#{@group_request.id}")
+When /^I defer the request$/ do
+  click_link("defer_group_request_#{@group_request.id}")
 end
 
 Then /^I should no longer see the request$/ do
@@ -35,14 +36,14 @@ Then /^the group request should be marked as approved$/ do
   @group_request.should be_approved
 end
 
-Then /^the group request should be marked as ignored$/ do
+Then /^the group request should be marked as defered$/ do
   @group_request.reload
-  @group_request.should be_ignored
+  @group_request.should be_defered
 end
 
-Then /^an invitation email should be sent to the group admin$/ do
+Then /^an invitation to start a new group should be sent to the group admin$/ do
   open_email(@group_request.admin_email)
-  current_email.should have_subject("Invitation to join Loomio (#{@group_request.name})")
+  current_email.should have_content("Great news! Your request for a Loomio group has been approved!")
 end
 
 Then /^I should be redirected to the Group Requests page$/ do

--- a/features/step_definitions/request_new_group_steps.rb
+++ b/features/step_definitions/request_new_group_steps.rb
@@ -39,12 +39,21 @@ When /^I fill in and submit the Request New Group Form incorrectly$/ do
   find("#submit-group-request").click
 end
 
+When /^I open the verification email sent to me$/ do
+  open_email(@group_admin_email)
+end
+
+When /^I click the verification link$/ do
+  click_first_link_in_email
+end
+
 Then /^a new Loomio group request should be created$/ do
-  GroupRequest.where(:name => @group_name).size.should == 1
+  @group_request = GroupRequest.where(:name => @group_name).first
+  @group_request.should_not be_nil
 end
 
 Then /^I should be told that my request will be reviewed shortly$/ do
-  page.should have_css("body.group_requests.confirmation")
+  page.should have_css("body.group_requests.verify")
 end
 
 Then /^a new Loomio group request should not be created$/ do
@@ -58,3 +67,13 @@ end
 Then /^I should still see the Group Request Form$/ do
   page.should have_css("#new_group_request")
 end
+
+Then /^I should be told to check my inbox for a verification email$/ do
+  page.should have_content("Please check your email for a verification link")
+end
+
+Then /^the group request should be marked as verified$/ do
+  @group_request.reload
+  @group_request.status.should == 'verified'
+end
+

--- a/features/step_definitions/view_group_requests_steps.rb
+++ b/features/step_definitions/view_group_requests_steps.rb
@@ -1,8 +1,13 @@
 Given /^there are many group requests$/ do
-  @unapproved_group_request = FactoryGirl.create :group_request, status: :awaiting_approval
+  @unverified_group_request = FactoryGirl.create :group_request
+  @verified_group_request = FactoryGirl.create :group_request, status: :verified
   @approved_group_request = FactoryGirl.create :group_request, status: :approved
   @accepted_group_request = FactoryGirl.create :group_request, status: :accepted
-  @group_requests = [@unapproved_group_request, @approved_group_request, @accepted_group_request]
+  @group_requests = [@unverified_group_request, @verified_group_request, @approved_group_request, @accepted_group_request]
+end
+
+When /^I click to see unverified group requests$/ do
+  find("li.scope.unverified a").click
 end
 
 When /^I click to see approved group requests$/ do
@@ -13,20 +18,30 @@ When /^I click to see accepted group requests$/ do
   find("li.scope.accepted a").click
 end
 
-Then /^I should only see the unapproved group requests$/ do
-  page.should have_css "#group_request_#{@unapproved_group_request.id}"
+Then /^I should only see the verified group requests$/ do
+  page.should have_css "#group_request_#{@verified_group_request.id}"
+  page.should_not have_css "#group_request_#{@unverified_group_request.id}"
+  page.should_not have_css "#group_request_#{@approved_group_request.id}"
+  page.should_not have_css "#group_request_#{@accepted_group_request.id}"
+end
+
+Then /^I should only see the unverified group requests$/ do
+  page.should have_css "#group_request_#{@unverified_group_request.id}"
+  page.should_not have_css "#group_request_#{@verified_group_request.id}"
   page.should_not have_css "#group_request_#{@approved_group_request.id}"
   page.should_not have_css "#group_request_#{@accepted_group_request.id}"
 end
 
 Then /^I should only see the approved group requests$/ do
   page.should have_css "#group_request_#{@approved_group_request.id}"
-  page.should_not have_css "#group_request_#{@unapproved_group_request.id}"
+  page.should_not have_css "#group_request_#{@verified_group_request.id}"
+  page.should_not have_css "#group_request_#{@unverified_group_request.id}"
   page.should_not have_css "#group_request_#{@accepted_group_request.id}"
 end
 
 Then /^I should only see the accepted group requests$/ do
   page.should have_css "#group_request_#{@accepted_group_request.id}"
-  page.should_not have_css "#group_request_#{@unapproved_group_request.id}"
+  page.should_not have_css "#group_request_#{@verified_group_request.id}"
+  page.should_not have_css "#group_request_#{@unverified_group_request.id}"
   page.should_not have_css "#group_request_#{@approved_group_request.id}"
 end

--- a/spec/controllers/group_requests_controller_spec.rb
+++ b/spec/controllers/group_requests_controller_spec.rb
@@ -20,8 +20,38 @@ describe GroupRequestsController do
 
   describe "#create" do
     it "should redirect to the confirmation page" do
-      put :create, :group_request => group_request.attributes
+      put :create, group_request: group_request.attributes
       response.should redirect_to(group_request_confirmation_url)
+    end
+  end
+
+  describe "#confirmation" do
+    it "should successfully render the confirmation page" do
+      get :confirmation
+      response.should be_success
+      response.should render_template("confirmation")
+    end
+  end
+
+  describe "#verify" do
+    before { GroupRequest.stub(:find_by_token).and_return(group_request) }
+
+    context "group_request has not yet been verified" do
+      it "sets the status to verified" do
+        group_request.should_receive(:verify!)
+        put :verify, token: group_request.token
+      end
+      it "should render the verified page" do
+        put :verify, token: group_request.token
+        response.should render_template("verify")
+      end
+    end
+    context "group_request has been verified" do
+      before { group_request.stub(:unverified?).and_return(false) }
+      it "renders the invitation_accepted_error_page" do
+        put :verify, token: group_request.token
+        response.should render_template("invitation_accepted_error_page")
+      end
     end
   end
 
@@ -44,18 +74,9 @@ describe GroupRequestsController do
     end
     context "token is incorrect" do
       context "group request is approved"
-      context "group request is awaiting_approval"
+      context "group request is unverified"
       context "group request is "
       it "renders the invalid start group link page"
     end
   end
-
-  describe "#confirmation" do
-    it "should successfully render the confirmation page" do
-      get :confirmation
-      response.should be_success
-      response.should render_template("confirmation")
-    end
-  end
-
 end


### PR DESCRIPTION
This is part of the 'start new group' invitation process. 
It adds the verification steps to ensure emails do not go to spam and are in fact received by the group admin.

Mock up https://loomio.mybalsamiq.com/projects/invitationprocess/story

This pull request also changes 'ignore' to 'defer' and 'awaiting approval' to 'verified'
