### PR TITLE
Remove 'furry'

### DIFF
--- a/features/groups/create_subgroup.feature
+++ b/features/groups/create_subgroup.feature
@@ -1,9 +1,10 @@
   Feature: Create sub group
 
   Background:
-    Given a group "demo-group" with "furry@example.com" as admin
-    And I am logged in as "furry@example.com"
-    And I visit create subgroup page for group named "demo-group"
+    Given I am logged in
+    And I am an admin of a group
+    And I visit the group page
+    And I visit create subgroup page
 
   Scenario: Create public subgroup where all group members can invite
     When I fill details for public all members invite subgroup

--- a/features/step_definitions/group_steps.rb
+++ b/features/step_definitions/group_steps.rb
@@ -8,9 +8,9 @@ Given /^a group(?: named)? "(.*?)"(?: exists)?$/ do |group_name|
   FactoryGirl.create(:group, :name => group_name)
 end
 
-Given /^I visit create subgroup page for group named "(.*?)"$/ do |arg1|
+Given /^I visit create subgroup page$/ do
   find("#groups").click_on("Groups")
-  find("#groups").click_on(arg1)
+  find("#groups").click_on(@group.name)
   click_link("subgroup-new")
 end
 


### PR DESCRIPTION
This pull request remove the legacy way of setting up the background in the 'create subgroup cucumber spec.  This was causing travis to fail, but was working locally.
