### PR TITLE
Remove group activity dots.

### DIFF
--- a/app/views/application/_group_activity.html.haml
+++ b/app/views/application/_group_activity.html.haml
@@ -1,2 +1,0 @@
-- if group.activity_since_last_viewed?(user)
-  .group-activity.button-icon.dot-icon

--- a/app/views/application/_group_dropdown_item.html.haml
+++ b/app/views/application/_group_dropdown_item.html.haml
@@ -4,4 +4,3 @@
   %a.selector-link{ href: group_path(group) }
     .group-link.clearfix
       .group-link-name= group.name.length < 35 ? group.name : group.name[0..32]+'...'
-      .group-link-activity= render '/application/group_activity', user: current_user, group: group

--- a/app/views/dashboard/_groups.html.haml
+++ b/app/views/dashboard/_groups.html.haml
@@ -6,11 +6,9 @@
       %li
         .group-link.clearfix
           .group-link-name= link_to group.name, group_path(group), :class => 'view_'+group.viewable_by.to_s
-          .group-link-activity= render '/application/group_activity', user: current_user, group: group
         - if group.subgroups.size > 0
           - group.subgroups.each do |subgroup|
             - if (current_user && current_user.group_membership(subgroup))
               %li.sub-group
                 .group-link.clearfix
                   .group-link-name= link_to subgroup.name, group_path(subgroup), :class => 'view_'+subgroup.viewable_by.to_s
-                  .group-link-activity= render '/application/group_activity', user: current_user, group: subgroup

--- a/app/views/groups/_subgroups.html.haml
+++ b/app/views/groups/_subgroups.html.haml
@@ -8,5 +8,3 @@
         %li
           .group-link
             = link_to subgroup.name, group_path(subgroup), :class => 'view_'+subgroup.viewable_by.to_s
-            - if user_signed_in?
-              = render '/application/group_activity', user: current_user, group: subgroup


### PR DESCRIPTION
They were hardly being used and we're going to see a very large performance improvement for users in lots of groups.
