### PR TITLE
Add support for old invitation format

### DIFF
--- a/app/controllers/group_requests_controller.rb
+++ b/app/controllers/group_requests_controller.rb
@@ -18,8 +18,8 @@ class GroupRequestsController < BaseController
   end
 
   def start_new_group
-    group_request = GroupRequest.find(params[:id])
-    if group_request.token != params[:token] || group_request.accepted?
+    group_request = GroupRequest.find_by_token(params[:token])
+    if group_request.nil? or group_request.accepted?
       render "invitation_accepted_error_page"
     else
       session[:start_new_group_token] = group_request.token

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -84,6 +84,9 @@ Loomio::Application.routes.draw do
     root :to => 'dashboard#show'
   end
 
+  #redirect old invites
+  match "/groups/:id/invitations/:token" => "group_requests#start_new_group"
+
   match '/browser_not_supported' => 'high_voltage/pages#show', :id => 'browser_not_supported'
   match '/privacy' => 'high_voltage/pages#show', :id => 'privacy'
   match '/blog' => 'high_voltage/pages#show', :id => 'blog'

--- a/features/groups/accept_invitation_to_start_group.feature
+++ b/features/groups/accept_invitation_to_start_group.feature
@@ -46,3 +46,9 @@ Feature: Group admin accepts invitation to start a Loomio group
     When I open the email sent to me
     And I click the invitation link to start a new group
     Then I should be notified the invitation has already been accepted
+
+  Scenario: User accepts an invitation containing the old style link
+    Given I have requested to start a loomio group
+    And the group request has been approved
+    When I click the old format invitation link to start a new group
+    Then I should be asked to create an account

--- a/features/step_definitions/accept_invitation_to_start_group_steps.rb
+++ b/features/step_definitions/accept_invitation_to_start_group_steps.rb
@@ -42,6 +42,14 @@ When /^I choose to log in and then I submit the login form$/ do
   click_on "sign-in-btn"
 end
 
+When /^I click the old format invitation link to start a new group$/ do
+  visit("/groups/#{@group_request.group_id}/invitations/#{@group_request.token}")
+end
+
+Then /^I should be asked to create an account$/ do
+  page.should have_content("Your request to a start a new group on Loomio has been approved!")
+end
+
 Then /^I should become the admin of the group$/ do
   @user ||= User.find_by_email(@admin_email)
   @user.is_group_admin?(@group).should == true


### PR DESCRIPTION
The invitation format has been changed and the old style invitation link are not working.

New route and controller logic added to fix this
