### PR TITLE
Remove some complexity from discussions controller

### DIFF
--- a/app/controllers/discussions_controller.rb
+++ b/app/controllers/discussions_controller.rb
@@ -59,27 +59,20 @@ class DiscussionsController < GroupBaseController
     @discussion = Discussion.find(params[:id])
     @last_collaborator = User.find @discussion.originator.to_i if @discussion.has_previous_versions?
     @group = GroupDecorator.new(@discussion.group)
-    @current_motion = @discussion.current_motion
     @vote = Vote.new
+    @current_motion = @discussion.current_motion
     @activity = @discussion.activity
     assign_meta_data
-    if (not params[:proposal])
-      if @current_motion
-        @unique_votes = Vote.unique_votes(@current_motion)
-        @votes_for_graph = @current_motion.votes_graph_ready
-        @user_already_voted = @current_motion.user_has_voted?(current_user)
-      end
-    else
-      @selected_motion = Motion.find(params[:proposal])
-      @user_already_voted = @selected_motion.user_has_voted?(current_user)
-      @votes_for_graph = @selected_motion.votes_graph_ready
+    if params[:proposal]
+      @displayed_motion = Motion.find(params[:proposal])
+    elsif @current_motion
+      @displayed_motion = @current_motion
     end
-
     if current_user
       @uses_markdown = current_user.uses_markdown?
+      @discussion.update_total_views
       current_user.update_motion_read_log(@current_motion) if @current_motion
       current_user.update_discussion_read_log(@discussion)
-      @discussion.update_total_views
     end
   end
 

--- a/app/helpers/motions_helper.rb
+++ b/app/helpers/motions_helper.rb
@@ -7,4 +7,8 @@ module MotionsHelper
     motion_class = ["motion-preview", "clearfix"]
     motion_class.join(" ")
   end
+
+  def display_vote_buttons?(motion, user)
+    motion.voting? && (not motion.user_has_voted?(user)) && motion.group.users_include?(user)
+  end
 end

--- a/app/models/motion.rb
+++ b/app/models/motion.rb
@@ -53,10 +53,6 @@ class Motion < ActiveRecord::Base
     group.users.where(User.arel_table[:id].not_eq(author.id))
   end
 
-  def user_has_voted?(user)
-    votes.map{|v| v.user.id}.include?(user.id)
-  end
-
   def with_votes
     votes if votes.size > 0
   end
@@ -74,7 +70,7 @@ class Motion < ActiveRecord::Base
     }.to_hash
   end
 
-  def votes_graph_ready
+  def votes_for_graph
     votes_for_graph = []
     votes_breakdown.each do |k, v|
       votes_for_graph.push ["#{k.capitalize} (#{v.size})", v.size, "#{k.capitalize}", [v.map{|b| b.user.email}]]
@@ -105,6 +101,10 @@ class Motion < ActiveRecord::Base
       discussion.group = group
       discussion.save
     end
+  end
+
+  def unique_votes
+    Vote.unique_votes(self)
   end
 
   # motion is closed by user

--- a/app/views/discussions/_discussion_preview.html.haml
+++ b/app/views/discussions/_discussion_preview.html.haml
@@ -43,7 +43,7 @@
           el: '.pie'
           id_string: "graph_#{discussion.current_motion.id}"
           legend: false
-          data: #{discussion.current_motion.votes_graph_ready.to_json.html_safe}
+          data: #{discussion.current_motion.votes_for_graph.to_json.html_safe}
           type: 'pie'
           tooltip_selector: '#tooltip'
           diameter: 25

--- a/app/views/discussions/show.html.haml
+++ b/app/views/discussions/show.html.haml
@@ -20,32 +20,29 @@
             %h3.header-text= t :current_decision
             .content-proposal-body
               %ul.selector-list
-                - if @current_motion
-                  - if (not @selected_motion) && (can? :close_voting, @current_motion)
-                    %li= render '/motions/admin_buttons', :motion => @current_motion
-                  - if @selected_motion && (@selected_motion != @current_motion)
-                    %li.selector-item.current-proposal
-                      = render '/motions/motion_preview', motion: @current_motion, this_group: @group
-                  - else
-                    %li.selector-item.current-proposal
-                      = render @current_motion, unique_votes: @unique_votes
-                - else
+                - if @current_motion.nil?
                   - if can? :create, Motion.new(discussion_id: @discussion.id)
                     = link_to t("create_new_proposal"), new_proposal_discussion_path(@discussion.id), class: 'btn new-proposal-btn', id: 'new-proposal'
                   %li.selector-item.empty-list-message= t :empty_decision_list
-
-            - if @discussion.motions.where("phase = 'closed'").count > 0
+                - else
+                  - if @displayed_motion == @current_motion
+                    - if can? :close_voting, @current_motion
+                      %li= render '/motions/admin_buttons', :motion => @current_motion
+                    %li.selector-item.current-proposal
+                      = render @current_motion, unique_votes: @current_motion.unique_votes
+                  - else
+                    %li.selector-item.current-proposal
+                      = render '/motions/motion_preview', motion: @current_motion, this_group: @group
+                  = render '/motions/edit_close_date', motion: @current_motion, input_time: @input_time
+            - if @discussion.closed_motions.count > 0
               #previous-proposals
                 .clearfix
                   .large-icon.decision-icon
                   %h3.header-text= t "previous_decisions"
-
                 .content-proposal-body
                   %ul.selector-list
                     - @discussion.closed_motions.each do |closed_motion|
-                      - if closed_motion == @selected_motion
-                        %li.selector-item= render @selected_motion, unique_votes: @unique_votes, this_group: @group
+                      - if closed_motion == @displayed_motion
+                        %li.selector-item= render closed_motion, unique_votes: closed_motion.unique_votes, this_group: @group
                       - else
                         %li.selector-item= render '/motions/motion_preview', motion: closed_motion, this_group: @group
-- if @current_motion
-  = render '/motions/edit_close_date', :motion => @current_motion, :input_time => @input_time

--- a/app/views/motions/_motion.html.haml
+++ b/app/views/motions/_motion.html.haml
@@ -16,9 +16,8 @@
       .proposed-by
         = "Proposed #{time_ago_in_words(motion.created_at)} ago by #{motion.author_name}"
     .span2.motion-admin-buttons
-      = render '/motions/admin_buttons', motion: @current_motion unless @selected_motion || motion.closed?
-  - if motion.closed?
-    =render "motions/outcome_statement", motion: motion, this_group: this_group
+      = render '/motions/admin_buttons', motion: motion unless motion.closed?
+    =render "motions/outcome_statement", motion: motion, this_group: this_group if motion.closed?
 
   .description
 
@@ -42,7 +41,7 @@
     = "have " unless motion.closed?
     = "stated their position (#{motion.group_count - motion.no_vote_count}/#{motion.group_count})"
   .votes
-    - if motion.voting? && @group.users_include?(current_user) && (not @user_already_voted)
+    - if display_vote_buttons?(motion, current_user)
       %h3 State your position
       .vote-buttons.clearfix
         =link_to image_tag("hand-yes.png", title:"I agree", alt:"I agree"), new_motion_vote_path(motion_id: motion.id, position: 'yes'), "title" => "I agree", "data-content" => "I agree with this and want it to go ahead.", class: "position btn vote-yes", id: "yes-vote"
@@ -60,7 +59,7 @@
           el: '.pie'
           id_string: "graph_#{motion.id}"
           legend: true
-          data: #{@votes_for_graph.to_json}
+          data: #{motion.votes_for_graph.to_json}
           type: 'pie'
           tooltip_selector: '#tooltip'
           diameter: 200

--- a/app/views/motions/_motion_preview.html.haml
+++ b/app/views/motions/_motion_preview.html.haml
@@ -21,7 +21,7 @@
               = "no close date"
             =" · " unless this_group
           .proposal-group-name= DiscussionDecorator.new(motion.discussion).display_group_name(this_group)
-      .pie{id: "graph_#{motion.id}", 'data-votes' => motion.votes_graph_ready.to_json}
+      .pie{id: "graph_#{motion.id}", 'data-votes' => motion.votes_for_graph.to_json}
 
 - if params[:controller] == 'discussions'
   :coffeescript
@@ -32,14 +32,14 @@
           el: '.pie'
           id_string: "graph_#{motion.id}"
           legend: false
-          data: #{motion.votes_graph_ready.to_json}
+          data: #{motion.votes_for_graph.to_json}
           type: 'pie'
           tooltip_selector: '#tooltip'
           diameter: 25
           padding: 1
           gap: 1
           shadow: 0.75
-          
+
       # IE8 FIX - for some reason we have to load the graph after everything else.
       # Otherwise, the graph doesn't display in IE8.
       #

--- a/app/views/user_mailer/motion_closing_soon.html.haml
+++ b/app/views/user_mailer/motion_closing_soon.html.haml
@@ -24,7 +24,7 @@
   -#-else
     -#Please state your position
   -#%br
-  -@motion.votes_graph_ready.each do |results|
+  -@motion.votes_for_graph.each do |results|
     =results[0]
   %br
   #{@motion.percent_voted}% of members have stated their position (#{@motion.group_count - @motion.no_vote_count}/#{@motion.group_count})

--- a/spec/controllers/discussions_controller_spec.rb
+++ b/spec/controllers/discussions_controller_spec.rb
@@ -42,7 +42,7 @@ describe DiscussionsController do
 
       context do
         before do
-          motion.stub(:votes_graph_ready).and_return([])
+          motion.stub(:votes_for_graph).and_return([])
           motion.stub(:user_has_voted?).and_return(true)
           motion.stub(:open_close_motion)
           motion.stub(:voting?).and_return(true)

--- a/spec/helpers/motion_helper_spec.rb
+++ b/spec/helpers/motion_helper_spec.rb
@@ -1,0 +1,31 @@
+ require 'spec_helper'
+
+describe MotionsHelper do
+  describe "display_vote_buttons?(motion)" do
+    before do
+      @user = stub :user
+      @motion = mock_model(Motion)
+      @motion.stub(:voting?).and_return(true)
+      @motion.stub(:user_has_voted?).and_return(false)
+      @motion.stub_chain(:group, :users_include?).and_return(true)
+    end
+    context "motion closed" do
+      before { @motion.stub(:voting?).and_return(false) }
+      it "returns false" do
+        display_vote_buttons?(@motion, @user).should == false
+      end
+    end
+    context "user has voted" do
+      before { @motion.stub(:user_has_voted?).and_return(true) }
+      it "returns false" do
+        display_vote_buttons?(@motion, @user).should == false
+      end
+    end
+    context "user does not belong to the group" do
+      before { @motion.stub_chain(:group, :users_include?).and_return(false)}
+      it "returns false" do
+        display_vote_buttons?(@motion, @user).should == false
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is an attempt to remove complexity and confusion around the discussion show action.
John was having a hard time understanding it so I thought it time to perhaps revisit it and give it a little love.  The discussions show and _motion partials have also benifitted slightly from this refactor.  There is still a lot to do as it is an unwieldily beast but it is a start.
