### PR TITLE
Improve speed of tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'http://rubygems.org'
 
 gem 'rails', '~> 3.2.12'
-gem "haml-rails"
+gem 'haml-rails', '~> 0.4'
 gem 'devise', '~> 2.2.3'
 gem 'devise_invitable', '~> 1.0.0'
 gem 'pg', '~> 0.14.1'
@@ -46,7 +46,7 @@ gem 'rinku'
 #       which does not allow us to do this
 #
 #       https://github.com/rails/sass-rails/issues/38#issuecomment-2046678
-gem 'sass-rails',   '~> 3.2.5'
+gem 'sass-rails',   '~> 3.2.6'
 gem 'coffee-rails', '~> 3.2.2'
 
 # Gems used only for assets and not required
@@ -63,7 +63,6 @@ group :development, :test do
   gem "factory_girl_rails", "~> 4.0"
   gem 'faker'
   gem 'rspec-rails'
-  gem 'ruby-prof', :git => 'https://github.com/wycats/ruby-prof.git'
   gem 'shoulda-matchers'
   gem 'capybara'
   gem 'database_cleaner'
@@ -88,12 +87,10 @@ end
 
 group :test do
   gem 'cucumber-rails', :require => false
-  gem 'cane', :git => 'git://github.com/square/cane.git'
-  gem 'simplecov', :require => false
-  gem 'flay', :require => false
-  gem "rails_best_practices", :require => false
   gem 'email_spec'
   gem 'poltergeist', :git => 'https://github.com/jonleighton/poltergeist.git'
+  gem 'webmock', '~> 1.11.0'
+  gem 'vcr', '~> 2.4.0'
 end
 
 group :staging, :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,4 @@
 GIT
-  remote: git://github.com/square/cane.git
-  revision: 350777252265dc5345bb9b63727f13660a1127c2
-  specs:
-    cane (1.0.0)
-      tailor
-
-GIT
   remote: https://github.com/jonleighton/poltergeist.git
   revision: 5c2e092001074a8cf09f332d3714e9ba150bc8ca
   specs:
@@ -28,12 +21,6 @@ GIT
   revision: e7f328cd38985da7e7441aff17813132ff0e479a
   specs:
     redcarpet (2.1.1)
-
-GIT
-  remote: https://github.com/wycats/ruby-prof.git
-  revision: ffae61a895531f9601dd302a3eb0abc58c2a5473
-  specs:
-    ruby-prof (0.11.0)
 
 GEM
   remote: http://rubygems.org/
@@ -133,8 +120,8 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.1.3)
-    colored (1.2)
     columnize (0.3.6)
+    crack (0.3.2)
     cucumber (1.2.1)
       builder (>= 2.1.2)
       diff-lcs (>= 1.1.3)
@@ -191,9 +178,6 @@ GEM
     faye-websocket (0.4.6)
       eventmachine (>= 0.12.0)
     ffi (1.3.1)
-    flay (1.4.3)
-      ruby_parser (~> 2.0)
-      sexp_processor (~> 3.0)
     foreman (0.60.2)
       thor (>= 0.13.6)
     formtastic (2.0.2)
@@ -213,12 +197,12 @@ GEM
       childprocess (>= 0.2.3)
       guard (>= 1.1)
       spork (>= 0.8.4)
-    haml (3.1.4)
-    haml-rails (0.3.4)
-      actionpack (~> 3.0)
-      activesupport (~> 3.0)
-      haml (~> 3.0)
-      railties (~> 3.0)
+    haml (3.1.8)
+    haml-rails (0.4)
+      actionpack (>= 3.1, < 4.1)
+      activesupport (>= 3.1, < 4.1)
+      haml (>= 3.1, < 4.1)
+      railties (>= 3.1, < 4.1)
     has_scope (0.5.1)
     high_voltage (1.2.0)
     highline (1.6.8)
@@ -301,7 +285,6 @@ GEM
     polyamorous (0.5.0)
       activerecord (~> 3.0)
     polyglot (0.3.3)
-    progressbar (0.10.0)
     pry (0.9.10)
       coderay (~> 1.0.5)
       method_source (~> 0.8)
@@ -335,13 +318,6 @@ GEM
       coffee-script (~> 2.2.0)
       ejs (~> 1.0.0)
       railties (>= 3.1.0)
-    rails_best_practices (1.9.0)
-      activesupport
-      colored
-      erubis
-      i18n
-      progressbar
-      sexp_processor
     railties (3.2.13)
       actionpack (= 3.2.13)
       activesupport (= 3.2.13)
@@ -349,7 +325,7 @@ GEM
       rake (>= 0.8.7)
       rdoc (~> 3.4)
       thor (>= 0.14.6, < 2.0)
-    rake (10.0.3)
+    rake (10.0.4)
     rb-fchange (0.0.5)
       ffi
     rb-fsevent (0.9.1)
@@ -375,8 +351,6 @@ GEM
       rspec-core (~> 2.12.0)
       rspec-expectations (~> 2.12.0)
       rspec-mocks (~> 2.12.0)
-    ruby_parser (2.3.1)
-      sexp_processor (~> 3.0)
     rubyzip (0.9.9)
     sass (3.2.7)
     sass-rails (3.2.6)
@@ -388,16 +362,11 @@ GEM
       libwebsocket (~> 0.1.3)
       multi_json (~> 1.0)
       rubyzip
-    sexp_processor (3.2.0)
     shoulda-matchers (1.2.0)
       activesupport (>= 3.0.0)
     simple_form (2.0.4)
       actionpack (~> 3.0)
       activemodel (~> 3.0)
-    simplecov (0.6.1)
-      multi_json (~> 1.0)
-      simplecov-html (~> 0.5.3)
-    simplecov-html (0.5.3)
     sinatra (1.3.3)
       rack (~> 1.3, >= 1.3.6)
       rack-protection (~> 1.2)
@@ -416,14 +385,11 @@ GEM
       rack (~> 1.0)
       tilt (~> 1.1, != 1.3.0)
     sqlite3 (1.3.6)
-    tailor (0.1.5)
-      term-ansicolor (>= 1.0.5)
-    term-ansicolor (1.0.7)
     thin (1.4.1)
       daemons (>= 1.0.9)
       eventmachine (>= 0.12.6)
       rack (>= 1.0.0)
-    thor (0.17.0)
+    thor (0.18.1)
     tilt (1.3.6)
     treetop (1.4.12)
       polyglot
@@ -433,8 +399,12 @@ GEM
       execjs (>= 0.3.0)
       multi_json (>= 1.0.2)
     uuidtools (2.1.3)
+    vcr (2.4.0)
     warden (1.2.1)
       rack (>= 1.0)
+    webmock (1.11.0)
+      addressable (>= 2.2.7)
+      crack (>= 0.3.2)
     websocket (1.0.6)
     xpath (0.1.4)
       nokogiri (~> 1.3)
@@ -452,7 +422,6 @@ DEPENDENCIES
   bootstrap-sass (~> 2.3.1)
   browser
   cancan
-  cane!
   capistrano
   capybara
   client_side_validations
@@ -470,14 +439,13 @@ DEPENDENCIES
   exception_notification
   factory_girl_rails (~> 4.0)
   faker
-  flay
   foreman
   formtastic
   gravtastic
   guard
   guard-rspec
   guard-spork
-  haml-rails
+  haml-rails (~> 0.4)
   high_voltage
   hirefireapp
   inherited_resources
@@ -501,7 +469,6 @@ DEPENDENCIES
   rack-canonical-host
   rails (~> 3.2.12)
   rails-backbone
-  rails_best_practices
   rb-fchange
   rb-fsevent
   rb-inotify
@@ -509,13 +476,13 @@ DEPENDENCIES
   rinku
   rmagick
   rspec-rails
-  ruby-prof!
-  sass-rails (~> 3.2.5)
+  sass-rails (~> 3.2.6)
   selenium-webdriver (= 2.25.0)
   shoulda-matchers
   simple_form (~> 2.0.0)
-  simplecov
   spork-rails
   thin
   twitter-text!
   uglifier (>= 1.0.3)
+  vcr (~> 2.4.0)
+  webmock (~> 1.11.0)

--- a/features/support/vcr.rb
+++ b/features/support/vcr.rb
@@ -1,0 +1,6 @@
+require 'vcr'
+VCR.configure do |c|
+  c.cassette_library_dir = 'spec/support/vcr_cassettes'
+  c.hook_into :webmock
+  c.ignore_localhost = true
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,9 +18,16 @@ Spork.prefork do
   Spork.trap_method(Rails::Application::RoutesReloader, :reload!) if Spork.using_spork?
 
   require File.expand_path("../../config/environment", __FILE__)
+
+  require 'vcr'
+  VCR.configure do |c|
+    c.cassette_library_dir = 'spec/support/vcr_cassettes'
+    c.hook_into :webmock
+    c.ignore_localhost = true
+  end
+
   require 'rspec/rails'
   require 'rspec/autorun'
-
   RSpec.configure do |config|
     config.mock_with :rspec
 


### PR DESCRIPTION
Installed the vcr gem which stubs out all Net::HTTP requests unless they
are explicitly allowed. =)

This should bring our test speeds back down to normal.
