### PR TITLE
Bug/fixing mentions - Issue 582

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -13,6 +13,7 @@ class UsersController < BaseController
     if @group_request && (not @group_request.accepted?)
       @user = User.new(params[:user])
       if @user.save
+        @user.generate_username
         sign_in @user
         redirect_to group_path(@group_request.group)
       else

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -52,7 +52,6 @@ class User < ActiveRecord::Base
            :conditions => { :access_level => Membership::MEMBER_ACCESS_LEVELS },
            :dependent => :destroy
 
-
   has_many :groups,
            :through => :memberships
   has_many :adminable_groups,

--- a/db/migrate/20130402220904_add_missing_usernames.rb
+++ b/db/migrate/20130402220904_add_missing_usernames.rb
@@ -1,0 +1,38 @@
+class AddMissingUsernames < ActiveRecord::Migration
+  class User < ActiveRecord::Base
+    def generate_username
+      ensure_name_entry if name.nil?
+      if name.include? '@'
+        #email used in place of name
+        email_str = email.split("@").first
+        new_username = email_str.gsub(/[^a-zA-Z0-9]/, "").downcase
+      else
+        new_username = name.gsub(/[^a-zA-Z0-9]/, "").downcase
+      end
+      username_tmp = new_username.dup
+      num = 1
+      while(User.where("username = ?", username_tmp).count > 0)
+        username_tmp = "#{new_username}#{num}"
+        num+=1
+      end
+      self.username = username_tmp
+      save
+    end
+
+    def ensure_name_entry
+      unless name
+        self.name = email
+        save
+      end
+    end
+  end
+
+  def up
+    User.where("username IS NULL").each do |user|
+      user.generate_username
+    end
+  end
+
+  def down
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20130318033458) do
+ActiveRecord::Schema.define(:version => 20130402220904) do
 
   create_table "active_admin_comments", :force => true do |t|
     t.string   "resource_id",   :null => false

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -9,6 +9,19 @@ describe UsersController do
     request.env["HTTP_REFERER"] = previous_url
   end
 
+  describe "#create" do
+    before do
+      req = mock_model(GroupRequest, :accepted? => false, :group => mock(:group))
+      GroupRequest.stub!(:find_by_token).and_return(req)
+      User.stub!(:new).and_return(user)
+    end
+
+    it "generates a username based on user's name" do
+      user.should_receive(:generate_username)
+      post :create, :user => {}
+    end
+  end
+
   describe "#update" do
     it "updates user.name" do
       user.should_receive(:name=).with("Peter Chilltooth")


### PR DESCRIPTION
This is to fix the following issue : 

> Group admins are not having usernames generated for their account #582

Issue is fixed and a migration has been written to generate all the usernames for Users who slipped through the cracks.
