### PR TITLE
add markdown to at mention emails, fixes #583

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,5 +1,6 @@
 class UserMailer < ActionMailer::Base
   include ApplicationHelper
+  include ActionView::Helpers::TextHelper
   default :from => "\"Loomio\" <noreply@loomio.org>"
 
   def daily_activity(user, activity, since_time)
@@ -15,6 +16,7 @@ class UserMailer < ActionMailer::Base
   def mentioned(user, comment)
     @user = user
     @comment = comment
+    @comment_body = conditional_markdown(comment.uses_markdown, comment.body)
     @discussion = comment.discussion
     mail to: @user.email,
          subject: "#{comment.author.name} mentioned you in the #{comment.group.name} group on Loomio"

--- a/app/views/user_mailer/mentioned.html.haml
+++ b/app/views/user_mailer/mentioned.html.haml
@@ -2,7 +2,9 @@
 
 %p #{@comment.author.name} said:
 
-%p #{@comment.body}
+%p
+  :plain
+    #{@comment_body}
 
 %p
   = link_to "Click here to view this discussion", discussion_url(@discussion)

--- a/features/discussions/mention_user.feature
+++ b/features/discussions/mention_user.feature
@@ -16,14 +16,26 @@ Scenario: User selects a group member to mention
   And I click on "@harry" in the menu that pops up
   And I should see "@harry" added to the "new-comment" field
 
-Scenario: User mentions a group member
-  Given "Harry" is a member of the group
+Scenario: User mentions a group member (and prefers markdown)
+  Given I prefer markdown
+  And "Harry" is a member of the group
   And no emails have been sent
   And harry wants to be emailed when mentioned
   When I visit the discussion page
   And I write and submit a comment that mentions harry
   And I wait 5 seconds
-  Then harry should get an email saying I mentioned him
+  Then harry should get an email with markdown rendered saying I mentioned him
+  And the user should be notified that they were mentioned
+
+Scenario: User mentions a group member (and doesn't prefer markdown)
+  Given I don't prefer markdown
+  And "Harry" is a member of the group
+  And no emails have been sent
+  And harry wants to be emailed when mentioned
+  When I visit the discussion page
+  And I write and submit a comment that mentions harry
+  And I wait 5 seconds
+  Then harry should get an email without markdown rendered saying I mentioned him
   And the user should be notified that they were mentioned
 
 Scenario: User tries to mention a group non-member

--- a/features/step_definitions/mention_user_steps.rb
+++ b/features/step_definitions/mention_user_steps.rb
@@ -31,15 +31,26 @@ Then /^I should see a link to "(.*?)"\'s user$/ do |user|
 end
 
 When /^I write and submit a comment that mentions harry$/ do
-  fill_in 'new-comment', with: 'hi @harry'
+  fill_in 'new-comment', with: 'hi @harry , do you like *markdown*?'
   click_on 'Post comment'
 end
 
 Then /^harry should get an email saying I mentioned him$/ do
-  last_email = ActionMailer::Base.deliveries.last
-  last_email.to.should include 'harry@example.org'
-  last_email.body.should have_content 'mentioned'
-  last_email.body.should have_content 'Unsubscribe'
+  @last_email = ActionMailer::Base.deliveries.last
+  @last_email.to.should include 'harry@example.org'
+  @last_email.body.should have_content 'mentioned'
+  @last_email.body.should have_content 'Unsubscribe'
+end
+
+Then /^harry should get an email with markdown rendered saying I mentioned him$/ do
+  step 'harry should get an email saying I mentioned him'
+  @last_email.body.should have_content 'markdown'
+  @last_email.body.should_not have_content '*markdown*'
+end
+
+Then /^harry should get an email without markdown rendered saying I mentioned him$/ do
+  step 'harry should get an email saying I mentioned him'
+  @last_email.body.should have_content '*markdown*'
 end
 
 Given /^harry wants to be emailed when mentioned$/ do


### PR DESCRIPTION
hey @rdbartlett here's this thing you issued
bit that it will add links in comments as live links in emails :P
