### PR TITLE
Bugfix/markdown button css

### DIFF
--- a/app/assets/javascripts/pop-over.js.coffee
+++ b/app/assets/javascripts/pop-over.js.coffee
@@ -33,5 +33,6 @@ $ ->
 
 $ ->
   $("#discussion-markdown-dropdown").tooltip
-    placement: "left",
+    placement: "right",
+    container: "body",
     title: "Text formatting settings and info."

--- a/app/assets/stylesheets/discussions.css.scss
+++ b/app/assets/stylesheets/discussions.css.scss
@@ -7,8 +7,9 @@ body.discussions.new, body.discussions.create {
   .helper-text.align-with-input { margin-top: 20px }
 
   #discussion-markdown-dropdown {
-    float: right;
-    margin-top: 8px;
+    float: left;
+    margin-top: 10px;
+    margin-left: 10px;
   }
 
   #discussion-submit {
@@ -16,8 +17,9 @@ body.discussions.new, body.discussions.create {
     float: left;
   }
 
-    .markdown-setting-dropdown {
-    margin-top: -14px;
+  .markdown-setting-dropdown {
+    margin-top: 2px;
+    margin-left: -10px;
   }
 }
 
@@ -94,6 +96,8 @@ body.discussions.show {
 
     #discussion-markdown-dropdown {
       margin-top: 10px;
+      margin-right: 8px;
+      padding-right: 0px;
     }
   }
 
@@ -254,11 +258,11 @@ pre{
     margin-right: 10px;
   }
   #comment-markdown-dropdown {
-    margin-top: -43px;
-    margin-right: 10px;
+    margin-top: -32px;
+    margin-right: -8px;
   }
   .markdown-setting-dropdown {
-    margin-top: -20px;
+    margin-top: -2px;
   }
   #new-comment {
     margin: 0 0 5px 0px;

--- a/app/views/discussions/_add_comment.html.haml
+++ b/app/views/discussions/_add_comment.html.haml
@@ -5,7 +5,7 @@
       = text_area_tag 'comment', "", id: 'new-comment', placeholder: t(:comment_form_placeholder)
       = hidden_field_tag 'global_uses_markdown', @uses_markdown, {id: 'global-uses-markdown'}
       = submit_tag t(:comment_form_submit_button), class: "btn btn-small submit", id: 'post-new-comment', :data => {:disable_with => t(:comment_form_submit_button)}
-  .dropdown#comment-markdown-dropdown.global-markdown-setting
-    %a.dropdown-toggle{href:'#comment-markdown-dropdown', id:'comment-markdown-dropdown-link', 'data-toggle'=> 'dropdown'}
-      = markdown_img(@uses_markdown)
-    = render 'markdown_setting', target: current_user
+    .dropdown#comment-markdown-dropdown.global-markdown-setting
+      %a.dropdown-toggle{href:'#comment-markdown-dropdown', id:'comment-markdown-dropdown-link', 'data-toggle'=> 'dropdown'}
+        = markdown_img(@uses_markdown)
+      = render 'markdown_setting', target: current_user

--- a/app/views/groups/_privacy_dropdown.html.haml
+++ b/app/views/groups/_privacy_dropdown.html.haml
@@ -1,5 +1,5 @@
 .dropdown.privacy-dropdown
-  %a.dropdown-toggle{ :href => "#", :id => 'privacy', 'data-toggle' => 'dropdown',  "data-title" => t(:group_privacy, who: group.viewable_by.to_s) }
+  %a.dropdown-toggle{ :href => "#", :id => 'privacy', 'data-toggle' => 'dropdown',  "data-title" => t(:group_privacy, who: group.viewable_by.to_s), 'data-container'=> 'body' }
     = image_tag("privicon_"+group.viewable_by.to_s+".png", alt: group.viewable_by.to_s, :id => 'privacy-image')
   - if can? :edit, group
     %ul.dropdown-menu.pull-left

--- a/features/step_definitions/post_in_discussion_steps.rb
+++ b/features/step_definitions/post_in_discussion_steps.rb
@@ -7,12 +7,12 @@ When /^I write and submit a comment$/ do
 end
 
 When /^I enable comment markdown$/ do
-  click_on 'comment-markdown-dropdown-link'
+  find('#comment-markdown-dropdown-link .markdown-icon').click
   find('#comment-markdown-dropdown .enable-markdown').click
 end
 
 When /^I disable comment markdown$/ do
-  click_on 'comment-markdown-dropdown-link'
+  find('#comment-markdown-dropdown-link .markdown-icon').click
   find('#comment-markdown-dropdown .disable-markdown').click
 end
 


### PR DESCRIPTION
this moves the markdown button on the New Discussion page,
it fixes the markdown dropdowns so they sit below the markdown button
it also adds a container=body attribute to the tooltips so that on:hover the tooltip text flows in a single line (e.g. see the Privacy settings tooltip and markdown tooltip)
