### PR TITLE
Add fallback language to i18n

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -37,6 +37,7 @@ module Loomio
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     # config.i18n.default_locale = :de
+    config.i18n.fallbacks = true
 
     # Configure the default encoding used in templates for Ruby 1.9.
     config.encoding = "utf-8"


### PR DESCRIPTION
Enabling the fallback means any missing translations will be rendered as English.
