### PR TITLE
remove char counter from discussion description, fixes #654

### DIFF
--- a/app/views/discussions/_description.html.haml
+++ b/app/views/discussions/_description.html.haml
@@ -26,7 +26,6 @@
       = hidden_field_tag 'description_uses_markdown', description_markdown_setting, {id: 'description-markdown-setting'}
       .control-group
         = text_area_tag 'description', description, {id: 'description-input',  :autofocus => true }
-        .character-counter
       .save-buttons.clearfix
         = submit_tag t(:save), class: 'btn btn-small btn-grey run-validations', id: 'add-description-submit', :data => {:disable_with => t(:saving)}
         = link_to t(:cancel), "#", id: 'cancel-add-description'


### PR DESCRIPTION
one line commit

this removes the character counter div from the discussion description (it was erroneously copied when the discussion/group descriptions were split apart) 
