### PR TITLE
add missing html files to mailers, fixes #645

### DIFF
--- a/app/views/group_mailer/new_membership_request.html.haml
+++ b/app/views/group_mailer/new_membership_request.html.haml
@@ -1,0 +1,6 @@
+= render '/application/mailer_doctype'
+
+%p #{@user.name} has requested access to one of your Loomio groups.
+
+%p You can approve or decline the request #{link_to("here", group_url(@group))}
+

--- a/app/views/groups/_add_members.html.haml
+++ b/app/views/groups/_add_members.html.haml
@@ -21,7 +21,7 @@
               - unless no_member_limit
                 .member-request-message
                   %span.label= invites_left
-                  = t(:remaining_invtes)
+                  = t(:remaining_invites)
                   %p
                   %p= t(:need_more_invites_html, :href => link_to( t("get_in_touch_link"), "mailto:contact@loomio.org", target: "_blank"))
               %input#group_id{ type: "hidden", value: group.id }

--- a/app/views/user_mailer/added_to_group.html.haml
+++ b/app/views/user_mailer/added_to_group.html.haml
@@ -1,0 +1,12 @@
+= render '/application/mailer_doctype'
+%html
+  %p
+    - if @inviter != nil
+      = "#{@inviter.name} added you to a group called '#{@group.name}' on Loomio."
+    - else
+      = "You have been added to a group called '#{@group.name}' on Loomio."
+
+  %p
+    = link_to "view group", group_url(@group)
+
+  = render 'unsubscribe_link'

--- a/app/views/user_mailer/group_membership_approved.html.haml
+++ b/app/views/user_mailer/group_membership_approved.html.haml
@@ -1,0 +1,5 @@
+= render '/application/mailer_doctype'
+%html
+  %p Your request for access to the group '#{@group.name}' on Loomio has been approved.
+
+  %p Click #{link_to("here", group_url(@group))} to view group

--- a/app/views/user_mailer/invited_to_loomio.html.haml
+++ b/app/views/user_mailer/invited_to_loomio.html.haml
@@ -1,0 +1,9 @@
+= render '/application/mailer_doctype'
+%html
+  %p Hello
+
+  %p #{@inviter.name} has invited you to participate in group discussion and decision making using a new tool called Loomio.
+
+  %p #{link_to("Click here", accept_invitation_url(@new_user, :invitation_token => @new_user.invitation_token))} to accept their invitation.
+
+  %p If you have any questions contact #{link_to(@inviter.email, "mailto:"+@inviter.email)} or find out more about Loomio at #{link_to("http://loomio.org", "http://loomio.org")}

--- a/app/views/user_mailer/motion_closing_soon.html.haml
+++ b/app/views/user_mailer/motion_closing_soon.html.haml
@@ -1,41 +1,43 @@
-%p
-  Proposal:
-  =link_to(@motion.name, motion_url(@motion))
-  %br
-  Group:
-  =@motion.discussion.group.name
-  %br
-  Author:
-  =@motion.author.name
-  %br
-  Closes at:
-  =l @motion.close_date
-  %br
-  Description:
-  =@motion.description
-
-%p
-  %b Summary
-  %br
-  -#-if @motion.user_has_voted?(@user)
-    -#- vote = @user.get_vote_for(@motion)
-    -#Your position
-    -#=vote.position
-  -#-else
-    -#Please state your position
-  -#%br
-  -@motion.votes_for_graph.each do |results|
-    =results[0]
-  %br
-  #{@motion.percent_voted}% of members have stated their position (#{@motion.group_count - @motion.no_vote_count}/#{@motion.group_count})
-
-%p
-  %b Positions
-  %br
-  -@motion.unique_votes.each do |vote|
-    #{vote.user_name} #{vote.position_to_s}
-    -if vote.statement.present?
-      \- #{vote.statement}
+= render '/application/mailer_doctype'
+%html
+  %p
+    Proposal:
+    =link_to(@motion.name, motion_url(@motion))
     %br
+    Group:
+    =@motion.discussion.group.name
+    %br
+    Author:
+    =@motion.author.name
+    %br
+    Closes at:
+    =l @motion.close_date
+    %br
+    Description:
+    =@motion.description
 
-=render 'unsubscribe_link'
+  %p
+    %b Summary
+    %br
+    -#-if @motion.user_has_voted?(@user)
+      -#- vote = @user.get_vote_for(@motion)
+      -#Your position
+      -#=vote.position
+    -#-else
+      -#Please state your position
+    -#%br
+    -@motion.votes_for_graph.each do |results|
+      =results[0]
+    %br
+    #{@motion.percent_voted}% of members have stated their position (#{@motion.group_count - @motion.no_vote_count}/#{@motion.group_count})
+
+  %p
+    %b Positions
+    %br
+    -@motion.unique_votes.each do |vote|
+      #{vote.user_name} #{vote.position_to_s}
+      -if vote.statement.present?
+        \- #{vote.statement}
+      %br
+
+  =render 'unsubscribe_link'


### PR DESCRIPTION
Added html files to mailers:
- new_membership_request.html.haml
- added_to_group.html.haml
- group_membership_approved.html.haml
- invited_to_loomio.html.haml

Used mailcatcher to test emails and all seemed to be rendering fine

Fixed translation typo in symbol "request_invtes"
