### PR TITLE
Get stats export tasks to use fog instead of S3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,7 @@ gem 'rinku', '~> 1.7.2'
 gem 'sass-rails',   '~> 3.2.6'
 gem 'coffee-rails', '~> 3.2.2'
 gem 'piwik_analytics', '~> 1.0.1'
+gem 'fog'
 
 # Gems used only for assets and not required
 # in production environments by default.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -141,6 +141,7 @@ GEM
     eventmachine (0.12.10)
     exception_notification (2.6.1)
       actionmailer (>= 3.0.4)
+    excon (0.20.1)
     execjs (1.2.9)
       multi_json (~> 1.0)
     factory_girl (4.0.0)
@@ -154,8 +155,19 @@ GEM
     faye-websocket (0.4.7)
       eventmachine (>= 0.12.0)
     ffi (1.3.1)
+    fog (1.9.0)
+      builder
+      excon (~> 0.14)
+      formatador (~> 0.2.0)
+      mime-types
+      multi_json (~> 1.0)
+      net-scp (~> 1.0.4)
+      net-ssh (>= 2.1.3)
+      nokogiri (~> 1.5.0)
+      ruby-hmac
     foreman (0.60.2)
       thor (>= 0.13.6)
+    formatador (0.2.4)
     formtastic (2.0.2)
       rails (~> 3.0)
     gherkin (2.11.1)
@@ -338,6 +350,7 @@ GEM
       rspec-core (~> 2.12.0)
       rspec-expectations (~> 2.12.0)
       rspec-mocks (~> 2.12.0)
+    ruby-hmac (0.4.0)
     rubyzip (0.9.9)
     sass (3.2.7)
     sass-rails (3.2.6)
@@ -428,6 +441,7 @@ DEPENDENCIES
   exception_notification (~> 2.6.1)
   factory_girl_rails (~> 4.0)
   faker (~> 1.0.1)
+  fog
   foreman (~> 0.60.2)
   formtastic
   gravtastic (~> 3.2.6)


### PR DESCRIPTION
@jonlemmon was right, this does make the permission much easier to set. 
