### PR TITLE
make notifications load via async get

### DIFF
--- a/app/assets/javascripts/notifications.js.coffee
+++ b/app/assets/javascripts/notifications.js.coffee
@@ -16,3 +16,14 @@ $ ->
   $(".notification-item").click((event)->
     event.stopPropagation()# if (event.metaKey || event.ctrlKey)
   )
+
+$ ->
+  # load the notifications on page load
+  $("li#notification-dropdown-items").load('/notifications/dropdown_items')
+
+  # when the user clicks the notifications toggle, send mark as viewed event
+  $("a#notifications-toggle").on 'click', (event) ->
+    if $('li.notification-item').length > 0
+      notification_css_id = $('li.notification-item').first().attr('id')
+      notification_id = /\d+/.exec(notification_css_id)
+      $.post("notifications/mark_as_viewed?latest_viewed=#{notification_id}")

--- a/app/controllers/base_controller.rb
+++ b/app/controllers/base_controller.rb
@@ -1,5 +1,5 @@
 class BaseController < InheritedResources::Base
-  before_filter :authenticate_user!, :check_browser, :check_invitation, :get_notifications
+  before_filter :authenticate_user!, :check_browser, :check_invitation
   # inherit_resources
 
   def check_browser
@@ -17,13 +17,6 @@ class BaseController < InheritedResources::Base
         session[:start_new_group_token] = nil
         redirect_to group_url(group_request.group_id)
       end
-    end
-  end
-
-  def get_notifications
-    if user_signed_in?
-      @unviewed_notifications = current_user.unviewed_notifications
-      @notifications = current_user.recent_notifications
     end
   end
 end

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -1,9 +1,13 @@
 class NotificationsController < BaseController
+  def dropdown_items
+    @unviewed_notifications = current_user.unviewed_notifications
+    @notifications = current_user.recent_notifications
+    render layout: false
+  end
+
   def index
     @notifications = []
-    if user_signed_in?
-      @notifications = current_user.notifications.page(params[:page]).per(15)
-    end
+    @notifications = current_user.notifications.page(params[:page]).per(15)
   end
 
   def mark_as_viewed

--- a/app/views/application/_groups_dropdown.html.haml
+++ b/app/views/application/_groups_dropdown.html.haml
@@ -1,0 +1,15 @@
+%li.nav-item.dropdown#groups
+  %a.nav-link{href: "#",  class: 'dropdown-toggle', 'data-toggle' => 'dropdown'}
+    %span.header-bar-icon.nav-item-icon.large-icon.group-icon
+    %span= t :groups
+    %b.caret
+  %ul.dropdown-menu
+    #group-dropdown-items
+      - current_user.root_groups.each do |group|
+        = render 'group_dropdown_item', user: current_user, group: group, subgroup: false
+        - if group.subgroups.size > 0
+          - group.subgroups.each do |subgroup|
+            - if current_user.group_membership(subgroup)
+              = render 'group_dropdown_item', user: current_user, group: subgroup, subgroup: true
+    %li.group-item.new-group
+      =link_to t(:request_new_group), request_new_group_path

--- a/app/views/application/_header.html.haml
+++ b/app/views/application/_header.html.haml
@@ -8,55 +8,9 @@
               = image_tag("top-bar-loomio.png", :alt => "Loomio")
 
           - if user_signed_in?
-            %li.nav-item.dropdown#groups
-              %a.nav-link{href: "#",  class: 'dropdown-toggle', 'data-toggle' => 'dropdown'}
-                %span.header-bar-icon.nav-item-icon.large-icon.group-icon
-                %span= t :groups
-                %b.caret
-              %ul.dropdown-menu
-                #group-dropdown-items
-                  - current_user.root_groups.each do |group|
-                    = render 'group_dropdown_item', user: current_user, group: group, subgroup: false
-                    - if group.subgroups.size > 0
-                      - group.subgroups.each do |subgroup|
-                        - if current_user.group_membership(subgroup)
-                          = render 'group_dropdown_item', user: current_user, group: subgroup, subgroup: true
-                %li.group-item.new-group
-                  =link_to t(:request_new_group), request_new_group_path
-
-            -if notifications.present?
-              %li.nav-item.dropdown#notifications-container
-                - latest_seen_notification = notifications.first.id if notifications.present?
-                = link_to "#", 'ajax-path' => mark_as_viewed_notifications_path(:latest_viewed => latest_seen_notification),
-                         :id => 'notifications-toggle', :class => 'dropdown-toggle nav-link', 'data-target' => '#',
-                         'data-toggle' => 'dropdown' do
-                  %span.header-bar-icon.nav-item-icon.large-icon.notification-icon
-                  - if unviewed_notifications.present?
-                    %span#notifications-count.label.label-important
-                      = unviewed_notifications.size
-                  %span= t("notifications.header")
-                  %b.caret
-                %ul.dropdown-menu
-                  %li
-                    %h3= t("notifications.header")
-                  %li#notification-dropdown-items
-                    %ul
-                      - if notifications.empty?
-                        %li.notifications-placeholder= t :empty_notifications
-                      - notifications.each do |notification|
-                        = render notification
-                  %li#notifications-see-more= link_to t(:see_all_notifications), notifications_path
-
-            %li.nav-item.dropdown#user
-              %a.nav-link{href: "#", class: 'dropdown-toggle', 'data-toggle' => 'dropdown'}
-                = render 'avatar', user: current_user, size: "small", kind: nil, id: 'header-user-image'
-                %span#user-name-dropdown
-                  = current_user.name
-                %b.caret
-              %ul.dropdown-menu
-                %li= link_to t(:user_settings), user_settings_path
-                %li= link_to t(:email_preferences), email_preferences_path
-                %li= link_to(t(:sign_out), destroy_user_session_path, method: :delete)
+            = render 'groups_dropdown'
+            = render 'notifications_dropdown'
+            = render 'user_dropdown'
 
             %li.nav-item#feedback
               %a.nav-link{:href => 'mailto:contact@loomio.org', :target => '_blank'}

--- a/app/views/application/_notifications_dropdown.html.haml
+++ b/app/views/application/_notifications_dropdown.html.haml
@@ -1,0 +1,13 @@
+%li.nav-item.dropdown#notifications-container
+  %a#notifications-toggle.dropdown-toggle.nav-link{'data-toggle' => 'dropdown', :href => '#'}
+    %span.header-bar-icon.nav-item-icon.large-icon.notification-icon
+    %span#notifications-count.label.label-important
+    %span= t("notifications.header")
+    %b.caret
+  %ul.dropdown-menu
+    %li
+      %h3= t("notifications.header")
+    %li#notification-dropdown-items
+      %ul
+        %li Loading
+    %li#notifications-see-more= link_to t(:see_all_notifications), notifications_path

--- a/app/views/application/_user_dropdown.html.haml
+++ b/app/views/application/_user_dropdown.html.haml
@@ -1,0 +1,10 @@
+%li.nav-item.dropdown#user
+  %a.nav-link{href: "#", class: 'dropdown-toggle', 'data-toggle' => 'dropdown'}
+    = render 'avatar', user: current_user, size: "small", kind: nil, id: 'header-user-image'
+    %span#user-name-dropdown
+      = current_user.name
+    %b.caret
+  %ul.dropdown-menu
+    %li= link_to t(:user_settings), user_settings_path
+    %li= link_to t(:email_preferences), email_preferences_path
+    %li= link_to(t(:sign_out), destroy_user_session_path, method: :delete)

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -11,9 +11,8 @@
 
   %body{class: "#{controller_name} #{action_name}"}
     .main-container.container
-      = render 'header', :notifications => @notifications,
-        :unviewed_notifications => @unviewed_notifications
       = render 'announcements' if user_signed_in?
+      = render 'header'
       = render 'flash_messages', :flash => flash, :on_landing_page => false
       = render_help_text(@group)
       .page-container

--- a/app/views/notifications/dropdown_items.html.haml
+++ b/app/views/notifications/dropdown_items.html.haml
@@ -1,0 +1,10 @@
+%ul
+  - if @notifications.empty?
+    %li.notifications-placeholder= t :empty_notifications
+  - @notifications.each do |notification|
+    = render notification
+:coffeescript
+  new_notifications_count = #{@unviewed_notifications.size}
+  if new_notifications_count > 0
+    $('span#notifications-count').html(new_notifications_count)
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -44,6 +44,7 @@ Loomio::Application.routes.draw do
   post "/discussion/update_version/:version_id", :to => "discussions#update_version", :as => "update_version_discussion"
 
   resources :notifications, :only => :index do
+    get :dropdown_items, on: :collection
     post :mark_as_viewed, :on => :collection, :via => :post
   end
 

--- a/spec/jstests/index.html
+++ b/spec/jstests/index.html
@@ -1,0 +1,23 @@
+<html>
+  <head>
+    <title>Test Suite</title>
+    <script>
+      function assert(value, desc) {
+        var li = document.createElement("li");
+        li.className = value ? "pass" : "fail";
+        li.appendChild(document.createTextNode(desc));
+        document.getElementById("results").appendChild(li);
+}window.onload = function() {
+        assert(true, "The test suite is running.");
+        assert(false, "Fail!");
+}; </script>
+    <script src="email_tests.js"></script>
+    <style>
+      #results li.pass { color: green; }
+      #results li.fail { color: red; }
+    </style>
+  </head>
+  <body>
+     <ul id="results"></ul>
+  </body>
+</html>


### PR DESCRIPTION
Fix a pet peeve and improve performance - probably by a fair amount but I've not measured it.

This represents the least work necessary to make notifications load via ajax and work exactly the same way as before in regards to marking unviewed notifications as viewed
