### PR TITLE
remove short and see more from group description

### DIFF
--- a/app/views/groups/_description.html.haml
+++ b/app/views/groups/_description.html.haml
@@ -1,21 +1,8 @@
 - description_markdown_setting ||= false
 .description-container
   .description-body
-    - too_long = true if group.description && group.description.length > 500
-    - long_description = render_rich_text(group.description, description_markdown_setting)
-    - short_description = render_rich_text(truncate(group.description, length: 500, omission: '...', separator: ' '), description_markdown_setting)
-    <!--[if IE 7]>
     .long-description.model-description
-      ~ long_description
-    <![endif]-->
-
-    <!--[if !IE 7]><!-->
-    .short-description.model-description
-      ~ short_description
-    .long-description.model-description{style: "display: none"}
-      ~ long_description
-    = link_to "Show More", "#", class: 'see-more' if too_long
-    <!--<![endif]-->
+      ~ render_rich_text(group.description, description_markdown_setting)
 
     - if can? :edit_description, group
       = link_to "Edit group info", "#", class: "edit-description edit-group-description", id: 'edit_description'

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -111,6 +111,7 @@ ActiveRecord::Schema.define(:version => 20130422085712) do
     t.datetime "discussion_last_viewed_at"
   end
 
+  add_index "discussion_read_logs", ["discussion_id"], :name => "index_motion_read_logs_on_discussion_id"
   add_index "discussion_read_logs", ["user_id", "discussion_id"], :name => "index_discussion_read_logs_on_user_id_and_discussion_id"
   add_index "discussion_read_logs", ["user_id"], :name => "index_motion_read_logs_on_user_id"
 


### PR DESCRIPTION
@AaronThornton00 reported some [vesitgal](http://en.wikipedia.org/wiki/Vestigiality) group description code, a hang-over from some refactoring.

I removed the long/ short and see-more because the database in this context limits submission to 250 chars 
