### PR TITLE
fix improper carrot escaping, fixes #674

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -55,18 +55,22 @@ module ApplicationHelper
 
     if md_boolean
       options = [
-        :no_intra_emphasis => true,
-        :tables => true,
-        :fenced_code_blocks => true,
-        :autolink => true,
-        :strikethrough => true,
+        :no_intra_emphasis   => true,
+        :tables              => true,
+        :fenced_code_blocks  => true,
+        :autolink            => true,
+        :strikethrough       => true,
         :space_after_headers => true,
-        :superscript => true
+        :superscript         => true,
+        :underline           => true
       ]
 
-      renderer = Redcarpet::Render::HTML.new(link_attributes: {target: '_blank'})
+      renderer = Redcarpet::Render::HTML.new(
+        :filter_html         => true,
+        :link_attributes     => {target: '_blank'}
+        )
       markdown = Redcarpet::Markdown.new(renderer, *options)
-      markdown.render(html_escape(text)).html_safe
+      markdown.render(text).html_safe
     else
       Rinku.auto_link(simple_format(html_escape(text)), mode=:all, 'target="_blank"').html_safe
     end
@@ -114,5 +118,4 @@ module ApplicationHelper
     end
   end
 end
-
 


### PR DESCRIPTION
re-introduced the `:filter_html` option. This means behaviour such as: 

`2 <5    but you need to see this 3> 4   not` 
=> 2 <5    but you need to see this 3> 4   not

`2 < 5 but you need to see this 3 > 4 not` 
=> 2 < 5 but you need to see this 3 > 4 not

---

i think this is the best solution for the moment as it will bring back all < markdown quote functionality and &&'s in code blocks behave (as html_escape is no longer necessary when filter_html is active).

Downside(s):
- if a user is tech enough to know tags like `<a href='bobo'>here</>` the output will be `` ... but they'll probably then be smart enough to realise what's happened/ someone will point out their comment makes no sense.
- if a user accidentally puts carrots directly next to text their text will be _nuked_. again they will probably see this .... and it's an edge case which probably involves mathematicians and emoticon fans...
