### PR TITLE
Add rack-timeout for better error reporting

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,7 @@ gem 'delayed_job_active_record', '~> 0.3.3'
 gem 'hirefireapp', '~> 0.0.8'
 gem 'foreman', '~> 0.60.2'
 gem 'rinku', '~> 1.7.2'
+gem 'rack-timeout', '~> 0.0.4'
 
 # NOTE: sass-rails should be inside :assets group, but currently there is an issue with activeadmin
 #       which does not allow us to do this

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -302,6 +302,7 @@ GEM
       rack
     rack-test (0.6.2)
       rack (>= 1.0)
+    rack-timeout (0.0.4)
     rails (3.2.13)
       actionmailer (= 3.2.13)
       actionpack (= 3.2.13)
@@ -472,6 +473,7 @@ DEPENDENCIES
   rabl (~> 0.7.3)
   rack-canonical-host (~> 0.0.8)
   rack-mini-profiler (~> 0.1.23)
+  rack-timeout (~> 0.0.4)
   rails (~> 3.2.13)
   rails-backbone (~> 0.7.2)
   rb-fchange (~> 0.0.5)

--- a/config/initializers/timeout.rb
+++ b/config/initializers/timeout.rb
@@ -1,0 +1,1 @@
+Rack::Timeout.timeout = Integer(ENV['RACK_TIMEOUT'] || 20) # seconds

--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -1,7 +1,7 @@
 # config/unicorn.rb
 
-worker_processes Integer(ENV['WEB_CONCURRENCY'] || 3)
-timeout Integer(ENV['WEB_TIMEOUT'] || 30)
+worker_processes Integer(ENV['UNICORN_WORKERS'] || 3)
+timeout Integer(ENV['UNICORN_TIMEOUT'] || 30)
 preload_app true
 
 before_fork do |server, worker|


### PR DESCRIPTION
This will give us better error reporting when stuff times out.
It will also allow us to have finer control over how long
we allow requests to go for. Perhaps we only want requests to
last for 10 seconds before cancelling... rack-timeout lets us
control this.
