### PR TITLE
Typographical improvements to front page

### DIFF
--- a/app/views/pages/home.html.haml
+++ b/app/views/pages/home.html.haml
@@ -5,12 +5,12 @@
         .span6
           %h2.buffer Creating a world where it’s easy for anyone to participate in decisions that affect them.
 
-          %p 
+          %p
             Loomio is a user-friendly app for building shared understanding, making clear decisions and turning talk into action.
             =link_to 'Find out more', about_path
 
-          %p 
-            We're still in development - if you want to get involved early
+          %p
+            We’re still in development &ndash; if you want to get involved early
             %a{href: request_new_group_path} apply to get your group on Loomio.
         .span6
           <iframe class="no-bottom-margin" src="https://player.vimeo.com/video/51331688?title=0&amp;byline=0&amp;portrait=0&amp;badge=0&amp;color=ff9933" width="426" height="264" frameborder="0" webkitAllowFullScreen mozallowfullscreen allowFullScreen></iframe>


### PR DESCRIPTION
There was a hyphen instead of a dash, and a straight quote mark instead of a proper one.
