### PR TITLE
Feature/loomio metrics

### DIFF
--- a/app/assets/javascripts/load_metrics_listener.js.coffee
+++ b/app/assets/javascripts/load_metrics_listener.js.coffee
@@ -1,0 +1,24 @@
+  if url = window.metrics_listener_url
+    # Inspiration found at http://friendlybit.com/js/lazy-loading-asyncronous-javascript/
+    (->
+      async_load = ->
+        s = document.createElement("script")
+        s.type = "text/javascript"
+        s.async = true
+        s.src = url
+        x = document.getElementsByTagName("script")[0]
+        x.parentNode.insertBefore s, x
+
+      if window.attachEvent
+        window.attachEvent "onload", async_load
+      else
+        window.addEventListener "load", async_load, false
+
+      window.lmReady = ->
+        try
+          $(document).lm()
+        catch err
+          return # the user doesn't care if there's any error in the tracking script - ignore them
+    )()
+
+

--- a/app/views/application/_metrics_listener_data.html.haml
+++ b/app/views/application/_metrics_listener_data.html.haml
@@ -1,0 +1,3 @@
+:javascript
+  window.user_id = #{ user_signed_in? ? current_user.id : 'undefined' };
+  window.metrics_listener_url = "#{ ENV['METRICS_LISTENER_URL'] }";

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -21,4 +21,6 @@
 
     - if Rails.env.production? || Rails.env.staging?
       = render 'google_analytics'
+      = render 'metrics_listener_data'
+      = javascript_include_tag 'load_metrics_listener'
       /= piwik_tracking_tag # Disabling piwik until we've moved it over to our own server

--- a/app/views/layouts/pages.html.haml
+++ b/app/views/layouts/pages.html.haml
@@ -33,5 +33,8 @@
           =link_to('About us', '/about#about-us')
     = yield
   = javascript_include_tag "frontpage"
-  = render 'google_analytics'
-  /= piwik_tracking_tag # Disabling piwik until we've moved it over to our own server
+  - if Rails.env.production? || Rails.env.staging?
+    = render 'metrics_listener_data'
+    = javascript_include_tag 'load_metrics_listener'
+    = render 'google_analytics'
+    /= piwik_tracking_tag # Disabling piwik until we've moved it over to our own server

--- a/config/initializers/variables.rb
+++ b/config/initializers/variables.rb
@@ -1,0 +1,1 @@
+ENV['METRICS_LISTENER_URL'] ||= "http://loomio-metrics.s3.amazonaws.com/js/metrics_listener.js?v=1.0"


### PR DESCRIPTION
This does an unobtrusive lazy load of the loomio-metrics.js jQuery plugin (loading the last version from github). 

Also, the id of the current user is passed trough a HTML5 data attribute to the dom so that the jQuery plugin can use it. We might want to pass additional data like this at a later point.

The code of the jQuery plugin that is loaded with this code is available [here](https://github.com/loomio/loomio-metrics-client/blob/master/loomio-metrics.js)

You can test the plugin [on a herokufied loomio app running this branch](https://loomio-metrics.herokuapp.com/) (login with loomio@metri.cs/metrics). The visualisation of the metrics can be visualised [here](http://198.199.65.175:4242) (this is irrelevant to this pull request).
