### PR TITLE
fix bug in routes for cancel membership request

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,7 +25,7 @@ Loomio::Application.routes.draw do
        # these three (and #new) are for membership requests which I hope to split off into a new class
        post :approve_request, as: :approve_request_for
        post :ignore_request, as: :ignore_request_for
-       post :cancel_request, as: :cancel_request_for
+       delete :cancel_request, as: :cancel_request_for
       end
     end
 


### PR DESCRIPTION
'cancel request' button on group page was not working.

this was due to a difference between a link_to and a route 
- `link_to` was trying to send a DELETE request
- route was for PUT requests.

investigating the Memberships Controller, I found the `cancel_request` action, which is calling `@membership.destroy` 

so i changed the routes to match the link_to (both are DELETE now) 
