### PR TITLE
Group facilitator is being added to pending invitation list

### DIFF
--- a/extras/accept_invitation.rb
+++ b/extras/accept_invitation.rb
@@ -7,5 +7,6 @@ class AcceptInvitation
     else
       invitation.group.add_member!(user, invitation.inviter)
     end
+    invitation.save!
   end
 end


### PR DESCRIPTION
I start a new group and invite some people to it, I then visit the pending invitations from the group page and find myself in that list.
invitation.accepted is not being saved when I am added to the group I am creating.
This marks invitations as accepted so they cannot be reused.
