### PR TITLE
Remove validation for invites

### DIFF
--- a/app/assets/javascripts/invitations.js.coffee
+++ b/app/assets/javascripts/invitations.js.coffee
@@ -6,12 +6,6 @@ $ -> # Remove email help class if changed
   $(".validate-emails").keyup () ->
     hideValidateEmailErrorMessageFor($(this))
 
-$ -> # Parse emails and display number of valid ones
-  $(".validate-emails").focusout () ->
-    emailList = parseEmails($(this).val())
-    validateMinimumEmailCount(this, emailList.length)
-
-
 ### FUNCTIONS ###
 
 parseEmails = (input_emails) ->
@@ -24,16 +18,9 @@ parseEmails = (input_emails) ->
 Application.validateEmailsAndConfirm = (field) ->
   if $(field).is(":visible")
     emailList = parseEmails($(field).val())
-    return false unless validateMinimumEmailCount(field, emailList.length)
-    return false unless confirm("#{emailList.length} invitations will be sent")
-    $(".recipients").val(emailList.toString())
-  true
-
-validateMinimumEmailCount = (field, num) ->
-  if num == 0
-    $(field).parent().addClass('error')
-    $(field).parent().find(".email-validation-help").show()
-    return false
+    if(emailList.length > 0)
+      return false unless confirm("#{emailList.length} invitations will be sent")
+      $(".recipients").val(emailList.toString())
   true
 
 hideValidateEmailErrorMessageFor = (field) ->

--- a/app/assets/stylesheets/pages.css.scss
+++ b/app/assets/stylesheets/pages.css.scss
@@ -212,14 +212,14 @@ a.btn-icon:hover { color: $dark-grey; }
 
   .pull-right { margin-top: 10px; }
 
-  section {
+  section{
     margin-top: 34px;
     background: white;
     box-shadow: 3px 3px 5px #eee;
     border: 1px solid #eee;
   }
 
-  section.first {
+  section.first{
     margin-top: 0px;
   }
 

--- a/app/controllers/groups/group_setup_controller.rb
+++ b/app/controllers/groups/group_setup_controller.rb
@@ -15,7 +15,7 @@ class Groups::GroupSetupController < GroupBaseController
       invite_attributes = build_invite_attributes(params[:group_setup])
       @invite_people = InvitePeople.new(invite_attributes)
       num = CreateInvitation.to_people_and_email_them(@invite_people, group: @group_setup.group, inviter: current_user)
-      flash[:notice] = "#{num} invitation(s) sent"
+      flash[:notice] = "#{num} invitation(s) sent" if num > 0
       @group_setup.group.setup_completed_at = Time.now
       @group_setup.group.save!
       redirect_to group_path

--- a/app/controllers/groups/invitations_controller.rb
+++ b/app/controllers/groups/invitations_controller.rb
@@ -9,7 +9,7 @@ class Groups::InvitationsController < GroupBaseController
   def create
     @invite_people = InvitePeople.new(params[:invite_people])
     num = CreateInvitation.to_people_and_email_them(@invite_people, group: @group, inviter: current_user)
-    flash[:notice] = "#{num} invitations sent"
+    flash[:notice] = "#{num} invitation(s) sent" if num > 0
     redirect_to group_path(@group)
   end
 

--- a/app/views/groups/_invite_users.html.haml
+++ b/app/views/groups/_invite_users.html.haml
@@ -9,7 +9,6 @@
   = form.input :recipients, as: :hidden, input_html: { class: 'recipients' }
   %p= t("invitation.invites_more_help")
 .control-group
-  = form.input :message_body, label: false, as: :text, input_html: { class: 'validate-presence', value: t("invitation.body_editable", group: group.name) }, label: t("invitation.message_body")
-  .inline-help= t("group_setup_form.errors.invites_body")
+  = form.input :message_body, label: false, as: :text, input_html: { value: t("invitation.body_editable", group: group.name) }, label: t("invitation.message_body")
 %p= t("invitation.invites_more_help1")
 

--- a/app/views/groups/group_setup/setup.html.haml
+++ b/app/views/groups/group_setup/setup.html.haml
@@ -73,7 +73,7 @@
               .more-help= t("invitation.invites_more_help2").html_safe
       .row
         .span5
-          = f.submit "Finish setup", class: 'btn btn-info btn-large run-validations', id: 'send_invites', :data => { :disable_with => "Send invites" }
+          = f.submit "Finish setup", class: 'btn btn-info btn-large run-validations', id: 'send_invites', :data => { :disable_with => "Finish setup" }
           = link_to t('next'), '#', class: 'btn btn-info btn-large', id: 'next'
           = link_to t('prev'), '#', class: 'btn btn-warning btn-large', id: 'prev'
       .row

--- a/app/views/groups/invitations/index.html.haml
+++ b/app/views/groups/invitations/index.html.haml
@@ -16,4 +16,4 @@
 
 %p= t "invitation.copy"
 
-= link_to t(:invite_people), new_group_invitation_path(@group), :class => "btn btn-info btn-large", :data => { disable_with: t(:invite_people) }
+= link_to t(:invite_people), new_group_invitation_path(@group), :class => "btn btn-info btn-large"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -452,7 +452,6 @@ en:
       motion_closing_inputs: "Please give a future close date"
       admin_email: "Please fill in the an administrator email address"
       invitees: "Please fill in the invited email addresse(s)"
-      message_body: "Please fill in the invite body"
 
   simple_form:
     labels:

--- a/features/step_definitions/edit_invitations_step.rb
+++ b/features/step_definitions/edit_invitations_step.rb
@@ -26,7 +26,7 @@ Then(/^there should be a couple of pending invitations to those people$/) do
 end
 
 Then(/^the flash notice should inform me of (\d+) invitations being sent$/) do |arg1|
-  page.should have_content "#{arg1} invitations sent"
+  page.should have_content "#{arg1} invitation(s) sent"
 end
 
 Given(/^there is a pending invitation to join the group$/) do


### PR DESCRIPTION
Co-ordiantors want the ability to be able to skip past inviting people in the group set up wizard. 
Validations removed so they can finish the process.
This effects the process from the group page too. 
