### PR TITLE
prevent group requests from being deleted if there is a group associated

### DIFF
--- a/app/models/group_request.rb
+++ b/app/models/group_request.rb
@@ -20,6 +20,7 @@ class GroupRequest < ActiveRecord::Base
   scope :approved, where(:status => :approved)
   scope :accepted, where(:status => :accepted)
 
+  before_destroy :prevent_destroy_if_group_present
   before_create :mark_spam
   before_validation :generate_token, on: :create
 
@@ -83,6 +84,12 @@ class GroupRequest < ActiveRecord::Base
 
 
   private
+  def prevent_destroy_if_group_present
+    if self.group.present?
+      errors.add(:group, "dont' delete group requests ok!")
+    end
+    errors.blank?
+  end
 
   def mark_spam
     mark_as_spam unless robot_trap.blank?

--- a/spec/models/group_request_spec.rb
+++ b/spec/models/group_request_spec.rb
@@ -8,6 +8,26 @@ describe GroupRequest do
     @group_request = build(:group_request)
   end
 
+  describe 'destroy' do
+    before do
+      @group_request = FactoryGirl.create(:group_request)
+    end
+
+    it 'returns normaly (ie: itself)' do
+      @group_request.destroy.should == @group_request
+    end
+
+    context 'if group present?' do
+      before do
+        @group_request.group = FactoryGirl.create(:group)
+      end
+
+      it 'returns false if group associated' do
+        @group_request.destroy.should be_false
+      end
+    end
+  end
+
   describe "#status" do
     it "should default to unverified" do
       @group_request.save!


### PR DESCRIPTION
Hopefully this will prevent some exceptions we're seeing
