### PR TITLE
Design tweaks mostly based on https://www.loomio.org/discussions/3097

### DIFF
--- a/app/assets/stylesheets/_settings.scss
+++ b/app/assets/stylesheets/_settings.scss
@@ -5,6 +5,7 @@ $baseLineHeight: 18px;
 // application
 $font-tinywiny: 0.7em;
 $font-tiny: 0.8em;
+$font-smaller: 0.85em;
 $font-small: 0.9em;
 $font-medium: 1em;
 $font-medium-large: 1.2em;
@@ -13,7 +14,7 @@ $font-xlarge: 1.5em;
 $font-xxlarge: 1.7em;
 
 // colors
-$lighter-grey: #EAEAEA;
+$lighter-grey: #E6E6E6;
 $light-grey: #BBB;
 $mid-grey: #777;
 $dark-grey: #555;
@@ -30,13 +31,13 @@ $error-color: firebrick;
 $comment-color: white;
 $current-proposal: white;
 
-$main-background: #F7F7ED;
+$main-background: #F7F7F7;
 
 $container: white;
 $sub-selector-panel: #efefef;
 $selector-panel: #ebebeb;
 $selector: #e0eaf1;
-$highlighted: #edeff5;
+$highlighted: #f6f6f6;
 $unhighlighted: white;
 // $group-activity: #ABBEE6;
 $group-activity: #75A0CF;

--- a/app/assets/stylesheets/dashboard.css.scss
+++ b/app/assets/stylesheets/dashboard.css.scss
@@ -3,8 +3,8 @@
 body.dashboard {
   &.show {
     .sub-panel ul {
-      margin: 0 0 0 10px;
       a:hover { color: $dark-grey }
+      li { line-height: 21px; }
       .sub-group a { padding-left: 20px; }
     }
   }

--- a/app/assets/stylesheets/discussions.css.scss
+++ b/app/assets/stylesheets/discussions.css.scss
@@ -35,7 +35,7 @@ body.discussions.new, body.discussions.create {
 
 body.discussions.show {
   .description-body {
-    color: $dark-grey;
+    color: black;
     margin-bottom: 10px;
   }
 }
@@ -73,10 +73,9 @@ body.discussions.show {
   .selector-panel {
     background-color: $selector-panel;
     @include border-radius(8px);
-    border: 1px solid $light-grey;
-    margin-bottom: 20px;
+    border: 1px solid $lighter-grey;
+    margin: 10px 0 20px 0;
     min-height: 59px;
-    padding-top: 2px;
     .dropdown {
       float: right;
       padding: 5px 10px;
@@ -92,7 +91,7 @@ body.discussions.show {
   .discussion-title-container{
     display: inline-block;
     width: 850px;
-    margin: 0 0 4px 0px;
+    margin: 0 0 0 15px;
   }
   #edit-discussion-title {
     float: left;
@@ -125,16 +124,16 @@ body.discussions.show {
 
   #discussion-page-container {
     background-color: white;
-    border-top: 1px solid $light-grey;
-    border-bottom: 1px solid $light-grey;
+    border-top: 1px solid $lighter-grey;
+    border-bottom: 1px solid $lighter-grey;
     padding-bottom: 20px;
     margin-bottom: 5px;
   }
 
   #discussion-context {
-    min-height: 40px;
-    border-bottom: 1px solid $light-grey;
-    padding: 10px 0px 10px 50px;
+    min-height: 70px;
+    border-bottom: 1px solid $lighter-grey;
+    padding: 15px 10px 10px 15px;
 
     #discussion-markdown-dropdown {
       margin-right: 8px;
@@ -143,21 +142,18 @@ body.discussions.show {
   }
 
   .right-context {
-    width: 230px;
+    width: 265px;
   }
 
   .discussion-additional-info {
-    font-size: $font-small;
+    font-size: $font-smaller;
     color: $mid-grey;
-    width: 170px;
-    background-color: #EEE;
-    padding: 5px;
+    max-width: 190px;
     float: right;
   }
 
   .header-text {
-  //   color: $mid-grey;
-  //   font-weight: bold;
+    color: $mid-grey;
     line-height: 2.0em;
   }
 
@@ -196,7 +192,7 @@ body.discussions.show {
 .content-proposal-body {
   padding: 10px 10px 10px 50px;
 }
-.content-proposal-body ul.selector-list { border-top: 1px solid $light-grey; }
+.content-proposal-body ul.selector-list { border-top: 1px solid $lighter-grey; }
 li .motion {
   .close-date {
     font-size: $font-tiny;
@@ -283,9 +279,9 @@ pre{
 }
 
 #discussion-activity-container {
-  border-right: 1px solid $light-grey;
+  border-right: 1px solid $lighter-grey;
   min-height: 660px;
-  padding-right: 10px;
+  padding: 7px 10px 0 0;
 
   #discussion-activity-body {
     padding: 10px 0px 10px 8px;
@@ -316,12 +312,17 @@ pre{
     margin: 5px 5px 5px 45px;
   }
   ul#activity-list {
+    border-top: 1px solid $lighter-grey;
     list-style: none;
     margin: 0 15px 3px 0;
+    padding-top: 3px;
     width: 437px;
 
     li.empty-list-message {
       margin-left: 45px; /*check this still works*/
+    }
+    .activity-icon {
+      margin-left: -26px;
     }
     .divider {
       border-bottom: 1px solid $light-grey;
@@ -329,12 +330,12 @@ pre{
     }
     .activity-item-container {
       width: 100%;
+      margin-top: 8px;
     }
     .activity-item-body {
       margin-left: 45px;
-      border-bottom: 1px solid $light-grey;
-      margin-bottom: 5px;
-      padding-bottom: 5px;
+      border-bottom: 1px solid $lighter-grey;
+      padding-bottom: 9px;
     }
     .activity-item-avatar {
       height: 35px;
@@ -343,22 +344,32 @@ pre{
     }
     .activity-item-comment-actor{
       font-weight: bold;
+      float: left;
+      margin-right: 8px;
     }
     .activity-item-actor{
       font-weight: bold;
       a {color: $dark-grey;}
     }
     .activity-item-header{
-      color: $dark-grey;
+      p {
+        color: black;
+        &:last-child {
+          margin-bottom: 2px;
+        }
+      }
     }
     .activity-item-content{
       color: $mid-grey;
       font-style: italic;
       word-wrap: break-word;
     }
-    .activity-item-time{
-      color: $dark-grey;
+    .activity-item-time {
+      color: $mid-grey;
       font-size: $font-tiny;
+      a {
+        color: $mid-grey;
+      }
     }
     .activity-item-likes{
       color: $dark-grey;
@@ -383,7 +394,7 @@ pre{
 
 .popover-motion-name { color: black; }
 .popover-content { padding-top: 8px; }
-.popover-close-date { 
+.popover-close-date {
   font-weight: normal;
   display: inline;
   font-size: $font-tiny;
@@ -406,7 +417,7 @@ li.popover-item {
   .vote-time { font-size: $font-tiny; }
 }
 li.selector-item .discussion-preview:hover {
-  background-color: $selector;
+  background-color: $selector ! important;
 }
 
 .discussion-preview {
@@ -472,9 +483,14 @@ li.selector-item .discussion-preview:hover {
     height: 36px;
     z-index: 1;
   }
-  .activity-icon { float: right; }
-  .discussion-icon.activity-icon { margin: 8px 6px 0 0; }
-  .pie-icon.activity-icon { margin: 10px 10px 0 0; }
+  .activity-icon {
+    float: right;
+  }
+  .discussion-icon.activity-icon {
+    margin: 8px 6px 0 0;
+  }
+  .pie-icon.activity-icon {
+    margin: 10px 5px 0 0; }
   .activity-count {
     font-size: $font-tinywiny;
     position: relative;
@@ -514,4 +530,10 @@ li.selector-item .discussion-preview:hover {
   padding: 5px 0 5px 0;
   border-bottom: 1px solid $light-grey;
   min-height: 40px;
+}
+
+.user-name {
+  &:link, &:visited {
+    color: $mid-grey;
+  }
 }

--- a/app/assets/stylesheets/main.css.scss
+++ b/app/assets/stylesheets/main.css.scss
@@ -134,7 +134,7 @@ ul.selector-list {
   &.bordered { border-top: 1px solid $light-grey }
   li.selector-item {
     background-color: $unhighlighted;
-    border-bottom: 1px solid $light-grey;
+    border-bottom: 1px solid $lighter-grey;
     color: $dark-grey;
     font-weight: normal;
     a.selector-link {
@@ -159,8 +159,9 @@ ul.selector-list {
   background-color: $sub-selector-panel;
   border: 1px solid $light-grey;
   @include border-radius(8px);
-  margin-bottom: 12px;
-  padding: 4px 6px 10px 6px;
+  margin-bottom: 20px;
+  padding: 6px 10px;
+
   h4 {
     line-height: 1.8em;
     margin-bottom: 5px;

--- a/app/assets/stylesheets/motions.css.scss
+++ b/app/assets/stylesheets/motions.css.scss
@@ -66,8 +66,11 @@
 
 #content-proposal{
   margin-left: 0px;
+  padding: 7px 0 0 0;
 
-  #closing-info { font-size: $font-small; }
+  #closing-info {
+    font-size: $font-smaller;
+    color: $mid-grey; }
 
   #close-voting {
     float: right;
@@ -161,7 +164,9 @@
   .proposal-title-container { width: 305px; }
 
   .proposed-by {
-    font-size: $font-small;
+    color: $mid-grey;
+    font-size: $font-smaller;
+    margin-bottom: 20px;
   }
 
   .percentage-to-vote {

--- a/app/assets/stylesheets/pages.css.scss
+++ b/app/assets/stylesheets/pages.css.scss
@@ -46,10 +46,10 @@ h4, h5, h6 { line-height: 18px; }
 .revision-title p { font-size: 85%; }
 
 // structural elements (containers etc.)
-.page-container { margin-top: 30px; }
+.page-container { margin-top: 20px; }
 
-// #start-new-discussion { margin: 0 0 20px 2px; }
-.main-content { margin-top: 20px; }
+.main-content {
+  margin-top: 15px; }
 
 
 /**** Structural elements ****/
@@ -58,7 +58,6 @@ li.selector-item {
   background-color: $unhighlighted;
   color: $dark-grey;
   font-weight: normal;
-  border-bottom: 1px solid $light-grey;
 }
 
 li.selector-item a.selector-link {
@@ -72,7 +71,7 @@ li.selector-item a.selector-link:hover {
 }
 
 .alert {
-  margin: 10px 0;
+  margin: 20px 0 -10px 0;
 }
 
 // color coded urgency labels

--- a/app/views/dashboard/show.html.haml
+++ b/app/views/dashboard/show.html.haml
@@ -1,7 +1,5 @@
 - if current_user.parent_groups.present?
   =render '/groups/title', group: nil
-  .clearfix
-    = icon_button(new_discussion_path, t(:start_a_discussion), '/assets/topic-18.png', 'start-new-discussion')
   .row.main-content
     %section.span9
       %ul.selector-list.bordered

--- a/app/views/discussions/_activity.html.haml
+++ b/app/views/discussions/_activity.html.haml
@@ -1,5 +1,4 @@
 %ul#activity-list
-  %li.divider
   - if discussion.activity.count == 0
     %li.selector-item.empty-list-message= t :empty_discussion_list
   - else

--- a/app/views/discussions/_discussion_context.html.haml
+++ b/app/views/discussions/_discussion_context.html.haml
@@ -6,10 +6,8 @@
       %p= t "discussion_context.helper_text"
     .discussion-additional-info
       = t("discussion_context.started_when", when: time_ago_in_words(@discussion.created_at))
-      .started-by
-        = t :by
-        = " "
-        =link_to @discussion.author.name, user_path(@discussion.author), class: "user-name"
+      = t :by
+      =link_to @discussion.author.name, user_path(@discussion.author), class: "user-name"
       -if defined? @last_collaborator
         .last-edited-by
           = t("discussion_context.last_edited", when: time_ago_in_words(@discussion.last_versioned_at))

--- a/app/views/discussions/_title.html.haml
+++ b/app/views/discussions/_title.html.haml
@@ -1,5 +1,4 @@
 .clearfix
-  .large-icon.topic-icon
   .discussion-title-container
     %h2#discussion-title
       = discussion.title

--- a/app/views/votes/new.html.haml
+++ b/app/views/votes/new.html.haml
@@ -1,4 +1,4 @@
-.page-title
+.group-title
   %h1= link_to @motion.name, discussion_path(@motion.discussion)
 .row#vote-form
   .span5

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -517,7 +517,7 @@ en:
   ago: "%{quantity_of_time} ago"
   approve: "Approve"
   back: "Back"
-  by: "By"
+  by: "by"
   cancel: "Cancel"
   change: "Change"
   changing: "Changing"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -412,7 +412,7 @@ es:
   ago: "hace %{quantity_of_time}"
   approve: "Aprobar"
   back: "Atrás"
-  by: "Por"
+  by: "por"
   cancel: "Cancelar"
   change: "Cambiar"
   changing: "Cambiando"

--- a/extras/discussion_items/discussion_title_edited.rb
+++ b/extras/discussion_items/discussion_title_edited.rb
@@ -22,7 +22,7 @@ class DiscussionItems::DiscussionTitleEdited < DiscussionItem
   end
 
   def body
-    " \"#{discussion.version_at(event.created_at).title}\""
+    " #{discussion.version_at(event.created_at).title}"
   end
 
   def time

--- a/extras/discussion_items/motion_closed.rb
+++ b/extras/discussion_items/motion_closed.rb
@@ -24,7 +24,7 @@ class DiscussionItems::MotionClosed < DiscussionItem
   end
 
   def body
-    " \"#{motion.name}\""
+    " #{motion.name}"
   end
 
   def time

--- a/extras/discussion_items/new_discussion.rb
+++ b/extras/discussion_items/new_discussion.rb
@@ -23,7 +23,7 @@ class DiscussionItems::NewDiscussion < DiscussionItem
   end
 
   def body
-    " \"#{discussion.version_at(event.created_at).title}\""
+    " #{discussion.version_at(event.created_at).title}"
   end
 
   def time

--- a/extras/discussion_items/new_motion.rb
+++ b/extras/discussion_items/new_motion.rb
@@ -22,7 +22,7 @@ class DiscussionItems::NewMotion < DiscussionItem
   end
 
   def body
-    " \"#{motion.name}\""
+    " #{motion.name}"
   end
 
   def time

--- a/extras/discussion_items/new_vote.rb
+++ b/extras/discussion_items/new_vote.rb
@@ -33,7 +33,7 @@ class DiscussionItems::NewVote < DiscussionItem
 
   def body
     return "" if vote.statement.blank?
-    "\"#{vote.statement}\""
+    "#{vote.statement}"
   end
 
   def time


### PR DESCRIPTION
Dashboard:
- Lose start new discussion button (discussion [here](https://www.loomio.org/discussions/4412#comment-34196))
- Gentler highlight colour
- Make highlight work on unread lines (with a wicked ! important)
- Groups panel typography & button to bottom
- Nudge live pie to line up with fake pie

Discussion page:
- Better vertical spacing in header
- User-contributed text to black
- Gentler chrome
- Context panel & right-context panel tweaks
- Discussion and proposal headers gentler
- Activity list tweaks, including softening lines, inline names, icons out-dented
- Lose double-quotes around proposals & discussion titles in activity list
