### PR TITLE
Fix links not opening in new tabs for Firefox #553

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,7 +55,7 @@ gem 'roadie', '~> 2.3.4'
 # Gems used only for assets and not required
 # in production environments by default.
 group :assets do
-  gem 'bootstrap-sass', '~> 2.3.1.0'
+  gem "bootstrap-sass", '~> 2.3.2.0'
   gem 'uglifier', '~> 1.1.0'
   gem 'modernizr-rails', '~> 2.6.2'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,7 +56,7 @@ GEM
     better_errors (0.6.0)
       coderay (>= 1.0.0)
       erubis (>= 2.6.6)
-    bootstrap-sass (2.3.1.3)
+    bootstrap-sass (2.3.2.0)
       sass (~> 3.2)
     bourbon (3.1.8)
       sass (>= 3.2.0)
@@ -412,7 +412,7 @@ DEPENDENCIES
   acts_as_commentable_with_threading (~> 1.1.2)
   awesome_print (~> 1.0.2)
   better_errors (~> 0.6.0)
-  bootstrap-sass (~> 2.3.1.0)
+  bootstrap-sass (~> 2.3.2.0)
   browser (~> 0.1.3)
   cancan (~> 1.6.7)
   capistrano


### PR DESCRIPTION
This was a bug in bootstrap. Fixed in 2.3.2.

The fix uses the official repo of the gem on Github, because the latest version with the relevant patch hasn't been pushed to rubygems.org yet.

UPDATE: The repo owner just pushed the gem to rubygem.org, so the Gemfile is now using the official reference instead.
