### PR TITLE
Refactor icon button to take a hash of well named parameters

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -32,10 +32,18 @@ module ApplicationHelper
     content_for :title, title.gsub(/["'<>]/, '')
   end
 
-  def icon_button(link, text, icon, id, is_modal = false)
-    modal_string = "modal" if is_modal
-    content_tag(:a, :href => link, :class => 'btn btn-grey btn-app', :id => id, 'data-toggle' => modal_string) do
-      image_tag(icon, :class => 'button-icon') + text
+  def icon_button(args)
+    href = args[:href]
+    method = args[:method] || 'get'
+    text = args[:text]
+    icon = args[:icon]
+    id = args[:id]
+    extra_classes = " #{args[:class]}"
+    data_toggle = args['data-toggle'] || false
+
+    classes = "btn btn-app" && extra_classes
+    content_tag(:a, href: href, method: method, class: classes, id: id, 'data-toggle' => data_toggle) do
+      image_tag(icon, class: 'button-icon') + text
     end
   end
 

--- a/app/views/dashboard/show.html.haml
+++ b/app/views/dashboard/show.html.haml
@@ -1,7 +1,7 @@
 - if current_user.parent_groups.present?
   =render '/groups/title', group: nil
   .clearfix
-    = icon_button(new_discussion_path, t(:start_a_discussion), '/assets/topic-18.png', 'start-new-discussion')
+    = icon_button(href: new_discussion_path, text: t(:start_a_discussion), icon: '/assets/topic-18.png', id: 'start-new-discussion', class: 'btn-grey')
   .row.main-content
     %section.span9
       %ul.selector-list.bordered

--- a/app/views/groups/_invite_button.html.haml
+++ b/app/views/groups/_invite_button.html.haml
@@ -1,4 +1,4 @@
 -if group.is_top_level?
-  = icon_button(new_group_invitation_path(@group), t(:invite_people), '/assets/member-18.png', 'invite-new-members')
+  = icon_button(href: new_group_invitation_path(@group), text: t(:invite_people), icon: '/assets/member-18.png', id: 'invite-new-members', class: 'btn-grey')
 -else
-  = icon_button('#invite-subgroup-members', t(:add_new_member), '/assets/member-18.png', 'group-add-members', true)
+  = icon_button(href: '#invite-subgroup-members', text: t(:add_new_member), icon: '/assets/member-18.png', id: 'group-add-members', class: 'btn-grey', 'data-toggle' => 'modal')

--- a/app/views/groups/show.html.haml
+++ b/app/views/groups/show.html.haml
@@ -3,7 +3,7 @@
     - set_title @group.name, "", @group.parent
     = render '/groups/title', group: @group
     - if can? :create, @discussion
-      = icon_button(new_discussion_path(:group_id => @group.id), t(:start_a_discussion), '/assets/topic-18.png', 'start-new-discussion')
+      = icon_button(href: new_discussion_path(:group_id => @group.id), text: t(:start_a_discussion), icon: '/assets/topic-18.png', id: 'start-new-discussion', class: 'btn-grey')
   .span3#button-container
     - if can?(:add_members, @group)
       = render 'invite_button', group: @group


### PR DESCRIPTION
This refactor makes this helper more general and easier to use.

You now can pass it:
- a data method for a delete button
- more classes for changing its color
- data-toggle for making it a dropdown

This can now be used for the options dropdown although this has not been included as a .png is required instead of the bootstrap class .cog
