### PR TITLE
add code to prevent double popup error when canceling send invite confirm - fixes #762

### DIFF
--- a/app/assets/javascripts/invitations.js.coffee
+++ b/app/assets/javascripts/invitations.js.coffee
@@ -18,10 +18,20 @@ parseEmails = (input_emails) ->
 Application.validateEmailsAndConfirm = (field) ->
   if $(field).is(":visible")
     emailList = parseEmails($(field).val())
-    if(emailList.length > 0)
-      return false unless confirm("#{emailList.length} invitations will be sent")
-      $(".recipients").val(emailList.toString())
+    if(emailList.length == 0)
+      addValidateEmailErrorMessageFor($(field))
+      return false
+    else
+      if confirm("#{emailList.length} invitations will be sent")
+        $(".recipients").val(emailList.toString())
+      else
+        event.preventDefault()
   true
+
+
+addValidateEmailErrorMessageFor = (field) ->
+  $(field).parent().addClass("error")
+  $(field).parent().find(".email-validation-help").show()
 
 hideValidateEmailErrorMessageFor = (field) ->
   $(field).parent().removeClass("error")


### PR DESCRIPTION
When you invite people and add email addresses then click 'invite' you are asked to confirm. If you choose cancel you are told there is a form error.
- add method to display error if no emails are provided (this has somehow been removed)
- prevent default instead of returning false
