### PR TITLE
Remove phase from motion and fix close date issue

### DIFF
--- a/app/assets/stylesheets/motions.css.scss
+++ b/app/assets/stylesheets/motions.css.scss
@@ -68,6 +68,7 @@
   margin-left: 0px;
   padding-top: 10px;
 
+  #add-outcome-submit { margin-top: 5px; }
   #closing-info {
     font-size: $font-smaller;
     color: $mid-grey; }
@@ -243,12 +244,17 @@ table.jqplot-table-legend {
   .motion-closing-inputs {
     .control-group { display: inline-block; }
 
-    .motion-close-at-date { width: 140px; }
-
+    .motion-close-at-date {
+      height: 20px;
+      position: relative;
+      top: 1px;
+      width: 100px;
+    }
+    .motion-close-at-time { width: 100px; }
+    .motion-close-at-time-zone { width: 120px; }
     .motion-close-at-time, .motion-close-at-time-zone {
       display: inline-block;
       margin-top: 10px;
-      width: 113px;
     }
   }
 }

--- a/app/controllers/motions_controller.rb
+++ b/app/controllers/motions_controller.rb
@@ -62,7 +62,7 @@ class MotionsController < GroupBaseController
 
   def close
     resource
-    @motion.close_motion! current_user
+    @motion.close! current_user
     redirect_to discussion_url(@motion.discussion, proposal: @motion)
   end
 

--- a/app/controllers/votes_controller.rb
+++ b/app/controllers/votes_controller.rb
@@ -54,7 +54,7 @@ class VotesController < GroupBaseController
         flash[:error] = t("error.position_not_updated")
       end
     else
-      flash[:error] = "Can only vote in voting phase"
+      flash[:error] = "You cannot edit your position after the proposal has closed."
     end
     redirect_to @motion.discussion
   end

--- a/app/helpers/discussions_helper.rb
+++ b/app/helpers/discussions_helper.rb
@@ -20,11 +20,11 @@ module DiscussionsHelper
     css_class
   end
 
-  def css_class_for_close_at(motion)
+  def css_class_for_closing_at(motion)
     css_class = "popover-close-date label"
 
-    if motion.close_at
-      hours_left = (((Time.now - motion.close_at) / 60) / 60) * -1
+    if motion.voting?
+      hours_left = (((Time.now - motion.closing_at) / 60) / 60) * -1
       css_class += " color-urgent" if hours_left < 30
       css_class += " color-warning" if (hours_left >= 3) && (hours_left <= 24)
       css_class += " color-ok" if hours_left > 24

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -65,16 +65,6 @@ class Group < ActiveRecord::Base
   has_many :admins, through: :admin_memberships, source: :user
   has_many :discussions, :dependent => :destroy
   has_many :motions, :through => :discussions
-  has_many :motions_in_voting_phase,
-           :through => :discussions,
-           :source => :motions,
-           :conditions => { phase: 'voting' },
-           :order => 'close_at'
-  has_many :motions_closed,
-           :through => :discussions,
-           :source => :motions,
-           :conditions => { phase: 'closed' },
-           :order => 'close_at DESC'
 
   belongs_to :parent, :class_name => "Group"
   has_many :subgroups, :class_name => "Group", :foreign_key => 'parent_id'
@@ -84,6 +74,14 @@ class Group < ActiveRecord::Base
   delegate :name, :to => :parent, :prefix => true
 
   paginates_per 20
+
+  def voting_motions
+    motions.voting
+  end
+
+  def closed_motions
+    motions.closed
+  end
 
   def archive!
     self.update_attribute(:archived_at, DateTime.now)

--- a/app/models/motion.rb
+++ b/app/models/motion.rb
@@ -1,5 +1,4 @@
 class Motion < ActiveRecord::Base
-  PHASES = %w[voting closed]
   CHART_COLOURS = ["#90D490", "#F0BB67", "#D49090", "#dd0000", '#ccc']
 
   belongs_to :author, :class_name => 'User'
@@ -8,8 +7,7 @@ class Motion < ActiveRecord::Base
   has_many :did_not_votes, :dependent => :destroy
   has_many :events, :as => :eventable, :dependent => :destroy
 
-  validates_presence_of :name, :discussion, :author, :close_at
-  validates_inclusion_of :phase, in: PHASES
+  validates_presence_of :name, :discussion, :author, :closing_at
   validates_format_of :discussion_url, with: /^((http|https):\/\/)?[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,5}(:[0-9]{1,5})?(\/.*)?$/i,
     allow_blank: true
 
@@ -22,7 +20,7 @@ class Motion < ActiveRecord::Base
   delegate :users, :full_name, :to => :group, :prefix => :group
   delegate :email_new_motion?, to: :group, prefix: :group
 
-  before_validation :set_close_at
+  before_validation :set_closing_at
   before_save :format_discussion_url
   after_save :update_counter_cache
   after_create :initialize_discussion
@@ -32,21 +30,10 @@ class Motion < ActiveRecord::Base
   attr_accessor :create_discussion
 
   attr_accessible :name, :description, :discussion_url, :discussion_id
-  attr_accessible :close_at_date, :close_at_time, :close_at_time_zone, :phase,  :outcome
+  attr_accessible :close_at_date, :close_at_time, :close_at_time_zone, :outcome
 
-  include AASM
-  aasm :column => :phase do
-    state :voting, :initial => true
-    state :closed
-
-    event :close, before: :before_close do
-      transitions :to => :closed, :from => [:voting]
-    end
-  end
-
-  scope :voting_sorted, voting.order('close_at ASC')
-  scope :closed_sorted, closed.order('close_at DESC')
-
+  scope :voting, where('closed_at IS NULL').order('closed_at ASC')
+  scope :closed, where('closed_at IS NOT NULL').order('closed_at DESC')
   scope :that_user_has_voted_on, lambda {|user|
     joins(:votes).where("votes.user_id = ?", user.id)
   }
@@ -55,8 +42,54 @@ class Motion < ActiveRecord::Base
     name
   end
 
-  def group_users_without_motion_author
-    group.users.where(User.arel_table[:id].not_eq(author.id))
+  def voting?
+    closed_at.nil?
+  end
+
+  def closed?
+    closed_at.present?
+  end
+
+  def close!(user=nil)
+    store_users_that_didnt_vote
+    self.closed_at = Time.now
+    save!
+    fire_motion_closed_event(user)
+   end
+
+  def close_if_expired
+    close! if closing_at <= Time.now
+  end
+
+  def set_default_close_at_date_and_time
+    self.close_at_date ||= 3.days.from_now.to_date
+    self.close_at_time ||= Time.now.strftime("%H:00")
+  end
+
+  def set_outcome!(str)
+    if closed?
+      self.outcome = str
+      save
+    end
+  end
+
+  def read_log_for(user)
+    MotionReadLog.where('motion_id = ? AND user_id = ?',
+      id, user.id).first
+  end
+
+  def last_looked_at_by(user)
+    read_log_for(user).motion_last_viewed_at if read_log_for(user)
+  end
+
+
+### vote methods ###
+
+  def blocked?
+    unique_votes.each do |v|
+      return true if v.position == "block"
+    end
+    false
   end
 
   def with_votes
@@ -93,98 +126,12 @@ class Motion < ActiveRecord::Base
     return votes_for_graph
   end
 
-  def blocked?
-    unique_votes.each do |v|
-      return true if v.position == "block"
-    end
-    false
-  end
-
   def user_has_voted?(user)
     votes.for_user(user).exists?
   end
 
   def can_be_voted_on_by?(user)
     user && group.users.include?(user)
-  end
-
-  def move_to_group(group)
-    if discussion.present?
-      discussion.group = group
-      discussion.save
-    end
-  end
-
-  def unique_votes
-    Vote.unique_votes(self)
-  end
-
-  # motion is closed by user
-  def close_motion!(user=nil)
-    close!
-    save!
-    fire_motion_closed_event(user)
-  end
-
-  def close_if_expired
-    close_motion! if (voting? && close_at && close_at <= Time.now)
-  end
-
-  def set_outcome!(str)
-    if closed?
-      self.outcome = str
-      save
-    end
-  end
-
-  def has_close_date?
-    close_at != nil
-  end
-
-  def no_vote_count
-    return group_count - unique_votes.count if voting?
-    did_not_votes.count
-  end
-
-  def percent_voted
-    (100-(no_vote_count/group_count.to_f * 100)).to_i
-  end
-
-  def group_count
-    return group.users.count if voting?
-    unique_votes.count + no_vote_count
-  end
-
-  def group_members
-    group.users
-  end
-
-  def update_discussion_activity
-    discussion.update_activity if discussion
-  end
-
-  def read_log_for(user)
-    MotionReadLog.where('motion_id = ? AND user_id = ?',
-      id, user.id).first
-  end
-
-  def number_of_votes_since_last_looked(user)
-    if user
-      return number_of_votes_since(last_looked_at_by(user)) if last_looked_at_by(user)
-    end
-    unique_votes.count
-  end
-
-  def last_looked_at_by(user)
-    read_log_for(user).motion_last_viewed_at if read_log_for(user)
-  end
-
-  def number_of_votes_since(time)
-    votes.where('votes.created_at > ?', time).count
-  end
-
-  def comments
-    discussion.comments
   end
 
   def vote!(user, position, statement=nil)
@@ -199,9 +146,24 @@ class Motion < ActiveRecord::Base
     created_at
   end
 
-  def set_default_close_at_date_and_time
-    self.close_at_date ||= 3.days.from_now.to_date
-    self.close_at_time ||= Time.now.strftime("%H:00")
+  def no_vote_count
+    return group_count - unique_votes.count if voting?
+    did_not_votes.count
+  end
+
+  def percent_voted
+    (100-(no_vote_count/group_count.to_f * 100)).to_i
+  end
+
+  def number_of_votes_since(time)
+    votes.where('votes.created_at > ?', time).count
+  end
+
+  def number_of_votes_since_last_looked(user)
+    if user
+      return number_of_votes_since(last_looked_at_by(user)) if last_looked_at_by(user)
+    end
+    unique_votes.count
   end
 
   def update_vote_counts!
@@ -214,7 +176,7 @@ class Motion < ActiveRecord::Base
     Vote.unique_votes(self).each do |vote|
       position_counts[vote.position] += 1
     end
-    
+
     Vote::POSITIONS.each do |position|
       self.send("#{position}_votes_count=", position_counts[position])
     end
@@ -223,13 +185,48 @@ class Motion < ActiveRecord::Base
   end
 
 
+### group methods ###
+
+  def group_count
+    return group.users.count if voting?
+    unique_votes.count + no_vote_count
+  end
+
+  def group_members
+    group.user/spec/models/vote_spec.rbs
+  end
+
+  def move_to_group(group)
+    if discussion.present?
+      discussion.group = group
+      discussion.save
+    end
+  end
+
+  def group_users_without_motion_author
+    group.users.where(User.arel_table[:id].not_eq(author.id))
+  end
+
+
+
+### discussion methods ###
+
+  def update_discussion_activity
+    discussion.update_activity if discussion
+  end
+
+  def comments
+    discussion.comments
+  end
+
+
   private
 
-    def set_close_at
+    def set_closing_at
       date_time_zone_format = '%Y-%m-%d %H:%M %Z'
       tz_offset = ActiveSupport::TimeZone[close_at_time_zone].formatted_offset
       date_time_zone_string = "#{close_at_date.to_s} #{close_at_time} #{tz_offset}"
-      self.close_at = DateTime.strptime(date_time_zone_string, date_time_zone_format)
+      self.closing_at = DateTime.strptime(date_time_zone_string, date_time_zone_format)
     end
 
     def fire_new_motion_event
@@ -238,11 +235,6 @@ class Motion < ActiveRecord::Base
 
     def fire_motion_closed_event(user)
       Events::MotionClosed.publish!(self, user)
-    end
-
-    def before_close
-      store_users_that_didnt_vote
-      self.close_at = Time.now
     end
 
     def store_users_that_didnt_vote

--- a/app/models/vote.rb
+++ b/app/models/vote.rb
@@ -10,7 +10,7 @@ class Vote < ActiveRecord::Base
     def validate_each(object, attribute, value)
       if object.motion && (not object.motion.voting?)
         object.errors.add attribute,
-          "can only be modified while the motion is open."
+          "can only be modified while the motion is in voting phase."
       end
     end
   end

--- a/app/views/discussions/_discussion_preview.html.haml
+++ b/app/views/discussions/_discussion_preview.html.haml
@@ -15,8 +15,8 @@
             = discussion_activity
       .discussion-date-info
         -if discussion.current_motion
-          - if discussion.current_motion_close_at
-            .proposal-close-date= "#{time_ago_in_words(discussion.current_motion_close_at)} until close"
+          - if discussion.current_motion_closing_at
+            .proposal-close-date= "#{time_ago_in_words(discussion.current_motion_closing_at)} until close"
         - else
           .latest-comment-time= "#{t('ago', :quantity_of_time => time_ago_in_words(discussion.latest_comment_time))}"
     - if discussion.current_motion

--- a/app/views/discussions/_graph_preview_pop_over_title.html.haml
+++ b/app/views/discussions/_graph_preview_pop_over_title.html.haml
@@ -1,7 +1,7 @@
 %span.popover-header-title
   =t :proposal
-%span{class: css_class_for_close_at(motion)}
-  - if motion.close_at
-    = time_ago_in_words(motion.close_at) + ' ' + t(:until_close)
+%span{class: css_class_for_closing_at(motion)}
+  - if motion.voting?
+    = time_ago_in_words(motion.closing_at) + ' ' + t(:until_close)
 .popover-motion-name
   = motion.name

--- a/app/views/discussions/show.html.haml
+++ b/app/views/discussions/show.html.haml
@@ -38,7 +38,7 @@
             - if can? :edit_close_date, @current_motion
               = render '/motions/edit_close_date', motion: @current_motion, user: @current_user, input_time: @input_time
 
-            - if @discussion.closed_motions.count > 0
+            - if @discussion.closed_motions.present?
               #previous-proposals
                 .clearfix
                   .large-icon.decision-icon

--- a/app/views/inbox/_motion_line_item.html.haml
+++ b/app/views/inbox/_motion_line_item.html.haml
@@ -12,8 +12,8 @@
     = link_to item.title, item
 
   .span2.time
-    %span.js-format-as-timeago{data:{time: item.close_at.iso8601}}
-      =time_formatted_relative_to_age(item.close_at)
+    %span.js-format-as-timeago{data:{time: item.closing_at.iso8601}}
+      =time_formatted_relative_to_age(item.closing_at)
     left
 
   .span1

--- a/app/views/motion_mailer/new_motion_created.html.haml
+++ b/app/views/motion_mailer/new_motion_created.html.haml
@@ -14,10 +14,9 @@
       %th= t :author
       %td= @motion.author.name
 
-    - if @motion.has_close_date?
-      %tr
-        %th.nowrap= t("email.create_proposal.closes_in")
-        %td= time_ago_in_words(@motion.close_at) + " (" + @motion.close_at.localtime.strftime('%a %d %b %Y, %I:%M%p, %Z') + ")"
+    %tr
+      %th.nowrap= t("email.create_proposal.closes_in")
+      %td= time_ago_in_words(@motion.closing_at) + " (" + @motion.closing_at.localtime.strftime('%a %d %b %Y, %I:%M%p, %Z') + ")"
 
     - if @rendered_motion_description.present?
       %tr

--- a/app/views/motion_mailer/new_motion_created.text.haml
+++ b/app/views/motion_mailer/new_motion_created.text.haml
@@ -12,9 +12,8 @@
 = "#{t(:author)}:"
 = @motion.author.name
 \
-- if @motion.has_close_date?
-  = "#{t('email.create_proposal.closes_in')}:"
-  = time_ago_in_words(@motion.close_at) + " (" + @motion.close_at.localtime.strftime('%a %d %b %Y, %I:%M%p, %Z') + ")"
+= "#{t('email.create_proposal.closes_in')}:"
+= time_ago_in_words(@motion.closing_at) + " (" + @motion.closing_at.localtime.strftime('%a %d %b %Y, %I:%M%p, %Z') + ")"
 \
 - if @motion.description.present?
   = "#{t(:details)}:"

--- a/app/views/motions/_close_at_inputs.html.haml
+++ b/app/views/motions/_close_at_inputs.html.haml
@@ -2,4 +2,4 @@
   = form.input :close_at_date, as: :date_picker, input_html: { class: 'motion-close-at-date validate-presence' }
   = form.input :close_at_time, as: :select, collection: time_select_options, include_blank: false, label: false, input_html: { class: 'motion-close-at-time' }
   = form.input :close_at_time_zone, default: current_user.time_zone_city, include_blank: false, label: false, input_html: { class: 'motion-close-at-time-zone' }
-  .inline-help= t("group_setup_form.errors.motion_closing_inputs")
+  .inline-help= t(:"error.motion_closing_inputs")

--- a/app/views/motions/_form.html.haml
+++ b/app/views/motions/_form.html.haml
@@ -13,7 +13,6 @@
         #description
           = f.input :description
 
-        = f.input :phase, as: :hidden, input_html: {value: "voting"}
         = f.input :facilitator_id, as: :hidden, input_html: {value: current_user.id}
         = f.input :discussion_id, as: :hidden, input_html: {value: @motion.discussion_id}
         = f.submit :class => "btn btn-large btn-info run-validations", id: "proposal-submit", :data => {:disable_with => :starting}

--- a/app/views/motions/_motion.html.haml
+++ b/app/views/motions/_motion.html.haml
@@ -6,13 +6,10 @@
         - if motion.closed?
           %span.label.label-important= t(:closed)
       #closing-info
-        - if motion.has_close_date?
-          - if motion.voting?
-            = t(:proposal_closing_when, when: time_ago_in_words(motion.close_at))
-          - else
-            %span= t(:proposal_closed_when, when: time_ago_in_words(motion.close_at))
+        - if motion.voting?
+          = t(:proposal_closing_when, when: time_ago_in_words(motion.closing_at))
         - else
-          No close date
+          %span= t(:proposal_closed_when, when: time_ago_in_words(motion.closed_at))
       .proposed-by
         = t(:proposed_when_by_who, when: time_ago_in_words(motion.created_at), who: motion.author_name)
     .span2.motion-admin-buttons

--- a/app/views/motions/_motion_preview.html.haml
+++ b/app/views/motions/_motion_preview.html.haml
@@ -12,13 +12,10 @@
             - if !motion.outcome.blank?
               = t(:outcome) + ": " + motion.outcome
           .proposal-close-date
-            - if motion.close_at.present?
-              - if motion.voting?
-                = t(:proposal_closing_when, when: time_ago_in_words(motion.close_at))
-              - else
-                = t(:proposal_closed_when, when: time_ago_in_words(motion.close_at))
+            - if motion.voting?
+              = t(:proposal_closing_when, when: time_ago_in_words(motion.closing_at))
             - else
-              = "no close date"
+              = t(:proposal_closed_when, when: time_ago_in_words(motion.closed_at))
             =" · " unless this_group
           .proposal-group-name= DiscussionDecorator.new(motion.discussion).display_group_name(this_group)
       .pie{id: "graph_#{motion.id}", 'data-votes' => motion.votes_for_graph.to_json}

--- a/app/views/motions/_votes_table_vote.html.haml
+++ b/app/views/motions/_votes_table_vote.html.haml
@@ -1,6 +1,6 @@
 .position-row.clearfix
   %div{ :class => 'activity-icon ' + vote_icon_name(vote.position) }
   = link_to vote.user_name, user_path(vote.user), class: 'user-name'
-  - if vote.can_be_edited_by?(current_user) && motion.phase == 'voting'
+  - if vote.can_be_edited_by?(current_user) && motion.voting?
     =link_to "edit", edit_motion_vote_path(motion, vote), class: 'btn btn-mini', id: 'edit-vote'
   %span.word-break~ vote.statement

--- a/app/views/user_mailer/daily_activity.html.haml
+++ b/app/views/user_mailer/daily_activity.html.haml
@@ -13,8 +13,8 @@
       %p
         -@motions.each do |motion|
           =link_to(motion.name, motion_url(motion))
-          -if motion.close_at.present?
-            \- closes in #{time_ago_in_words(motion.close_at)}
+          -if motion.voting?
+            \- closes in #{time_ago_in_words(motion.closing_at)}
           %br
     -if @discussions.present?
       %h4= t :discussions

--- a/app/views/user_mailer/daily_activity.text.haml
+++ b/app/views/user_mailer/daily_activity.text.haml
@@ -15,8 +15,8 @@
     -@motions.each do |motion|
       =motion.name
       =motion_url(motion)
-      -if motion.close_at.present?
-        \- closes in #{time_ago_in_words(motion.close_at)}
+      -if motion.voting?
+        \- closes in #{time_ago_in_words(motion.closing_at)}
         \
   -if @discussions.present?
     = t :discussions

--- a/app/views/user_mailer/motion_closing_soon.html.haml
+++ b/app/views/user_mailer/motion_closing_soon.html.haml
@@ -11,10 +11,9 @@
       %th= t :author
       %td= @motion.author.name
 
-    - if @motion.has_close_date?
-      %tr
-        %th.nowrap= t "email.proposal_closing_soon.closes_in"
-        %td= time_ago_in_words(@motion.close_at) + " (" + @motion.close_at.localtime.strftime('%a %d %b %Y, %I:%M%p, %Z') + ")"
+    %tr
+      %th.nowrap= t "email.proposal_closing_soon.closes_in"
+      %td= time_ago_in_words(@motion.closing_at) + " (" + @motion.closing_at.localtime.strftime('%a %d %b %Y, %I:%M%p, %Z') + ")"
 
     - if @rendered_motion_description.present?
       %tr

--- a/app/views/user_mailer/motion_closing_soon.text.haml
+++ b/app/views/user_mailer/motion_closing_soon.text.haml
@@ -11,7 +11,7 @@
 = @motion.author.name
 \
 = "#{t 'email.proposal_closing_soon.closes_in'}:"
-= time_ago_in_words(@motion.close_at) + " (" + @motion.close_at.localtime.strftime('%a %d %b %Y, %I:%M%p, %Z') + ")"
+= time_ago_in_words(@motion.closing_at) + " (" + @motion.closing_at.localtime.strftime('%a %d %b %Y, %I:%M%p, %Z') + ")"
 \
 = "#{t :details}:"
 = @motion.description

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,6 +30,7 @@ en:
     invalid_close_date: "Invalid close date, please check this date has not passed."
     invalid_email: "Please enter at least one valid email address"
     image_upload_fail: "Unable to upload picture. Make sure the picture is under 1 MB and is a .jpeg, .png, or .gif file."
+    motion_closing_inputs: "Invalid closing date"
     permission_to_invite: "You do not have permission to invite new members."
     position_not_updated: "Could not update position."
     settings_not_updated: "Your settings did not get updated."

--- a/db/migrate/20130629085841_add_closing_at_to_motion.rb
+++ b/db/migrate/20130629085841_add_closing_at_to_motion.rb
@@ -1,0 +1,25 @@
+class AddClosingAtToMotion < ActiveRecord::Migration
+  class Motion < ActiveRecord::Base
+  end
+
+  def up
+    add_column :motions, :closing_at, :datetime
+    rename_column :motions, :close_at, :closed_at
+    Motion.all. each do |motion|
+      motion.closing_at = motion.closed_at
+      motion.closed_at = nil if motion.phase == 'voting'
+      motion.save!
+    end
+  end
+
+  def down
+    rename_column :motions, :closed_at, :close_at
+    Motion.all.each do |motion|
+      if motion.close_at.nil?
+        motion.close_at = motion.closing_at
+        motion.save!
+      end
+    end
+    remove_column :motions, :closing_at
+  end
+end

--- a/db/migrate/20130629092802_remove_phase_from_motion.rb
+++ b/db/migrate/20130629092802_remove_phase_from_motion.rb
@@ -1,0 +1,10 @@
+class RemovePhaseFromMotion < ActiveRecord::Migration
+  def up
+    remove_column :motions, :phase
+  end
+
+  def down
+    add_column :motions, :phase, :string, default: 'voting', null: :false
+    Motion.where('closed_at IS NOT NULL').update_all(phase: 'closed')
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20130625050817) do
+ActiveRecord::Schema.define(:version => 20130629092802) do
 
   create_table "active_admin_comments", :force => true do |t|
     t.string   "resource_id",   :null => false
@@ -140,7 +140,6 @@ ActiveRecord::Schema.define(:version => 20130625050817) do
     t.boolean  "following",                 :default => true, :null => false
   end
 
-  add_index "discussion_read_logs", ["discussion_id"], :name => "index_motion_read_logs_on_discussion_id"
   add_index "discussion_read_logs", ["user_id", "discussion_id"], :name => "index_discussion_read_logs_on_user_id_and_discussion_id"
   add_index "discussion_read_logs", ["user_id"], :name => "index_motion_read_logs_on_user_id"
 
@@ -323,20 +322,20 @@ ActiveRecord::Schema.define(:version => 20130625050817) do
     t.integer  "author_id"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "phase",               :default => "voting", :null => false
-    t.string   "discussion_url",      :default => "",       :null => false
-    t.datetime "close_at"
+    t.string   "discussion_url",      :default => "",   :null => false
+    t.datetime "closed_at"
     t.integer  "discussion_id"
     t.string   "outcome"
     t.datetime "last_vote_at"
-    t.boolean  "uses_markdown",       :default => true,     :null => false
+    t.boolean  "uses_markdown",       :default => true, :null => false
     t.date     "close_at_date"
     t.string   "close_at_time"
     t.string   "close_at_time_zone"
-    t.integer  "yes_votes_count",     :default => 0,        :null => false
-    t.integer  "no_votes_count",      :default => 0,        :null => false
-    t.integer  "abstain_votes_count", :default => 0,        :null => false
-    t.integer  "block_votes_count",   :default => 0,        :null => false
+    t.integer  "yes_votes_count",     :default => 0,    :null => false
+    t.integer  "no_votes_count",      :default => 0,    :null => false
+    t.integer  "abstain_votes_count", :default => 0,    :null => false
+    t.integer  "block_votes_count",   :default => 0,    :null => false
+    t.datetime "closing_at"
   end
 
   add_index "motions", ["author_id"], :name => "index_motions_on_author_id"

--- a/extras/collects_recent_activity_by_group.rb
+++ b/extras/collects_recent_activity_by_group.rb
@@ -8,7 +8,7 @@ class CollectsRecentActivityByGroup
     user.groups.each do |group|
       h = {}
       h[:discussions] = group.discussions.active_since(since)
-      h[:motions] = group.motions_in_voting_phase
+      h[:motions] = group.voting_motions
       if h[:discussions].present? or h[:motions].present?
         @results[group.full_name] = h
       end

--- a/extras/queries/unvoted_motions.rb
+++ b/extras/queries/unvoted_motions.rb
@@ -2,6 +2,6 @@ class Queries::UnvotedMotions
   def self.for(user, group)
     group.motions.
     joins("LEFT OUTER JOIN votes ON votes.motion_id = motions.id AND votes.user_id = #{user.id}").
-    where('votes.id IS NULL AND motions.phase = ?', 'voting')
+    where('votes.id IS NULL AND motions.closed_at IS NULL')
   end
 end

--- a/extras/queries/visible_discussions.rb
+++ b/extras/queries/visible_discussions.rb
@@ -19,8 +19,7 @@ class Queries::VisibleDiscussions < SimpleDelegator
                      group.id, group.id, user.id)
         elsif user.is_parent_group_member?(group)
           relation = Discussion.includes(:group).
-                     where("
-                     discussions.group_id = ?
+                     where("discussions.group_id = ?
                      AND (groups.viewable_by = 'everyone'
                      OR groups.viewable_by = 'parent_group_members')",
                      group.id)
@@ -47,7 +46,7 @@ class Queries::VisibleDiscussions < SimpleDelegator
   end
 
   def with_current_motions
-    includes(:motions).where('motions.phase = ?', "voting")
+    includes(:motions).where("motions.closing_at IS NOT NULL AND motions.closed_at IS NULL")
   end
 
   def with_current_motions_user_has_voted_on
@@ -61,6 +60,6 @@ class Queries::VisibleDiscussions < SimpleDelegator
   end
 
   def without_current_motions
-    includes(:motions).where("discussions.id NOT IN (SELECT discussion_id FROM motions WHERE phase = 'voting')")
+    includes(:motions).where("discussions.id NOT IN (SELECT discussion_id FROM motions WHERE id IS NOT NULL AND closed_at IS NULL)")
   end
 end

--- a/features/motions/close_proposal.feature
+++ b/features/motions/close_proposal.feature
@@ -14,6 +14,7 @@ Feature: Admin/author closes a proposal
     And I confirm the action
     Then I should see the proposal in the list of previous proposals
     And the facilitator should recieve an email with subject "Proposal closed"
+    And the proposal close date should match the date the event was created
 
   Scenario: User tries to close a proposal
     Given there is a discussion in a public group

--- a/features/step_definitions/close_proposal_steps.rb
+++ b/features/step_definitions/close_proposal_steps.rb
@@ -22,3 +22,10 @@ end
 Then /^I should not see a link to close the proposal$/ do
   page.should_not have_content("Close proposal")
 end
+
+Then(/^the proposal close date should match the date the event was created$/) do
+  @motion.reload
+  floor = Event.last.created_at - 1.minute
+  ceiling =  Event.last.created_at + 1.minute
+  @motion.closed_at.should > floor && @motion.closed_at.should < ceiling
+end

--- a/features/step_definitions/proposal_closing_soon_email_steps.rb
+++ b/features/step_definitions/proposal_closing_soon_email_steps.rb
@@ -4,7 +4,7 @@ end
 
 When /^we run the rake task to check for closing proposals, (\d+) hours before it closes\.$/ do |arg1|
   now_but_tomorrow_1_hour_window = (1.day.from_now) ... (1.day.from_now + 1.hour)
-  Motion.where(:close_at => now_but_tomorrow_1_hour_window).each do |motion|
+  Motion.where(:closing_at => now_but_tomorrow_1_hour_window).each do |motion|
     Events::MotionClosingSoon.publish!(motion)
   end
 end
@@ -18,7 +18,7 @@ end
 Given /^the motion "(.*?)" is closing in (\d+) hours$/ do |arg1, arg2|
   motion = Motion.find_by_name(arg1)
   closing_at = 24.hours.from_now + 30.minutes
-  motion.update_attribute(:close_at, closing_at)
+  motion.update_attribute(:closing_at, closing_at)
 end
 
 Given /^"(.*?)" agreed with the proposal "(.*?)"$/ do |arg1, arg2|

--- a/features/step_definitions/translate_emails_steps.rb
+++ b/features/step_definitions/translate_emails_steps.rb
@@ -79,7 +79,7 @@ Given(/^the proposal started by "(.*?)" is closing soon$/) do |arg1|
   author = User.find_by_email("#{arg1}@example.org")
   group = FactoryGirl.create :group
   @discussion = FactoryGirl.create :discussion, group: group
-  @motion = FactoryGirl.create :motion, discussion: @discussion, author: author, close_at: Time.now + 1.hour
+  @motion = FactoryGirl.create :motion, discussion: @discussion, author: author, closing_at: Time.now + 1.hour
 end
 
 Then(/^"(.*?)" should receive the proposal closing soon email in English$/) do |arg1|

--- a/lib/tasks/email_test.rb
+++ b/lib/tasks/email_test.rb
@@ -337,7 +337,7 @@ describe "Test Email:" do
       unique_votes = []
       rand(2..11).times { unique_votes << create_vote }
       motion.stub unique_votes: unique_votes
-      motion.stub close_at: Time.now + 1.hour
+      motion.stub closing_at: Time.now + 1.hour
       addresses.each do |email|
         user.stub email: email
         UserMailer.motion_closing_soon(user, motion).deliver

--- a/spec/controllers/motions_controller_spec.rb
+++ b/spec/controllers/motions_controller_spec.rb
@@ -67,12 +67,10 @@ describe MotionsController do
       before do
         controller.stub(:authorize!).with(:close, motion).and_return(true)
         motion.stub(:close!)
-        motion.stub(:close_motion!)
-        Event.stub(:motion_closed!)
       end
 
       it "closes the motion" do
-        motion.should_receive(:close_motion!)
+        motion.should_receive(:close!).with(user)
         put :close, :id => motion.id
       end
 

--- a/spec/controllers/votes_controller_spec.rb
+++ b/spec/controllers/votes_controller_spec.rb
@@ -8,7 +8,7 @@ describe VotesController do
       @group = create(:group)
       @group.add_member!(@user)
       @discussion = create(:discussion, group: @group)
-      @motion = create(:motion,discussion: @discussion, phase: 'voting')
+      @motion = create(:motion, discussion: @discussion)
       @motion.save!
       @previous_url = motion_url(@motion)
       @vote_args = { motion_id: @motion.id,
@@ -16,7 +16,7 @@ describe VotesController do
       request.env["HTTP_REFERER"] = @previous_url
     end
 
-    context 'during voting phase' do
+    context 'proposal is open' do
 
       describe "casting a vote" do
         it 'redirects to previous url' do
@@ -97,10 +97,10 @@ describe VotesController do
       end
     end
 
-    context 'during closed phase' do
+    context 'proposal is closed' do
       before :each do
         @discussion = create(:discussion, group: @group, author: @user)
-        @motion = create(:motion, discussion: @discussion, phase: 'closed')
+        @motion = create(:motion, discussion: @discussion, closed_at: 2.days.ago)
       end
 
       it 'cannot vote' do

--- a/spec/extras/queries/unvoted_motions_spec.rb
+++ b/spec/extras/queries/unvoted_motions_spec.rb
@@ -39,7 +39,7 @@ describe Queries::UnvotedMotions do
 
     context 'there is a closed motion in the group' do
       it 'does not return the motion' do
-        motion.close_motion!(user)
+        motion.close!(user)
         Queries::UnvotedMotions.for(user, group).should_not include(motion)
       end
     end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -71,7 +71,6 @@ FactoryGirl.define do
   factory :motion do
     sequence(:name) { Faker::Name.name }
     association :author, :factory => :user
-    phase 'voting'
     description 'Fake description'
     discussion
     close_at_date '24-12-2044'

--- a/spec/models/discussion_spec.rb
+++ b/spec/models/discussion_spec.rb
@@ -144,17 +144,15 @@ describe Discussion do
       @discussion = create :discussion
       @motion = create :motion, discussion: @discussion
     end
-    context "where motion is in 'voting' phase" do
+    context "where motion is in open" do
       it "returns motion" do
         @discussion.current_motion.should eq(@motion)
       end
     end
     context "where motion close date has past" do
       before do
-        @motion.close_at_date = (Date.today - 3.day).strftime("%d-%m-%Y")
-        @motion.close_at_time = "12:00"
-        @motion.close_at_time_zone = "Wellington"
-        @motion.save
+        @motion.closed_at = 3.days.ago
+        @motion.save!
       end
       it "does not return motion" do
         @discussion.current_motion.should be_nil

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -49,29 +49,29 @@ describe Group do
     end
   end
 
-  describe "motions_in_voting_phase" do
-    it "returns motions that belong to the group and are in phase 'voting'" do
+  describe "#voting_motions" do
+    it "returns motions that belong to the group and are open" do
       @group = motion.group
-      @group.motions_in_voting_phase.should include(motion)
+      @group.voting_motions.should include(motion)
     end
 
-    it "should not return motions that belong to the group but are in phase 'closed'" do
+    it "should not return motions that belong to the group but are closed" do
       @group = motion.group
       motion.close!
-      @group.motions_in_voting_phase.should_not include(motion)
+      @group.voting_motions.should_not include(motion)
     end
   end
 
-  describe "motions_closed" do
-    it "returns motions that belong to the group and are in phase 'voting'" do
+  describe "#closed_motions" do
+    it "returns motions that belong to the group and are open" do
       motion.close!
       @group = motion.group
-      @group.motions_closed.should include(motion)
+      @group.closed_motions.should include(motion)
     end
 
-    it "should not return motions that belong to the group but are in phase 'closed'" do
+    it "should not return motions that belong to the group but are closed'" do
       @group = motion.group
-      @group.motions_closed.should_not include(motion)
+      @group.closed_motions.should_not include(motion)
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -65,25 +65,6 @@ describe User do
     user.admin_memberships.should include(membership)
   end
 
-  describe "open_votes" do
-    before do
-      @motion = create(:motion)
-      @motion.group.add_member! user
-      @vote = user.votes.new(:position => "yes")
-      @vote.motion = @motion
-      @vote.save
-    end
-
-    it "returns the user's votes on motions that are open" do
-      user.open_votes.should include(@vote)
-    end
-
-    it "does not return the user's votes on motions that are closed" do
-      @motion.close!
-      user.open_votes.should_not include(@vote)
-    end
-  end
-
   it "has authored discussions" do
     group.add_member!(user)
     discussion = Discussion.new(:group => group, :title => "Hello world")
@@ -99,29 +80,29 @@ describe User do
     user.authored_motions.should include(motion)
   end
 
-  describe "motions_in_voting_phase" do
-    it "returns motions that belong to user and are in phase 'voting'" do
+  describe "#voting_motions" do
+    it "returns motions that belong to user and are open" do
       motion = create(:motion, author: user)
-      user.motions_in_voting_phase.should include(motion)
+      user.voting_motions.should include(motion)
     end
 
-    it "should not return motions that belong to the group but are in phase 'closed'" do
+    it "should not return motions that belong to the group but are closed'" do
       motion = create(:motion, author: user)
       motion.close!
-      user.motions_in_voting_phase.should_not include(motion)
+      user.voting_motions.should_not include(motion)
     end
   end
 
-  describe "motions_closed" do
-    it "returns motions that belong to the group and are in phase 'voting'" do
+  describe "closed_motions" do
+    it "returns motions that belong to the group and are closed" do
       motion = create(:motion, author: user)
       motion.close!
-      user.motions_closed.should include(motion)
+      user.closed_motions.should include(motion)
     end
 
-    it "should not return motions that belong to the group but are in phase 'closed'" do
+    it "should not return motions that belong to the group but are closed" do
       motion = create(:motion, author: user)
-      user.motions_closed.should_not include(motion)
+      user.closed_motions.should_not include(motion)
     end
   end
 

--- a/spec/models/vote_spec.rb
+++ b/spec/models/vote_spec.rb
@@ -46,7 +46,7 @@ describe Vote do
     vote.motion = motion
     vote.user = user
     vote.save
-    vote.errors.messages[:position].first.should match(/can only be modified while the motion is open/)
+    vote.errors.messages[:position].first.should match(/can only be modified while the motion is in voting phase./)
   end
 
   it 'sends notification email to author if block is issued' do


### PR DESCRIPTION
When an admin closes a proposal the close date displayed is the date it was supposed to close not the date is was closed.

This area of the code is the oldest in the codebase and very messy.  This refactor separates out the functionality of 'tracking when the motion is closing' and 'if it has closed' into two different fields so there is no interference.
Scopes and queries become a lot cleaner as a result.
- Create a new column closing_at populated with close_at data
- Rename close_at to closed_at and set this field to NULL for any motions in phase 'voting'
- Remove column 'phase'.  (an 'open' motion is now, any motion with 'closed_at IS NULL')
- Change validate presence to closing_at
- Update all instances of close_at to closing_at or closed_at
- Create methods open? and closed? for motion
- Create open_motions and closed_motions methods for user, group and discussion
- Simplified 'close_motion' to close!
- Add a step to features/motions/close_proposal to make sure closed_at matches  
