### PR TITLE
language change

### DIFF
--- a/app/views/discussions/_discussion_context.html.haml
+++ b/app/views/discussions/_discussion_context.html.haml
@@ -6,13 +6,18 @@
       =render "application/hint", text: t(:"hint.context"), anchor: 'starting-an-engaging-discussion'
 
     .discussion-additional-info
-      = t("discussion_context.started_when", when: time_ago_in_words(@discussion.created_at))
-      = t :by
-      =link_to @discussion.author.name, user_path(@discussion.author), class: "user-name"
+      = t("discussion_context.started_html",
+          when: time_ago_in_words(@discussion.created_at),
+          who: @discussion.author.name,
+          link: user_path(@discussion.author),
+          link_class: 'user-name')
       -if defined? @last_collaborator
         .last-edited-by
-          = t("discussion_context.last_edited", when: time_ago_in_words(@discussion.last_versioned_at))
-          =link_to @last_collaborator.name, user_path(@last_collaborator), class: "user-name"
+          = t("discussion_context.last_edited_html",
+              when: time_ago_in_words(@discussion.last_versioned_at),
+              who: @last_collaborator.name,
+              link: user_path(@last_collaborator),
+              link_class: 'user-name')
         .see-revision-history
           %i.icon-time
           =link_to t("discussion_context.see_revision_history"), show_description_history_discussion_path(@discussion), :method => :post, :class => "see-description-history", :remote => true

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -260,8 +260,8 @@ en:
   empty_discussion_index_group: "This group does not have any discussions yet."
 
   discussion_context:
-    started_when: "Started %{when} ago"
-    last_edited: "Last edited about %{when} ago by "
+    started_html: "Started %{when} ago by <a href='%{link}' class='%{link_class}'>%{who}</a>"
+    last_edited_html: "Last edited %{when} ago by <a href='%{link}' class='%{link_class}'>%{who}</a>"
     see_revision_history: "See revision history"
 
   description_history:


### PR DESCRIPTION
This change makes it a lot easier for translators to convert
the edited-when-by-who string into their own language.

Incidentally we need to fix our time formatting asap I reckon,
those 'ago's don't translate very well.

@jonlemmon can we merge this asap please to help the translators?
