### PR TITLE
Ready for QA: Split sign up and sign in when accepting invitations

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -100,5 +100,8 @@ module ApplicationHelper
   def visitor?
     !user_signed_in?
   end
-end
 
+  def email_belongs_to_existing_user?(email)
+    User.find_by_email(email).present?
+  end
+end

--- a/app/helpers/invitations_helper.rb
+++ b/app/helpers/invitations_helper.rb
@@ -1,2 +1,13 @@
 module InvitationsHelper
+  def resource_name
+    :user
+  end
+
+  def resource
+    @resource ||= User.new
+  end
+
+  def devise_mapping
+    @devise_mapping ||= Devise.mappings[:user]
+  end
 end

--- a/app/views/devise/passwords/new.html.haml
+++ b/app/views/devise/passwords/new.html.haml
@@ -1,8 +1,10 @@
-%h2 Forgot your password?
-= form_for(resource, :as => resource_name, :url => password_path(resource_name), :html => { :method => :post }) do |f|
-  = devise_error_messages!
-  .padding
-    = f.label :email, t(:email)
-    = f.email_field :email
-  = f.submit t(:send_password_reset), class: "btn primary"
-= render :partial => "devise/shared/links"
+.row
+  .span4.offset3
+    %h2 Forgot your password?
+    = form_for(resource, :as => resource_name, :url => password_path(resource_name), :html => { :method => :post }) do |f|
+      = devise_error_messages!
+      .padding
+        = f.label :email, t(:email)
+        = f.email_field :email
+      = f.submit t(:send_password_reset), class: "btn primary"
+    = render :partial => "devise/shared/links"

--- a/app/views/devise/registrations/_form.html.haml
+++ b/app/views/devise/registrations/_form.html.haml
@@ -1,0 +1,8 @@
+=simple_form_for(@user, url: user_registration_path) do |f|
+  =f.input :name, :input_html => { :value => @user_name }
+  =f.input :email, :input_html => { :value => @invitation.recipient_email }
+  =f.input :password
+  =f.input :password_confirmation
+  =f.input :language_preference, :collection => Translation::LANGUAGES,
+           selected: I18n.locale, include_blank: false
+  =f.submit t("devise.registrations.sign_up"), class: "btn btn-info btn-large"

--- a/app/views/devise/sessions/_form.html.haml
+++ b/app/views/devise/sessions/_form.html.haml
@@ -1,0 +1,10 @@
+= simple_form_for(@user, url: user_session_path) do |f|
+  - if @invitation
+    = f.input :email, :input_html => { :value => @invitation.recipient_email }, required: false
+  - else
+    = f.input :email, required: false
+  = f.input :password
+  = f.input :remember_me, :as => :boolean, label: false, inline_label: t(:remember_me) if devise_mapping.rememberable?
+  .sign-in-button
+    = f.submit t(:sign_in), class: "btn, btn-info btn-large", id: "sign-in-btn", :data => { :disable_with => t(:sign_in) }
+= render "devise/shared/links"

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -10,18 +10,7 @@
       .row-fluid
         .span1 &nbsp;
         .span4
-          = form_for(resource, :as => resource_name, :url => session_path(resource_name)) do |f|
-            = f.label :email, t(:email)
-            = f.email_field :email, autofocus: true
-            = f.label :password, t(:password)
-            = f.password_field :password
-            - if devise_mapping.rememberable?
-              = f.check_box :remember_me, class: "pull-left"
-              = f.label :remember_me, t(:remember_me), class: "checkbox-label"
-            .sign-in-button
-              = f.submit t(:sign_in), class: "btn btn-info btn-large", :id => "sign-in-btn", :data => { :disable_with => t(:sign_in) }
-            = render :partial => "devise/shared/links"
-
+          = render "form"
         .span1 &nbsp;
         .span5
           %p

--- a/app/views/devise/shared/_links.haml
+++ b/app/views/devise/shared/_links.haml
@@ -1,4 +1,4 @@
-- if controller_name != 'sessions'
+- if (controller_name != 'sessions') && (controller_name != 'invitations')
   = link_to t(:sign_in), new_session_path(resource_name)
   %br/
 -#- if devise_mapping.registerable? && controller_name != 'registrations'

--- a/app/views/invitations/_form.html.haml
+++ b/app/views/invitations/_form.html.haml
@@ -1,17 +1,21 @@
-.row
-  .span4.offset3
-    .signup-form
-      %p
-        %strong= t :"devise.registrations.sign_up"
-        %br
-    =simple_form_for(@user, url: user_registration_path) do |f|
-      =f.input :name, :input_html => { :value => @user_name }
-      =f.input :email, :input_html => { :value => @invitation.recipient_email }
-      =f.input :password
-      =f.input :password_confirmation
-      =f.input :language_preference, :collection => Translation::LANGUAGES, selected: I18n.locale, include_blank: false
-      =f.submit t("devise.registrations.sign_up"), class: "btn btn-info btn-large"
-.row
-  .span6.offset3
-    %p= t :"or_sign_in_html", link: user_session_path
+- if email_belongs_to_existing_user? @invitation.recipient_email
+  .row
+    .span6.offset3
+      %p= t :"start_group.sign_in_intro" if @invitation.intent == "start_group"
+      %p= t :"join_group.sign_in_intro" if @invitation.intent == "join_group"
+  .row
+    .span4.offset3.signin-form
+      = render "devise/sessions/form"
+
+- else
+  .row
+    .span6.offset3
+      %p= t :"start_group.sign_up_intro" if @invitation.intent == "start_group"
+      %p= t :"join_group.sign_up_intro" if @invitation.intent == "join_group"
+  .row
+    .span4.offset3.signup-form
+      = render "devise/registrations/form"
+  .row
+    .span6.offset3
+      %h3= t :"or_sign_in_html", link: user_session_path
 

--- a/app/views/invitations/join_group.html.haml
+++ b/app/views/invitations/join_group.html.haml
@@ -3,6 +3,5 @@
     .inner-container
       .row
         .span6.offset3
-          %h2 #{@invitation.inviter_name} invited you to join #{@invitation.group_name}
-          %p You'll need to sign up or sign in to continue.
+          %h2= t(:"join_group.header", who: @invitation.inviter_name, group_name: @invitation.group_name)
       = render 'form'

--- a/app/views/invitations/start_group.html.haml
+++ b/app/views/invitations/start_group.html.haml
@@ -1,8 +1,7 @@
 .container
-  .section.first
+  %section.first
     .inner-container
       .row
         .span6.offset3
-          %h1 Welcome to Loomio
-          %p Your request to start a new group on Loomio has been approved! You'll need to set up a new account before you can create your group.
+          %h2= t :"start_group.header"
       = render 'form'

--- a/app/views/start_group_mailer/verification.html.haml
+++ b/app/views/start_group_mailer/verification.html.haml
@@ -9,4 +9,3 @@
     %p= link_to link_url, link_url
 
   %p= t("email.verification.ignore")
-= t :group

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -149,7 +149,7 @@ en:
   sign_out: "Sign out"
   sign_in: "Sign in"
   tagline: "Creating a world where it's easy for anyone to participate in decisions that affect them."
-  or_sign_in_html: "If you've already got an account, <a href='%{link}'0>click here to sign in</a>."
+  or_sign_in_html: "If you've already got an account, <a href='%{link}'>sign in here</a>."
 
   click_to_dismiss: "Click here to dismiss this message"
   generic_confirm: "Are you sure?"
@@ -495,6 +495,16 @@ en:
   forgot_your_password: "Forgot your password?"
   confirmation_not_received: "Didn't receive confirmation instructions?"
   unlock_not_received: "Didn't receive unlock instructions?"
+
+  join_group:
+    header: "%{who} invited you to join %{group_name}"
+    sign_up_intro: "You'll need to create an account to join the group."
+    sign_in_intro: "You'll need to sign in to join the group."
+
+  start_group:
+    header: "Welcome to Loomio"
+    sign_up_intro: "Your request to start a new group on Loomio has been approved! You'll need to set up a new account before you can create your group:"
+    sign_in_intro: "Your request to start a new group on Loomio has been approved! You'll need to sign in before you can create your group:"
 
   #
   # INVITATIONS

--- a/features/invitations/invitation_to_join_group.feature
+++ b/features/invitations/invitation_to_join_group.feature
@@ -18,17 +18,15 @@ Feature: Invitation to join group
     Given there is a group
     And an invitation to join the group has been sent to "jim@jam.com"
     When I open the email and click the accept invitation link
-    And I sign up as a new user speaking "Español"
+    And I sign up as a new user
     Then I should be a member of the group
     And I should be redirected to the group page
-    And I should see "Página principal"
 
   Scenario: Existing user accepts invitiation to join a group
     Given there is a group
     And an existing user with email "jim@jam.com"
     And an invitation to join the group has been sent to "jim@jam.com"
     When I open the email and click the accept invitation link
-    And I click the link to the sign in form
     And I sign in as "jim@jam.com"
     Then I should be a member of the group
     And I should be redirected to the group page

--- a/features/invitations/invitation_to_start_group.feature
+++ b/features/invitations/invitation_to_start_group.feature
@@ -9,9 +9,20 @@ Feature: User is invited to start a group on loomio
     When I approve the group request and send the setup invitation
     Then the requestor should get an invitation to start a loomio group
 
+  Scenario: Logged-in user accepts invitiation to start a loomio group
+    Given an invitiation to start a loomio group has been sent
+    And I am signed in as "jim@jam.com"
+    When the user clicks the invitiation link
+    Then they should be redirected to the group setup wizard
+
+  Scenario: Existing user accepts invitiation to start a loomio group
+    Given an invitiation to start a loomio group has been sent to an existing user "jim@jam.com"
+    When the user clicks the invitiation link
+    And they sign in as "jim@jam.com"
+    Then they should be redirected to the group setup wizard
+
   Scenario: New user accepts invitiation to start a loomio group
     Given an invitiation to start a loomio group has been sent
     When the user clicks the invitiation link
-    And they sign up as a new user speaking "Español"
+    And they sign up as a new user
     Then they should be redirected to the group setup wizard
-    And they should see "Grupo"

--- a/features/step_definitions/invitation_to_join_group_steps.rb
+++ b/features/step_definitions/invitation_to_join_group_steps.rb
@@ -85,7 +85,7 @@ Given(/^an existing user with email "(.*?)"$/) do |arg1|
   @user = FactoryGirl.create :user, email: arg1
 end
 
-When(/^I sign in as "(.*?)"$/) do |arg1|
+When(/^(?:I|they) sign in as "(.*?)"$/) do |arg1|
   fill_in :user_email, with: arg1
   fill_in :user_password, with: 'password'
   find('#sign-in-btn').click()

--- a/features/step_definitions/invitation_to_start_group_steps.rb
+++ b/features/step_definitions/invitation_to_start_group_steps.rb
@@ -32,6 +32,18 @@ Given /^an invitiation to start a loomio group has been sent$/ do
                                               message_body: 'We woud love to! {invitation_link}')
 end
 
+Given(/^an invitiation to start a loomio group has been sent to an existing user "(.*?)"$/) do |arg1|
+  user = FactoryGirl.create(:user, email: arg1)
+  @group_request = FactoryGirl.create(:group_request, admin_email: arg1)
+  @group_request.verify!
+  @site_admin = FactoryGirl.create :user, :is_admin => true
+  @setup_group = SetupGroup.new(@group_request)
+  @group = @setup_group.approve_group_request(approved_by: @site_admin)
+  @setup_group.send_invitation_to_start_group(inviter: @site_admin,
+                                              message_body: 'We woud love to! {invitation_link}')
+end
+
+
 When /^the user clicks the invitiation link$/ do
   email = ActionMailer::Base.deliveries.last
   url = email.body.match(/https?:\/\/[\S]+/)[0]

--- a/features/translate_emails.feature
+++ b/features/translate_emails.feature
@@ -71,11 +71,3 @@ Feature: deliver emails in the user's prefered language
     When "Eduardo" makes an announcement to the group
     Then "John" should receive the group email in English
     And "Viv" should receive the group email in Spanish
-
-  @javascript
-  Scenario: Group request verification email
-    Given "Joan" is a logged-out user
-    When they visit the Request New Group page
-    And their browser header indicates a Spanish language preference
-    When they fill in and submit the Request New Group Form
-    Then they should receive the group request verification email in Spanish

--- a/features/users/language_preferences.feature
+++ b/features/users/language_preferences.feature
@@ -49,3 +49,12 @@ Feature: Language preferences
     When I visit "/?locale=ro"
     And I visit "/help"
     Then I should see "Cum functioneaza"
+
+  Scenario: User sets their language preference on sign up page
+    Given there is a group
+    And an invitation to join the group has been sent to "jim@jam.com"
+    When I open the email and click the accept invitation link
+    And I sign up as a new user speaking "Español"
+    Then I should be a member of the group
+    And I should be redirected to the group page
+    And I should see "Página principal"

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -69,4 +69,18 @@ describe ApplicationHelper do
       end
     end
   end
+
+  describe "email_belongs_to_existing_user" do
+    context "for an unrecognised email address" do
+      it "returns false" do
+        helper.email_belongs_to_existing_user?("never_heard_of_him@what.com").should === false
+      end
+    end
+    context "for a recognised email address" do
+      it "returns true" do
+        user = create(:user)
+        helper.email_belongs_to_existing_user?(user.email).should == true
+      end
+    end
+  end
 end


### PR DESCRIPTION
Just wanted to get feedback on this feature. As it stands, when you click the 'start a new group' link in your email, you will get directed to one of these two pages, depending on whether or not your email address is recognised:

![screen shot 2013-07-12 at 11 33 32 am](https://f.cloud.github.com/assets/970124/785510/6f7f92d2-ea82-11e2-8eac-8aaa8679afee.png)
![screen shot 2013-07-12 at 11 30 26 am](https://f.cloud.github.com/assets/970124/785511/6f957b60-ea82-11e2-9974-579ce7eba2a7.png)
