### PR TITLE
redirect user to home when leaving group

### DIFF
--- a/app/controllers/groups/memberships_controller.rb
+++ b/app/controllers/groups/memberships_controller.rb
@@ -39,10 +39,11 @@ class Groups::MembershipsController < GroupBaseController
       @membership.destroy
       if current_user == @membership.user
         flash[:notice] = t("notice.you_have_left_group", which_group: @membership.group.name)
+        redirect_to root_url
       else
         flash[:notice] = t("notice.member_removed")
+        redirect_to group_memberships_path(@membership.group)
       end
-      redirect_to group_memberships_path(@membership.group)
     else
       redirect_to :back
     end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -68,7 +68,7 @@ en:
     proposal_not_created: "Proposal could not be created"
     user_already_admin: "%{which_user} is already a coordinator of this group."
     user_already_member: "%{which_user} is already a member of this group."
-    user_not_admin: "Sorry, %{which_user} must be an coordinator of this group to access this."
+    user_not_admin: "Sorry, %{which_user} must be a coordinator of this group to access this."
   success:
     added_to_group: "You have been added to %{which_group}."
     close_date_changed: "Close date successfully changed."

--- a/spec/controllers/groups/memberships_controller_spec.rb
+++ b/spec/controllers/groups/memberships_controller_spec.rb
@@ -36,7 +36,7 @@ describe Groups::MembershipsController do
           delete :destroy, :id => @membership.id
         end
         it { flash[:notice].should =~ /Member removed/ }
-        it { response.should redirect_to group_memberships_path(@group) }
+        it { response.should redirect_to group_memberships_path(@membership.group)}
         it { @group.users.should_not include(@new_user) }
 
         context "that was already removed" do


### PR DESCRIPTION
When leaving a group a user is currently redirected to the group which they have just left.
The controller flash message is ugly too as it displays 'an coordinator' instead of 'a coordinator'.
- redirect to home
- fix controller message in en.yaml
