### PR TITLE
Bug/motion not deleted with discussion

### DIFF
--- a/app/assets/stylesheets/icons.css.scss
+++ b/app/assets/stylesheets/icons.css.scss
@@ -48,7 +48,7 @@
   &.heart-icon {
     text-indent: -9999px;
     background-image:url('/assets/heart-small.png');
-    margin: 0;
+    margin: 1px 0 0 0;
   }
   &.notification-icon {
     background-image:url('/assets/notification-24.png');

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -132,6 +132,7 @@ class Comment < ActiveRecord::Base
     end
 
     def update_discussion_last_comment_at
+      return if discussion.nil?
       discussion.last_comment_at = discussion.latest_comment_time
       discussion.save
     end

--- a/app/models/motion.rb
+++ b/app/models/motion.rb
@@ -20,16 +20,14 @@ class Motion < ActiveRecord::Base
 
   delegate :email, :to => :author, :prefix => :author
   delegate :name, :to => :author, :prefix => :author
-  delegate :group, :group_id, :to => :discussion
+  delegate :group, :group_id, :to => :discussion, counter_cache: true
   delegate :users, :full_name, :to => :group, :prefix => :group
   delegate :email_new_motion?, to: :group, prefix: :group
 
   before_validation :set_closing_at
   before_save :format_discussion_url
-  after_save :update_counter_cache
   after_create :initialize_discussion
   after_create :fire_new_motion_event
-  after_destroy :update_counter_cache
 
   attr_accessor :create_discussion
 
@@ -270,9 +268,5 @@ class Motion < ActiveRecord::Base
       unless self.discussion_url.match(/^http/) || self.discussion_url.empty?
         self.discussion_url = "http://" + self.discussion_url
       end
-    end
-
-    def update_counter_cache
-      group.update_attribute(:motions_count, group.motions.count)
     end
 end

--- a/app/models/vote.rb
+++ b/app/models/vote.rb
@@ -88,11 +88,11 @@ class Vote < ActiveRecord::Base
 
   private
   def update_motion_vote_counts
-    motion.update_vote_counts!
+    motion.try(:update_vote_counts!)
   end
 
   def update_motion_last_vote_at
-    unless motion.nil?
+    unless motion.nil? || motion.discussion.nil?
       motion.last_vote_at = motion.latest_vote_time
       motion.save!
     end

--- a/db/migrate/20130724015029_remove_motions_with_no_discussion.rb
+++ b/db/migrate/20130724015029_remove_motions_with_no_discussion.rb
@@ -1,0 +1,28 @@
+class RemoveMotionsWithNoDiscussion < ActiveRecord::Migration
+  class Discussion < ActiveRecord::Base
+    has_many :motions, :dependent => :destroy
+    has_many :events, :as => :eventable, :dependent => :destroy
+    has_many :comments,  :as => :commentable, :dependent => :destroy
+  end
+  class Motion < ActiveRecord::Base
+    has_many :votes, :dependent => :destroy
+    has_many :did_not_votes, :dependent => :destroy
+    has_many :events, :as => :eventable, :dependent => :destroy
+  end
+  class Vote < ActiveRecord::Base
+  end
+  class DidNotVote < ActiveRecord::Base
+  end
+  class Event < ActiveRecord::Base
+    has_many :notifications, :dependent => :destroy
+  end
+  class Notification < ActiveRecord::Base
+  end
+
+  def up
+    Discussion.where(is_deleted: true).destroy_all
+  end
+
+  def down
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20130629092802) do
+ActiveRecord::Schema.define(:version => 20130724015029) do
 
   create_table "active_admin_comments", :force => true do |t|
     t.string   "resource_id",   :null => false

--- a/spec/models/discussion_spec.rb
+++ b/spec/models/discussion_spec.rb
@@ -309,10 +309,15 @@ describe Discussion do
   end
 
   describe "#delayed_destroy" do
-    it 'sets deleted_at before calling destroy' do
+    it 'sets deleted_at before calling destroy and then destroys everything', :focus do
       @discussion = create(:discussion)
+      @motion = create(:motion, discussion: @discussion)
+      @vote = create(:vote, motion: @motion)
       @discussion.should_receive(:is_deleted=).with(true)
       @discussion.delayed_destroy
+      Discussion.find_by_id(@discussion.id).should be_nil
+      Motion.find_by_id(@motion.id).should be_nil
+      Vote.find_by_id(@vote.id).should be_nil
     end
   end
 end


### PR DESCRIPTION
This bug was causing an application error as motions were not being destroyed when their parent discussion was destroyed.

Changed delay to handle_asynchronously
Put logic around update_discussion_last_comment_at
Migration to remove orphaned motions and their votes
Replace custom method update_counter_cache with activerecord counter_cache
