### PR TITLE
add permissions on sub-group creation

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -22,7 +22,7 @@ class Ability
     can [:add_members, :manage_membership_requests], Group, :members_invitable_by => :admins,
                              :id => user.adminable_group_ids
     can :archive, Group, :id => user.adminable_group_ids
-    can [:create, :request_membership], Group
+    can :create, Group, parent_id: user.group_ids
 
     #
     # MEMBERSHIPS

--- a/spec/controllers/groups_controller_spec.rb
+++ b/spec/controllers/groups_controller_spec.rb
@@ -50,25 +50,11 @@ describe GroupsController do
       end
 
       context "a non-member" do
-        before :each do
-          @previous_url = groups_url
-          request.env["HTTP_REFERER"] = @previous_url
-        end
         it "viewing a group should redirect to private message page" do
           get :show, :id => @group.id
           response.should render_template('application/display_error', message: I18n.t('error.group_private_or_not_found'))
         end
       end
-    end
-
-    it "creates a group" do
-      user = build(:user, :email => "contact@loomio.org")
-      user.save
-      @group = build(:group)
-      post :create, :group => @group.attributes
-      assigns(:group).users.should include(@user)
-      assigns(:group).admins.should include(@user)
-      response.should redirect_to(group_url(assigns(:group)))
     end
 
     it "creates a subgroup" do
@@ -186,8 +172,6 @@ describe GroupsController do
 
     describe "#email_members" do
       before do
-        @previous_url = group_url group
-        request.env["HTTP_REFERER"] = @previous_url
         Group.stub(:find).with(group.id.to_s).and_return(group)
         controller.stub(:authorize!).and_return(true)
         controller.stub(:can?).with(:email_members, group).and_return(true)
@@ -210,9 +194,9 @@ describe GroupsController do
         flash[:success].should == "Emails sending."
       end
 
-      it "redirects to previous page" do
+      it "redirects to group page" do
         post :email_members, @mailer_args
-        response.should redirect_to(@previous_url)
+        response.should redirect_to(group_url(group))
       end
     end
   end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -12,6 +12,8 @@ describe "User abilities" do
 
   context "member of a group" do
     let(:group) { create(:group) }
+    let(:subgroup) { build(:group, parent: group) }
+    let(:subgroup_for_another_group) { build(:group, parent: create(:group)) }
     let(:membership_request) { create(:membership_request, group: group, requestor: non_member) }
     let(:discussion) { create(:discussion, group: group) }
     let(:new_discussion) { user.authored_discussions.new(
@@ -31,6 +33,8 @@ describe "User abilities" do
     it { should_not be_able_to(:update, group) }
     it { should_not be_able_to(:email_members, group) }
     it { should be_able_to(:add_subgroup, group) }
+    it { should be_able_to(:create, subgroup) }
+    it { should_not be_able_to(:create, subgroup_for_another_group) }
     it { should be_able_to(:new_proposal, discussion) }
     it { should be_able_to(:add_comment, discussion) }
     it { should be_able_to(:update_description, discussion) }


### PR DESCRIPTION
Users could add subgroups to groups they did not belong
This feature adds permissions to the creation of a subgroup to protect against this. 
