### PR TITLE
add read_comment_count to discussion_read_logs

### DIFF
--- a/db/migrate/20130728044913_add_read_comments_count_to_discussion_read_logs.rb
+++ b/db/migrate/20130728044913_add_read_comments_count_to_discussion_read_logs.rb
@@ -1,0 +1,16 @@
+class AddReadCommentsCountToDiscussionReadLogs < ActiveRecord::Migration
+  def up
+    add_column :discussion_read_logs, :read_comments_count, :integer
+    DiscussionReadLog.reset_column_information
+    DiscussionReadLog.find_each do |drl|
+      if drl.discussion.present?
+        count = drl.discussion.comments.where('updated_at <= ?', drl.discussion_last_viewed_at).count
+        drl.update_attribute(:read_comments_count, count)
+      end
+
+      if drl.id % 100 == 0
+        puts drl.id
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20130724015029) do
+ActiveRecord::Schema.define(:version => 20130728044913) do
 
   create_table "active_admin_comments", :force => true do |t|
     t.string   "resource_id",   :null => false
@@ -138,6 +138,7 @@ ActiveRecord::Schema.define(:version => 20130724015029) do
     t.integer  "discussion_id"
     t.datetime "discussion_last_viewed_at"
     t.boolean  "following",                 :default => true, :null => false
+    t.integer  "read_comments_count"
   end
 
   add_index "discussion_read_logs", ["discussion_id"], :name => "index_motion_read_logs_on_discussion_id"


### PR DESCRIPTION
Only apply this when refacor/discussion_readers is able to follow immediately.

This adds a read_comments_count to discussion_read_logs and populates it with correct values.
This is in preparation for the discussion readers refactor.
