### PR TITLE
ensure migrations run from scratch. they'd become broken over time

### DIFF
--- a/db/migrate/20120502010636_fill_in_discussion_titles.rb
+++ b/db/migrate/20120502010636_fill_in_discussion_titles.rb
@@ -1,17 +1,6 @@
 class FillInDiscussionTitles < ActiveRecord::Migration
   def up
-    Discussion.all.each do |discussion|
-      motion = discussion.current_motion
-      if motion.nil?
-        title = "(no title)"
-      else
-        title = motion.name
-      end
-      title = "(no title)" if title.blank?
-      title = ActionController::Base.helpers.truncate(title, length: 150, separator: " ")
-      discussion.title = title
-      discussion.save!
-    end
+    # moved to extras/migrations/ fill in dicussion titles
   end
 
   def down

--- a/db/migrate/20120516044553_add_subgroup_members_to_parent_group.rb
+++ b/db/migrate/20120516044553_add_subgroup_members_to_parent_group.rb
@@ -1,13 +1,7 @@
 class AddSubgroupMembersToParentGroup < ActiveRecord::Migration
   def up
-    Membership.all.each do |membership|
-      parent_group = membership.group_parent
-      if parent_group.present?
-        unless parent_group.users_include? membership.user
-          parent_group.add_member!(membership.user)
-        end
-      end
-    end
+    # data migration moved to
+    # 20120516044553_add_subgroup_members_to_parent.rb
   end
 
   def down

--- a/db/migrate/20120521041044_make_discussion_activity_non_nullable.rb
+++ b/db/migrate/20120521041044_make_discussion_activity_non_nullable.rb
@@ -1,4 +1,6 @@
 class MakeDiscussionActivityNonNullable < ActiveRecord::Migration
+  class Discussion < ActiveRecord::Base
+  end
   def up
     Discussion.where("activity is NULL").each do |discussion|
       discussion.activity = 0

--- a/db/migrate/20120717044425_add_last_comment_at_to_discussions.rb
+++ b/db/migrate/20120717044425_add_last_comment_at_to_discussions.rb
@@ -1,4 +1,7 @@
 class AddLastCommentAtToDiscussions < ActiveRecord::Migration
+  class Discussion < ActiveRecord::Base
+  end
+
   def up
     add_column :discussions, :last_comment_at, :datetime
 

--- a/db/migrate/20120930014241_remove_defaults_from_last_viewed_at.rb
+++ b/db/migrate/20120930014241_remove_defaults_from_last_viewed_at.rb
@@ -1,4 +1,10 @@
 class RemoveDefaultsFromLastViewedAt < ActiveRecord::Migration
+  class Membership < ActiveRecord::Base
+  end
+
+  class DiscussionReadLog < ActiveRecord::Base
+  end
+
   def up
     change_column_default(:memberships, :last_viewed_at, nil)
     change_column_default(:discussion_read_logs, :discussion_last_viewed_at, nil)

--- a/db/migrate/20121003033500_make_group_last_viewed_at_in_membership_non_nullable.rb
+++ b/db/migrate/20121003033500_make_group_last_viewed_at_in_membership_non_nullable.rb
@@ -1,4 +1,7 @@
 class MakeGroupLastViewedAtInMembershipNonNullable < ActiveRecord::Migration
+  class Membership < ActiveRecord::Base
+  end
+
   def up
     Membership.where(:group_last_viewed_at => nil).update_all :group_last_viewed_at => Time.now
     change_column :memberships, :group_last_viewed_at, :datetime, :null => false

--- a/extras/migrations/20120502010636_fill_in_discussion_titles.rb
+++ b/extras/migrations/20120502010636_fill_in_discussion_titles.rb
@@ -1,0 +1,12 @@
+Discussion.all.each do |discussion|
+  motion = discussion.current_motion
+  if motion.nil?
+    title = "(no title)"
+  else
+    title = motion.name
+  end
+  title = "(no title)" if title.blank?
+  title = ActionController::Base.helpers.truncate(title, length: 150, separator: " ")
+  discussion.title = title
+  discussion.save!
+end

--- a/extras/migrations/20120516044553_add_subgroup_members_to_parent.rb
+++ b/extras/migrations/20120516044553_add_subgroup_members_to_parent.rb
@@ -1,0 +1,9 @@
+Membership.all.each do |membership|
+  parent_group = membership.group_parent
+  if parent_group.present?
+    unless parent_group.users_include? membership.user
+      parent_group.add_member!(membership.user)
+    end
+  end
+end
+


### PR DESCRIPTION
Older migrations had become broken as the rest of the application moves forward. This fixes them
