### PR TITLE
fix mark as read bug

### DIFF
--- a/app/controllers/inbox_controller.rb
+++ b/app/controllers/inbox_controller.rb
@@ -21,9 +21,8 @@ class InboxController < BaseController
   end
 
   def mark_all_as_read
-    group = current_user.groups.find(params[:group_id])
-    Queries::VisibleDiscussions.new(groups: [group], user: current_user).unread.
-                                order_by_latest_comment.each do |d|
+    discussion_ids = params[:discussion_ids].split('x').map(&:to_i)
+    current_user.discussions.where(id: discussion_ids).each do |d|
       d.as_read_by(current_user).viewed!
     end
     redirect_to_group_or_head_ok

--- a/app/views/inbox/index.html.haml
+++ b/app/views/inbox/index.html.haml
@@ -10,7 +10,8 @@
         .span10
           %h2= link_to group.full_name, group
         .span2.mark-all-as-read
-          =link_to 'Mark all as read', mark_all_as_read_inbox_path(group_id: group.id), class: 'mark-all-as-read-btn', remote: true
+          - discussion_ids = items.select{|i| i.is_a? Discussion }.map(&:id)
+          =link_to 'Mark all as read', mark_all_as_read_inbox_path(discussion_ids: discussion_ids.join('x')), class: 'mark-all-as-read-btn', remote: true
       %ul.inbox-list
         - items.each do |item|
           -if item.is_a? Discussion

--- a/extras/inbox.rb
+++ b/extras/inbox.rb
@@ -3,23 +3,9 @@ class Inbox
     @user = user
   end
 
-  def mark_all_as_read!(group)
-    unread_discussions_for(group).each do |discussion|
-      ViewLogger.discussion_viewed(discussion, @user)
-    end
-  end 
-
-  def mark_as_read!(item)
-    if @user.can? :show, item
-      ViewLogger.discussion_viewed(item, @user)
-    else
-      raise 'user cannot mark this item as read'
-    end
-  end
-
   def unfollow!(item)
     if @user.can? :unfollow, item
-      ViewLogger.discussion_unfollowed(item, @user)
+      raise 'no method yet.. should be added to DiscussionReader'
     end
   end
 
@@ -32,6 +18,14 @@ class Inbox
       @grouped_items[group] = motions + discussions
     end
     self
+  end
+
+  def items_count
+    count = 0
+    @grouped_items.each_pair do |group, items|
+      count += items.size
+    end
+    count
   end
 
   def empty?


### PR DESCRIPTION
@jonlemmon this fixes the problem where a user with an outdated inbox loaded in their browser could mark unlisted items as read.
