### PR TITLE
add paying subscription scope to active admin

### DIFF
--- a/app/admin/groups.rb
+++ b/app/admin/groups.rb
@@ -12,6 +12,12 @@ ActiveAdmin.register Group do
   scope "> 85% full" do |group|
     group.where('max_size > ? AND memberships_count/max_size >= ?', 0, 0.85)
   end
+  scope "Subscription" do |group|
+    group.where('paying_subscription IS true')
+  end
+  scope "Paying Subscription" do |group|
+    group.joins(:subscription)
+  end
 
   csv do
     column :id


### PR DESCRIPTION
we've added two scope in here
1) Subscription - this is all groups who have elected to pay a subscription for Loomio
2) Paying subscripions - this is all groups who have also selected a subscription plan

note there is currently nowhere in the admin panel to see the amount/ size of a subscription
![image](https://f.cloud.github.com/assets/2665886/914670/2df4aa52-fe44-11e2-9669-da4e253c5e53.png)
