### PR TITLE
add count of new groups to admin panel

### DIFF
--- a/app/admin/dashboards.rb
+++ b/app/admin/dashboards.rb
@@ -2,6 +2,8 @@ ActiveAdmin::Dashboards.build do
 
   section "Groups", :priority => 1 do
     h1 { Group.count }
+    div { "New today: #{Group.where('created_at >= ?', 24.hours.ago).count}"}
+    div { "New this week: #{Group.where('created_at >= ?', 1.week.ago).count}"}
     div { link_to "See all groups", admin_groups_path }
   end
 


### PR DESCRIPTION
I keep finding myself logging into the admin panel and counting up how many groups joined today, so I figured we should let the computer do the countring.
