### PR TITLE
change 'from' on invitation to group email

### DIFF
--- a/app/mailers/invite_people_mailer.rb
+++ b/app/mailers/invite_people_mailer.rb
@@ -7,12 +7,12 @@ class InvitePeopleMailer < BaseMailer
          subject: t("email.to_start_group.subject", group_name: @invitation.group_name)
   end
 
-  def to_join_group(invitation, sender_email, message_body)
+  def to_join_group(invitation, sender, message_body)
     @invitation = invitation
     @message_body = message_body
     mail to: invitation.recipient_email,
-         from: 'Loomio <contact@loomio.org>',
-         reply_to: sender_email,
+         from: "#{sender.name} <notifications@loomio.org>",
+         reply_to: sender.email,
          subject: t("email.to_join_group.subject", member: @invitation.inviter.name, group_name: @invitation.group_name)
   end
 

--- a/extras/create_invitation.rb
+++ b/extras/create_invitation.rb
@@ -25,7 +25,7 @@ class CreateInvitation
       invitation = to_join_group(recipient_email: recipient_email,
                                  group: args[:group],
                                  inviter: args[:inviter])
-      InvitePeopleMailer.delay.to_join_group(invitation, args[:inviter].email, invite_people.message_body)
+      InvitePeopleMailer.delay.to_join_group(invitation, args[:inviter], invite_people.message_body)
     end
     invite_people.parsed_recipients.size
   end


### PR DESCRIPTION
Current invitation to group comes 'from' contact@loomio.org, with 'reply-to' inviter.email. Seems unnecessarily confusing. This change just makes it come from inviter.name <inviter.email>.
