### PR TITLE
remove setting of default maxsize

### DIFF
--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,14 +1,11 @@
 class Group < ActiveRecord::Base
 
-  PERMISSION_CATEGORIES = ['everyone', 'members', 'admins', 'parent_group_members']
-  PAYMENT_PLANS = ['pwyc', 'subscription', 'manual_subscription']
+  PERMISSION_CATEGORIES = [:everyone, :members, :admins, :parent_group_members]
 
-  attr_accessible :name, :viewable_by, :parent_id, :parent, :cannot_contribute,
-                  :members_invitable_by, :email_new_motion, :description, :setup_completed_at,
-                  :next_steps_completed, :payment_plan
+  attr_accessible :name, :viewable_by, :parent_id, :parent, :cannot_contribute
+  attr_accessible :members_invitable_by, :email_new_motion, :description, :setup_completed_at
 
   validates_presence_of :name
-  validates_inclusion_of :payment_plan, in: PAYMENT_PLANS
   validates_inclusion_of :viewable_by, in: PERMISSION_CATEGORIES
   validates_inclusion_of :members_invitable_by, in: PERMISSION_CATEGORIES
   validates :description, :length => { :maximum => 250 }
@@ -20,32 +17,22 @@ class Group < ActiveRecord::Base
 
   after_initialize :set_defaults
   before_validation :set_max_group_size, on: :create
-  before_save :update_full_name_if_name_changed
 
   default_scope where(:archived_at => nil)
-
-  scope :parents_only, where(:parent_id => nil)
-  scope :visible_to_the_public,
-        where(viewable_by: 'everyone').
-        where('memberships_count > 4').
-        order(:full_name)
-
-  scope :search_full_name, lambda { |query| where("full_name ILIKE ?", "%#{query}%") }
 
   has_one :group_request
 
   has_many :memberships,
     :conditions => {:access_level => Membership::MEMBER_ACCESS_LEVELS},
     :dependent => :destroy,
-    :extend => GroupMemberships
+    :extend => GroupMemberships,
+    :include => :user,
+    :order => "LOWER(users.name)"
 
   has_many :membership_requests,
+    :conditions => {:access_level => 'request'},
+    :class_name => 'Membership',
     :dependent => :destroy
-
-  has_many :pending_membership_requests,
-           class_name: 'MembershipRequest',
-           conditions: {response: nil},
-           dependent: :destroy
 
   has_many :admin_memberships,
     :conditions => {:access_level => 'admin'},
@@ -54,11 +41,12 @@ class Group < ActiveRecord::Base
 
   has_many :members,
            through: :memberships,
-           source: :user
+           source: :user,
+           conditions: { :invitation_token => nil }
 
   has_many :pending_invitations,
            class_name: 'Invitation',
-           conditions: {accepted_at: nil, cancelled_at: nil}
+           conditions: {accepted_at: nil}
 
   alias :users :members
 
@@ -66,67 +54,106 @@ class Group < ActiveRecord::Base
   has_many :admins, through: :admin_memberships, source: :user
   has_many :discussions, :dependent => :destroy
   has_many :motions, :through => :discussions
+  has_many :motions_in_voting_phase,
+           :through => :discussions,
+           :source => :motions,
+           :conditions => { phase: 'voting' },
+           :order => 'close_at'
+  has_many :motions_closed,
+           :through => :discussions,
+           :source => :motions,
+           :conditions => { phase: 'closed' },
+           :order => 'close_at DESC'
 
   belongs_to :parent, :class_name => "Group"
   has_many :subgroups, :class_name => "Group", :foreign_key => 'parent_id'
-
-  has_one :subscription, dependent: :destroy
 
   delegate :include?, :to => :users, :prefix => true
   delegate :users, :to => :parent, :prefix => true
   delegate :name, :to => :parent, :prefix => true
 
-  paginates_per 20
-
-
-  def requestor_name
-    group_request.try(:admin_name)
-  end
-
-  def requestor_email
-    group_request.try(:admin_email)
-  end
-
-  def voting_motions
-    motions.voting
-  end
-
-  def closed_motions
-    motions.closed
-  end
-
-  def archive!
-    self.update_attribute(:archived_at, DateTime.now)
-    memberships.update_all(:archived_at => DateTime.now)
-    subgroups.each do |group|
-      group.archive!
+  def beta_features
+    if parent && (parent.beta_features == true)
+      true
+    else
+      self[:beta_features]
     end
   end
 
-  def archived?
-    self.archived_at.present?
+  def beta_features?
+    beta_features
   end
 
-  def viewable_by_everyone?
-    (viewable_by == 'everyone') and !archived?
+  def viewable_by
+    value = read_attribute(:viewable_by)
+    value.to_sym if value.present?
   end
 
-  def members_can_invite_members?
-    members_invitable_by == 'members'
+  def viewable_by=(value)
+    write_attribute(:viewable_by, value.to_s)
+  end
+
+  def members_can_invite?
+    members_invitable_by == :members
+  end
+
+  def members_invitable_by
+    value = read_attribute(:members_invitable_by)
+    value.to_sym if value.present?
+  end
+
+  def members_invitable_by=(value)
+    write_attribute(:members_invitable_by, value.to_s)
+  end
+
+  def full_name(separator= " - ")
+    if parent
+      parent_name + separator + name
+    else
+      name
+    end
+  end
+
+  def root_name
+    if parent
+      parent_name
+    else
+      name
+    end
   end
 
   def parent_members_visible_to(user)
     parent.users.sorted_by_name
   end
 
-  def is_pwyc?
-    payment_plan == 'pwyc'
+  def activity_since_last_viewed?(user)
+    membership = membership(user)
+    if membership
+      new_comments_since_last_looked_at_group = discussions
+        .includes(:comments)
+        .where('comments.user_id <> ? AND comments.created_at > ?' , user.id, membership.group_last_viewed_at)
+        .count > 0
+      new_comments_since_last_looked_at_discussions = discussions
+        .joins('INNER JOIN discussion_read_logs ON discussions.id = discussion_read_logs.discussion_id')
+        .where('discussion_read_logs.user_id = ? AND discussions.last_comment_at > discussion_read_logs.discussion_last_viewed_at',  user.id)
+        .count > 0
+      unread_comments = new_comments_since_last_looked_at_group &&
+                        new_comments_since_last_looked_at_discussions
+
+      # TODO: Refactor this to an active record query and write tests for it
+      unread_new_discussions = Discussion.find_by_sql(["
+        (SELECT discussions.id FROM discussions WHERE group_id = ? AND discussions.created_at > ?)
+        EXCEPT
+        (SELECT discussions.id FROM discussions
+         INNER JOIN discussion_read_logs ON discussions.id = discussion_read_logs.discussion_id
+         WHERE discussions.group_id = ? AND discussion_read_logs.user_id = ?);",
+        id, membership.group_last_viewed_at, id, user.id])
+
+      return true if unread_comments || unread_new_discussions.present?
+    end
+    false
   end
 
-  # deliberately does not include manual_subscription
-  def is_subscription?
-    payment_plan == 'subscription'
-  end
 
   # would be nice if the following 4 methods were reduced to just one - is_sub_group
   # parent and top_level are the less nice terms
@@ -153,6 +180,13 @@ class Group < ActiveRecord::Base
 
   def membership(user)
     memberships.where("group_id = ? AND user_id = ?", id, user.id).first
+  end
+
+  def add_request!(user)
+    if user_can_join?(user) && !user_membership_or_request_exists?(user)
+      membership = user.memberships.create!(:group_id => id)
+      membership
+    end
   end
 
   def add_member!(user, inviter=nil)
@@ -199,65 +233,20 @@ class Group < ActiveRecord::Base
   end
 
   def invitations_remaining
-    max_size - memberships_count - pending_invitations.count
-  end
-
-  def has_member_with_email?(email)
-    users.where('email = ?', email).present?
-  end
-
-  def has_membership_request_with_email?(email)
-    membership_requests.where('email = ?', email).present?
-  end
-
-  def is_setup?
-    self.setup_completed_at.present?
-  end
-
-  def update_full_name_if_name_changed
-    if changes.include?('name')
-      update_full_name
-      subgroups.each do |subgroup|
-        subgroup.full_name = name + " - " + subgroup.name
-        subgroup.save(validate: false)
-      end
-    end
-  end
-
-  def update_full_name
-    self.full_name = calculate_full_name
-  end
-
-  def has_subscription_plan?
-    subscription.present?
-  end
-
-  def subscription_plan
-    subscription.amount
+    max_size - memberships_count 
   end
 
 
   private
 
-  def calculate_full_name
-    if is_a_parent?
-      name
-    else
-      parent_name + " - " + name
-    end
-  end
-
   def set_max_group_size
-    self.max_size = 50 if (is_a_parent? && max_size.nil?)
+    self.max_size = 300 if (is_a_parent? && max_size.nil?)
   end
 
   def set_defaults
-    if is_a_subgroup?
-      self.viewable_by ||= 'parent_group_members'
-    else
-      self.viewable_by ||= 'members'
-    end
-    self.members_invitable_by ||= 'members'
+    self.viewable_by ||= :members if parent_id.nil?
+    self.viewable_by ||= :parent_group_members unless parent_id.nil?
+    self.members_invitable_by ||= :members
   end
 
   def limit_inheritance


### PR DESCRIPTION
Max size had previously been restricted to control growth
This fix lets increases the max_size to 300 for new groups.

Don't know why all these changes are showing as I have only change one line.  @s01us could you test this.  It may need cherry picking if these differences don't disappear.  My guess is master is out of date?
