### PR TITLE
increase default max_size

### DIFF
--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -248,7 +248,7 @@ class Group < ActiveRecord::Base
   end
 
   def set_max_group_size
-    self.max_size = 50 if (is_a_parent? && max_size.nil?)
+    self.max_size = 300 if (is_a_parent? && max_size.nil?)
   end
 
   def set_defaults


### PR DESCRIPTION
Max size had previously been restricted to control growth
This fix lets increases the max_size to 300 for new groups.

@s01us this will need a smoke test
