### PR TITLE
boost default group max_size

### DIFF
--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -248,7 +248,7 @@ class Group < ActiveRecord::Base
   end
 
   def set_max_group_size
-    self.max_size = 50 if (is_a_parent? && max_size.nil?)
+    self.max_size = 300 if (is_a_parent? && max_size.nil?)
   end
 
   def set_defaults


### PR DESCRIPTION
Quick fix for now, let's talk about fixing max_size properly in a bigger discussion.
