### PR TITLE
Fix incorrect email error message in forgotten password form

### DIFF
--- a/app/views/devise/passwords/new.html.haml
+++ b/app/views/devise/passwords/new.html.haml
@@ -2,9 +2,9 @@
   .span4.offset3
     %h2 Forgot your password?
     = form_for(resource, :as => resource_name, :url => password_path(resource_name), :html => { :method => :post }) do |f|
-      = devise_error_messages!
+      - if resource.errors.any?
+        %p The email address you have entered is invalid, please enter a valid email address
       .padding
         = f.label :email, t(:email)
         = f.email_field :email
       = f.submit t(:send_password_reset), class: "btn primary"
-    = render :partial => "devise/shared/links"


### PR DESCRIPTION
Replaced 'devise_error_messages' with customised message
Removed 'sign in' link at bottom of form because the sign in button is visible on the page
