### PR TITLE
Inbox mark motion as read

### DIFF
--- a/app/assets/javascripts/inbox.js.coffee
+++ b/app/assets/javascripts/inbox.js.coffee
@@ -35,7 +35,7 @@ $ ->
     $('.mark-all-as-read-btn').on 'click', (e) ->
       group_div = $(e.target).parents('.inbox-group')
 
-      group_div.find('li.discussion').fadeOut fade_time, ->
+      group_div.find('li').fadeOut fade_time, ->
         $(this).remove()
         remove_group_if_empty(group_div)
         show_inbox_empty_msg_if_empty

--- a/app/controllers/inbox_controller.rb
+++ b/app/controllers/inbox_controller.rb
@@ -25,16 +25,20 @@ class InboxController < BaseController
   end
 
   def mark_as_read
-    item = load_resource_from_params
-    item.as_read_by(current_user).viewed!
-    redirect_to_group_or_head_ok
-  end
-
-  def mark_all_as_read
-    discussion_ids = params[:discussion_ids].split('x').map(&:to_i)
-    current_user.discussions.where(id: discussion_ids).each do |d|
-      d.as_read_by(current_user).viewed!
+    if params.has_key?(:discussion_ids)
+      ids = params[:discussion_ids].split('x').map(&:to_i)
+      current_user.discussions.where(id: ids).each do |discussion|
+        discussion.as_read_by(current_user).viewed!
+      end
     end
+
+    if params.has_key?(:motion_ids)
+      ids = params[:motion_ids].split('x').map(&:to_i)
+      current_user.motions.where(id: ids).each do |motion|
+        motion.as_read_by(current_user).viewed!
+      end
+    end
+
     redirect_to_group_or_head_ok
   end
 
@@ -61,8 +65,11 @@ class InboxController < BaseController
   def load_resource_from_params
     class_name = params[:class]
     id = params[:id]
+
     if class_name == 'Discussion'
-      current_user.discussions.find id
+      current_user.discussions.find_by_id(id)
+    elsif class_name == 'Motion'
+      current_user.motions.find_by_id(id)
     end
   end
 

--- a/app/models/motion.rb
+++ b/app/models/motion.rb
@@ -21,7 +21,7 @@ class Motion < ActiveRecord::Base
 
   delegate :email, :to => :author, :prefix => :author
   delegate :name, :to => :author, :prefix => :author
-  delegate :group, :group_id, :to => :discussion, counter_cache: true
+  delegate :group, :group_id, :to => :discussion
   delegate :users, :full_name, :to => :group, :prefix => :group
   delegate :email_new_motion?, to: :group, prefix: :group
 
@@ -37,6 +37,7 @@ class Motion < ActiveRecord::Base
   scope :that_user_has_voted_on, lambda {|user|
     joins(:votes).where("votes.user_id = ?", user.id)
   }
+  scope :order_by_latest_activity, -> { order('last_vote_at desc') }
 
   def title
     name

--- a/app/views/inbox/_discussion_line_item.html.haml
+++ b/app/views/inbox/_discussion_line_item.html.haml
@@ -15,5 +15,5 @@
         -#= link_to 'h', unfollow_inbox_path({class: item.class.to_s, id: item.id}), remote: true, method: :post, id: 'unfollow-btn'
   .span1
     .mark-as-read-btn
-      = link_to 'x', mark_as_read_inbox_path({class:item.class.to_s, id: item.id} ), remote: true, method: :post
+      = link_to 'x', mark_as_read_inbox_path(discussion_ids: item.id), remote: true, method: :post
 

--- a/app/views/inbox/_motion_line_item.html.haml
+++ b/app/views/inbox/_motion_line_item.html.haml
@@ -23,4 +23,5 @@
       left
 
   .span1
-    &nbsp;
+    .mark-as-read-btn
+      = link_to 'x', mark_as_read_inbox_path(motion_ids: item.id), remote: true, method: :post

--- a/app/views/inbox/index.html.haml
+++ b/app/views/inbox/index.html.haml
@@ -18,7 +18,8 @@
           %h3= link_to group.full_name, group
         .span2.mark-all-as-read
           - discussion_ids = items.select{|i| i.is_a? Discussion }.map(&:id)
-          =link_to 'Clear', mark_all_as_read_inbox_path(discussion_ids: discussion_ids.join('x')), class: 'mark-all-as-read-btn', remote: true
+          - motion_ids = items.select{|i| i.is_a? Motion }.map(&:id)
+          =link_to 'Clear', mark_as_read_inbox_path(discussion_ids: discussion_ids.join('x'), motion_ids: motion_ids.join('x')), class: 'mark-all-as-read-btn', remote: true
       %ul.inbox-list
         - items.each do |item|
           -if item.is_a? Discussion

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,7 +18,6 @@ Loomio::Application.routes.draw do
   get '/inbox/preferences', to: 'inbox#preferences', as: :inbox_preferences
   put '/inbox/update_preferences', to: 'inbox#update_preferences', as: :update_inbox_preferences
   match '/inbox/mark_as_read', to: 'inbox#mark_as_read', as: :mark_as_read_inbox
-  match '/inbox/mark_all_as_read', to: 'inbox#mark_all_as_read', as: :mark_all_as_read_inbox
   match '/inbox/unfollow', to: 'inbox#unfollow', as: :unfollow_inbox
 
   resources :invitations, only: [:show]

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -57,7 +57,7 @@ ActiveRecord::Schema.define(:version => 20130903214957) do
     t.integer  "filesize"
   end
 
-  add_index "attachments", ["user_id", "comment_id"], :name => "index_attachments_on_user_id_and_comment_id"
+  add_index "attachments", ["comment_id"], :name => "index_attachments_on_comment_id"
 
   create_table "campaign_signups", :force => true do |t|
     t.integer  "campaign_id"
@@ -469,8 +469,8 @@ ActiveRecord::Schema.define(:version => 20130903214957) do
     t.boolean  "subscribed_to_proposal_closure_notifications",                :default => true,       :null => false
     t.string   "authentication_token"
     t.string   "unsubscribe_token"
-    t.boolean  "uses_markdown",                                               :default => false
     t.integer  "memberships_count",                                           :default => 0,          :null => false
+    t.boolean  "uses_markdown",                                               :default => false
     t.string   "language_preference"
     t.string   "time_zone"
   end

--- a/extras/inbox.rb
+++ b/extras/inbox.rb
@@ -19,7 +19,7 @@ class Inbox
       @unread_discussions_per_group[group] = unread_discussions_for(group).size
 
       discussions = unread_discussions_for(group).limit(unread_per_group_limit)
-      motions = unvoted_motions_for(group)
+      motions = unread_motions_for(group)
       next if discussions.empty? && motions.empty?
 
       aligned_items = []
@@ -84,5 +84,10 @@ class Inbox
 
   def unvoted_motions_for(group)
     Queries::UnvotedMotions.for(@user, group)
+  end
+
+  def unread_motions_for(group)
+    Queries::VisibleMotions.new(user: @user, groups: [group]).unread.voting.
+                                order_by_latest_activity.readonly(false)
   end
 end

--- a/extras/queries/visible_motions.rb
+++ b/extras/queries/visible_motions.rb
@@ -1,0 +1,56 @@
+class Queries::VisibleMotions < Delegator
+  def initialize(user: nil, groups: nil)
+    @user = user
+    @groups = groups
+
+    @relation = Motion.joins(:discussion => :group).where('archived_at IS NULL')
+
+    if @user.present?
+      @relation = @relation.select('motions.*,
+                                    1 as joined_to_motion_reader,
+                                    mr.id as motion_reader_id,
+                                    mr.user_id as motion_reader_user_id,
+                                    mr.read_votes_count as read_votes_count,
+                                    mr.read_activity_count as read_activity_count,
+                                    mr.last_read_at as last_read_at,
+                                    mr.following as viewer_following').
+                              joins("LEFT OUTER JOIN motion_readers mr ON
+                                    mr.motion_id = motions.id AND mr.user_id = #{@user.id}")
+    end
+
+    if @user.present? && @groups.present?
+      @relation = @relation.where("discussions.group_id IN (:group_ids) AND
+                                  (discussions.group_id IN (:user_group_ids) OR groups.viewable_by = 'everyone'
+                                   OR (groups.viewable_by = 'parent_group_members' AND groups.parent_id IN (:user_group_ids)))",
+                                  group_ids: @groups.map(&:id),
+                                  user_group_ids: @user.groups.map(&:id))
+    elsif @user.present? && @groups.blank?
+      @relation = @relation.where('discussions.group_id IN (:user_group_ids)', user_group_ids: @user.groups.map(&:id))
+    elsif @user.blank? && @groups.present?
+      @relation = @relation.where("discussions.group_id IN (:group_ids) AND groups.viewable_by = 'everyone'",
+                                  group_ids: @groups.map(&:id))
+    else
+      @relation = []
+    end
+
+    super(@relation)
+  end
+
+  def __getobj__
+    @relation
+  end
+
+  def __setobj__(obj)
+    @relation = obj
+  end
+
+  def unread
+    @relation = @relation.where('(mr.last_read_at < motions.last_vote_at) OR mr.last_read_at IS NULL')
+    self
+  end
+
+  def followed
+    @relation = @relation.where('mr.following = ? OR mr.following IS NULL', true)
+    self
+  end
+end

--- a/features/inbox.feature
+++ b/features/inbox.feature
@@ -23,17 +23,24 @@ Feature: Inbox
     When I visit the inbox
     Then I should see the motion
 
-  Scenario: Voted motions don't show in inbox
-    Given I belong to a group with a motion
-    And I have voted on the motion
-    When I visit the inbox
-    Then the inbox should be empty
+  # voted motions will show in inbox.. if there is new activity.
+  #Scenario: Voted motions don't show in inbox
+    #Given I belong to a group with a motion
+    #And I have voted on the motion
+    #When I visit the inbox
+    #Then the inbox should be empty
 
   Scenario: User marks discussion as read
     Given I belong to a group with a discussion
     When I visit the inbox
     And I mark the discussion as read
     Then the discussion should disappear
+
+  Scenario: User marks motion as read
+    Given I belong to a group with a motion
+    When I visit the inbox
+    And I mark the motion as read
+    Then the motion should disappear
 
   Scenario: Discussion with no comments gives 1 unread
     Given I belong to a group with a discussion

--- a/features/step_definitions/inbox_steps.rb
+++ b/features/step_definitions/inbox_steps.rb
@@ -40,6 +40,7 @@ When(/^I have voted on the motion$/) do
   vote.motion = @motion
   vote.user = @user
   vote.save!
+  @motion.as_read_by(@user).viewed!
 end
 
 When(/^I mark the discussion as read$/) do
@@ -56,6 +57,14 @@ end
 
 Then(/^the discussion should not show in inbox$/) do
   page.should_not have_content @discussion.title
+end
+
+When(/^I mark the motion as read$/) do
+  find('.motion .mark-as-read-btn a').click
+end
+
+Then(/^the motion should disappear$/) do
+  page.should_not have_content @motion.title
 end
 
 Given(/^I belong to a group with several discussions$/) do

--- a/spec/extras/queries/visible_motions_spec.rb
+++ b/spec/extras/queries/visible_motions_spec.rb
@@ -1,0 +1,70 @@
+require 'spec_helper'
+
+describe Queries::VisibleMotions do
+  let(:user) { create :user }
+  let(:group) { create :group }
+  let(:discussion) { create :discussion, group: group }
+  let(:motion) { create :motion, discussion: discussion }
+
+  subject do
+    Queries::VisibleMotions.new(user: user, groups: [group])
+  end
+
+  describe 'viewable_by' do
+    context 'everyone (aka public)' do
+      before { group.update_attribute(:viewable_by, 'everyone') }
+
+      it 'guests can see motions' do
+        subject.should include motion
+      end
+
+      it 'members can see motions' do
+        group.add_member! user
+        subject.should include motion
+      end
+    end
+
+    context 'members' do
+      before { group.update_attribute(:viewable_by, 'members') }
+
+      it 'guests cannot see motions' do
+        subject.should_not include motion
+      end
+
+      it 'members can see motions' do
+        group.add_member! user
+        subject.should include motion
+      end
+    end
+
+    context 'parent_group_members' do
+      let(:parent_group) { create :group }
+      let(:group) { create :group, parent: parent_group }
+
+      before { group.update_attribute(:viewable_by, 'parent_group_members') }
+
+      it 'guests cannot see motions' do
+        subject.should_not include motion
+      end
+
+      it 'member of parent group can see motions' do
+        parent_group.add_member! user
+        subject.should include motion
+      end
+
+      it 'members can see motions' do
+        parent_group.add_member! user
+        group.add_member! user
+        subject.should include motion
+      end
+    end
+  end
+
+  describe 'archived' do
+    it 'does not return motions in archived groups' do
+      motion
+      group.archive!
+      subject.should_not include motion
+    end
+  end
+end


### PR DESCRIPTION
Changes behaviour of inbox

Now motions that you have read will not show up and you are now able to mark motions as read.

Previously motions would stay in inbox until they were voted upon.

This means that inbox has a simpler behaviour and it is more easy to clear your inbox notifications. Those who want to get an overview of motions in voting can use dashboard as god intended.
