### PR TITLE
get membership request notification to render without error

### DIFF
--- a/app/assets/javascripts/notifications.js.coffee
+++ b/app/assets/javascripts/notifications.js.coffee
@@ -17,7 +17,6 @@ $ ->
         $.post("/notifications/mark_as_viewed?latest_viewed=#{notification_id}")
 $ ->
   $("#group-dropdown-items").load('/notifications/groups_tree_dropdown')
-  #$('#inbox-container').load('ccn
 
 $ ->
   $('#inbox-count').load('/inbox/size')

--- a/extras/notification_items/membership_requested.rb
+++ b/extras/notification_items/membership_requested.rb
@@ -7,12 +7,20 @@ class NotificationItems::MembershipRequested < NotificationItem
     @notification = notification
   end
 
+  def actor
+    @notification.eventable.requestor
+  end
+
   def action_text
     I18n.t('notifications.membership_requested')
   end
 
   def title
-    @notification.eventable.group_full_name
+    @notification.eventable.group_name
+  end
+
+  def group_full_name
+    @notification.eventable.group_name
   end
 
   def link

--- a/spec/extras/notification_items/membership_requested_spec.rb
+++ b/spec/extras/notification_items/membership_requested_spec.rb
@@ -3,9 +3,9 @@ describe NotificationItems::MembershipRequested do
   let(:item) { NotificationItems::MembershipRequested.new(notification) }
 
   it "#actor returns the user who requested membership" do
-    requester = stub(:user)
-    notification.stub_chain(:eventable, :user).and_return(requester)
-    item.actor.should == notification.eventable.user
+    requestor = stub(:user)
+    notification.stub_chain(:eventable, :requestor).and_return(requestor)
+    item.actor.should == notification.eventable.requestor
   end
 
   it "#action_text returns a string" do
@@ -13,13 +13,13 @@ describe NotificationItems::MembershipRequested do
   end
 
   it "#title returns the groups name" do
-    notification.stub_chain(:eventable, :group_full_name).and_return("hello")
-    item.title.should == notification.eventable.group_full_name
+    notification.stub_chain(:eventable, :group_name).and_return("hello")
+    item.title.should == notification.eventable.group_name
   end
 
   it "#group_full_name returns the group name including a parent group if there is one" do
-    notification.stub_chain(:eventable, :group_full_name).and_return("goob")
-    item.group_full_name.should == notification.eventable.group_full_name
+    notification.stub_chain(:eventable, :group_name).and_return("goob")
+    item.group_full_name.should == notification.eventable.group_name
   end
 
   it "#link returns a path to the requested group" do


### PR DESCRIPTION
This prevents the membership_request notification causing an error but there is currently another issue on Production that is preventing the notification count clearing on drop-down click.

Looks like this additional error has now been fixed in #1024 by @robguthrie 
