### PR TITLE
Patch up user_added_to_group notification

### DIFF
--- a/extras/notification_items/user_added_to_group.rb
+++ b/extras/notification_items/user_added_to_group.rb
@@ -20,6 +20,9 @@ class NotificationItems::UserAddedToGroup < NotificationItem
   end
 
   def actor
-    @notification.eventable.inviter
+    # JON: Temporary fix until I figure out why inviter is not
+    #      populating
+    inviter = @notification.eventable.inviter
+    inviter or @notification.eventable.user
   end
 end


### PR DESCRIPTION
For some reason Membership.inviter isn't getting populated in certain circumstances when the "UserAddedToGroup" event is fired. So this notification was breaking everything. I haven't figured out why it isn't getting populated, but this fix will at least get the notifications working again for these people.

cc: @robguthrie 
