### PR TITLE
improve comment likes performance

### DIFF
--- a/app/controllers/discussions_controller.rb
+++ b/app/controllers/discussions_controller.rb
@@ -69,7 +69,6 @@ class DiscussionsController < GroupBaseController
     @group = GroupDecorator.new(@discussion.group)
     @vote = Vote.new
     @current_motion = @discussion.current_motion
-    load_cached_comment_info
     assign_meta_data
     if params[:proposal]
       @displayed_motion = Motion.find(params[:proposal])
@@ -106,7 +105,6 @@ class DiscussionsController < GroupBaseController
       @comment = @discussion.add_comment(current_user, params[:comment],
                                          uses_markdown: params[:uses_markdown], attachments: params[:attachments])
       current_user.update_attributes(uses_markdown: params[:uses_markdown])
-      load_cached_comment_info
       @discussion.as_read_by(current_user).viewed!
       unless request.xhr?
         redirect_to @discussion
@@ -170,18 +168,6 @@ class DiscussionsController < GroupBaseController
   end
 
   private
-
-
-  def load_cached_comment_info
-    @comment_likes = @discussion.comment_likes
-    @comment_likes_by_comment_id = @comment_likes.group_by{|cv| cv.comment_id}
-    if current_user
-      @comment_ids_liked_by_current_user = @comment_likes.where(user_id: current_user.id).map{|cv|cv.comment_id}
-    else
-      @comment_ids_liked_by_current_user = []
-    end
-    @can_like_comments = can?(:like, @discussion.comments.first)
-  end
 
   def assign_meta_data
     if @group.viewable_by == 'everyone'

--- a/app/helpers/discussions_helper.rb
+++ b/app/helpers/discussions_helper.rb
@@ -47,34 +47,4 @@ module DiscussionsHelper
       image_tag("markdown_off.png", class: 'markdown-icon markdown-off')
     end
   end
-
-  def comment_likes_count(comment)
-    if @comment_likes_by_comment_id[comment.id].present?
-      @comment_likes_by_comment_id[comment.id].size
-    else
-      0
-    end
-  rescue
-    comment.comment_votes.count
-  end
-
-  def current_user_can_like_comments?
-    if @can_like_comments.present?
-      @can_like_comments
-    else
-      can?(:like, @comment)
-    end
-  end
-
-  def comment_likes_for(comment)
-    @comment_likes_by_comment_id[comment.id]
-  rescue
-    comment.comment_votes
-  end
-
-  def current_user_likes_comment?(comment)
-    @comment_ids_liked_by_current_user.include?(comment.id)
-  rescue
-    comment.comment_votes.where(user_id: current_user.id).exists?
-  end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -117,17 +117,13 @@ class Ability
          :edit_title,
          :show_description_history,
          :preview_version,
+         :like_comments,
          :update_version], Discussion do |discussion|
       @member_group_ids.include?(discussion.group_id)
     end
 
     can [:destroy], Comment do |comment|
       (comment.author == user) or @admin_discussion_ids.include?(comment.discussion_id)
-    end
-
-    can [:like,
-         :unlike], Comment do |comment|
-      @member_discussion_ids.include?(comment.discussion_id)
     end
 
     can :get_and_clear_new_activity, Motion do |motion|

--- a/app/models/comment_vote.rb
+++ b/app/models/comment_vote.rb
@@ -1,5 +1,4 @@
 class CommentVote < ActiveRecord::Base
-  default_scope include: :user
   belongs_to :comment, counter_cache: true
   belongs_to :user
   has_many :events, :as => :eventable, :dependent => :destroy

--- a/app/views/comments/_comment_likes.html.haml
+++ b/app/views/comments/_comment_likes.html.haml
@@ -1,8 +1,8 @@
 .activity-item-time
   = link_to(t('ago', :quantity_of_time => time_ago_in_words(comment.created_at)), "#comment-#{comment.id}")
-  - if current_user_can_like_comments?
+  - if @can_like_comments ||= can?(:like_comments, @discussion)
     = " · "
-    - if current_user_likes_comment?(comment)
+    - if comment.likers_include?(current_user)
       = link_to t(:unlike), like_comment_path(id: comment, like: 'false'), method: :post, remote: true, id: "unlike-comment-#{comment.id}"
     - else
       = link_to t(:like), like_comment_path(id: comment, like: 'true'), method: :post, remote: true, id: "like-comment-#{comment.id}"
@@ -10,11 +10,11 @@
     = " · "
     = link_to t(:delete), "#", 'data-title' => t(:delete_comment), 'data-body' => t(:confirm_delete_comment), 'data-confirm-path' => comment_path(comment), 'data-method-type' => 'delete', class: 'confirm-dialog', id: "delete-comment-#{comment.id}"
 
-- if comment_likes_count(comment) > 0
+- if comment.likes_count > 0
   .activity-item-likes
-    - likers = comment_likes_for(comment).map { |like| link_to(like.user_name, like.user) }
-    - if likers.length > 1
-      - likers = likers.slice(0, likers.length - 1).join(", ").concat(" and " + likers.slice(-1))
+    - liker_links = comment.liker_ids_and_names.map { |id, name| link_to(name, user_path(id)) }
+    - if liker_links.size == 1
+      - likers = liker_links.first
     - else
-      - likers = likers[0]
+      - likers = liker_links.slice(0, liker_links.size - 1).join(", ").concat(" and " + liker_links.last)
     = t(:liked_by, who: likers).html_safe

--- a/app/views/groups/_title.html.haml
+++ b/app/views/groups/_title.html.haml
@@ -5,7 +5,10 @@
         %h1.home-title
           = link_to t(:home), "/"
           = content_tag :span, "\u25B6", class: 'name-separator'
-          = group.fancy_link
+          - if group.is_a_subgroup?
+            = link_to group.parent.name, group.parent
+            = content_tag :span, "\u25B6", class: 'name-separator'
+          = link_to group.name, group
         = render 'groups/privacy_dropdown', :group => group
     - else
       .span10

--- a/app/views/notifications/dropdown_items.html.haml
+++ b/app/views/notifications/dropdown_items.html.haml
@@ -1,12 +1,9 @@
 %ul
   - if @notifications.empty?
     %li.notifications-placeholder= t :empty_notifications
-  - @notifications.each do |notification|
-    -if notification.user.present?
-      = render notification
+  = render @notifications
 :javascript
   var new_notifications_count = #{@unviewed_notifications.size}
   if (new_notifications_count > 0) {
     $('span#notifications-count').html(new_notifications_count)
   }
-

--- a/db/migrate/20130910070551_add_liker_name_and_ids_to_comments.rb
+++ b/db/migrate/20130910070551_add_liker_name_and_ids_to_comments.rb
@@ -1,0 +1,9 @@
+class AddLikerNameAndIdsToComments < ActiveRecord::Migration
+  def up
+    add_column :comments, :liker_ids_and_names, :text
+  end
+
+  def down
+    remove_column :comments, :liker_ids_and_names
+  end
+end

--- a/lib/tasks/upgrade_tasks.rake
+++ b/lib/tasks/upgrade_tasks.rake
@@ -30,4 +30,14 @@ namespace :upgrade_tasks do
       end
     end
   end
+
+  task :reset_comment_likers => :environment do
+    Comment.find_each do |c|
+      puts c.id if c.id % 100 == 0
+      c.comment_votes.each do |cv|
+        c.liker_ids_and_names[cv.user_id] = cv.user.name
+      end
+      c.save(validate: false)
+    end
+  end
 end

--- a/spec/controllers/comments_controller_spec.rb
+++ b/spec/controllers/comments_controller_spec.rb
@@ -14,6 +14,7 @@ describe CommentsController do
       Comment.stub(:find).and_return(comment)
     end
 
+
     context "user likes a comment" do
       before do
         @comment_vote = mock_model(CommentVote)
@@ -21,19 +22,14 @@ describe CommentsController do
         Events::CommentLiked.stub(:publish!)
       end
 
-      it "checks permissions" do
-        app_controller.should_receive(:authorize!).and_return(true)
-        post :like, id: comment.id, like: 'true'
-      end
-
       it "adds like to comment model" do
         comment.should_receive(:like).with(user)
-        post :like, id: comment.id, like: 'true'
+        post :like, id: comment.id, like: 'true', format: :js
       end
 
       it "fires comment_liked! event" do
         Events::CommentLiked.should_receive(:publish!).with(@comment_vote)
-        post :like, id: comment.id, like: 'true'
+        post :like, id: comment.id, like: 'true', format: :js
       end
     end
 
@@ -43,14 +39,13 @@ describe CommentsController do
       end
 
       it "checks permissions" do
-        app_controller.should_receive(:authorize!).and_return(true)
         comment.should_receive(:unlike).with(user) #hack? -PS
-        post :like, id: comment.id, like: 'false'
+        post :like, id: comment.id, like: 'false', format: :js
       end
 
       it "removes like from comment model" do
         comment.should_receive(:unlike).with(user)
-        post :like, id: comment.id, like: 'false'
+        post :like, id: comment.id, like: 'false', format: :js
       end
 
     end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -51,10 +51,7 @@ describe "User abilities" do
     it { should be_able_to(:destroy, user_comment) }
     it { should_not be_able_to(:destroy, discussion) }
     it { should_not be_able_to(:destroy, another_user_comment) }
-    it { should be_able_to(:like, user_comment) }
-    it { should be_able_to(:like, another_user_comment) }
-    it { should be_able_to(:unlike, user_comment) }
-    it { should be_able_to(:unlike, another_user_comment) }
+    it { should be_able_to(:like_comments, discussion) }
     it { should be_able_to(:create, new_discussion) }
     it { should_not be_able_to(:edit_privacy, group) }
     it { should_not be_able_to(:make_admin, @membership) }
@@ -197,8 +194,7 @@ describe "User abilities" do
     it { should_not be_able_to(:unfollow, group) }
     it { should_not be_able_to(:destroy, discussion) }
     it { should_not be_able_to(:destroy, another_user_comment) }
-    it { should_not be_able_to(:like, another_user_comment) }
-    it { should_not be_able_to(:unlike, another_user_comment) }
+    it { should_not be_able_to(:like_comments, discussion) }
     it { should_not be_able_to(:create, new_discussion) }
     it { should_not be_able_to(:create, new_motion) }
     it { should_not be_able_to(:close, motion) }

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -50,6 +50,7 @@ describe Comment do
   context "liked by user" do
     before do
       @like = comment.like user
+      comment.reload
     end
 
     it "increases like count" do


### PR DESCRIPTION
This is the slowest thing according to new relic. This patch inlines comment vote information onto the comment model, saving database lookups.

After migrations run rake upgrade_tasks:reset_comment_likers
