### PR TITLE
Make Comment dependent destroy CommentVote

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -6,7 +6,7 @@ class Comment < ActiveRecord::Base
   belongs_to :discussion, counter_cache: true
   belongs_to :user
 
-  has_many :comment_votes
+  has_many :comment_votes, :dependent => :destroy
   has_many :events, :as => :eventable, :dependent => :destroy
   has_many :attachments
 


### PR DESCRIPTION
**NOTE:**
We'll want to run `rake upgrade_tasks:2013-09_destroy_dangling_comment_votes` after this is deployed
