### PR TITLE
Fix motion closed notifications

### DIFF
--- a/app/views/notifications/_notification.html.haml
+++ b/app/views/notifications/_notification.html.haml
@@ -1,6 +1,6 @@
 - item = NotificationItem.new(notification).item
 - begin
-  - user = item.actor
+  - actor = item.actor
   - action_text = item.action_text
   - title_text = item.title
   - group_name = item.group_full_name
@@ -14,8 +14,8 @@
     %a{:href => href }
       = render 'avatar', user: avatar, size: "medium", kind: nil, id: nil
       %span.notification-content
-        - unless notification.event_kind == "motion_closing_soon" || (notification.event_kind == "motion_closed" && user.nil?)
-          %span.bold-name= user.name
+        - if actor
+          %span.bold-name= actor.name
         = " #{action_text} "
         - if title_text
           %span.bold-name= truncate(title_text, :length => 80, :omission => '...')

--- a/extras/notification_items/motion_closed.rb
+++ b/extras/notification_items/motion_closed.rb
@@ -8,7 +8,7 @@ class NotificationItems::MotionClosed < NotificationItem
   end
 
   def actor
-    @notification.event.eventable.author
+    @notification.event.user
   end
 
   def action_text
@@ -25,7 +25,10 @@ class NotificationItems::MotionClosed < NotificationItem
   end
 
   def avatar
-    return actor if actor
-    @notification.eventable.author
+    if actor
+      actor
+    else
+      @notification.eventable.author
+    end
   end
 end

--- a/extras/notification_items/motion_closing_soon.rb
+++ b/extras/notification_items/motion_closing_soon.rb
@@ -11,6 +11,10 @@ class NotificationItems::MotionClosingSoon < NotificationItem
     I18n.t('notifications.motion_closing_soon') + ": "
   end
 
+    def actor
+      nil
+    end
+
   def title
     @notification.eventable.name
   end

--- a/features/notifications/motion_closed.feature
+++ b/features/notifications/motion_closed.feature
@@ -1,0 +1,18 @@
+Feature: User sees notification that a motion has closed
+
+  Background:
+    Given I am logged in
+
+  @javascript
+  Scenario: Motion expired
+    Given I have a proposal which has expired
+    When I visit the dashboard
+    And I click the notifications dropdown
+    Then I should see that the motion expired
+
+  @javascript
+  Scenario: Motion closed
+    Given someone has closed a proposal in a group I belong to
+    When I visit the dashboard
+    And I click the notifications dropdown
+    Then I should see that someone closed the motion

--- a/features/step_definitions/notifications_steps.rb
+++ b/features/step_definitions/notifications_steps.rb
@@ -1,0 +1,27 @@
+Given(/^I have a proposal which has expired$/) do
+  @motion = FactoryGirl.create :motion, author: @user
+  @motion.close_at_date = Date.parse((Time.zone.now - 10.days).to_s)
+  @motion.save
+end
+
+When(/^I click the notifications dropdown$/) do
+  find("#notifications-toggle").click
+end
+
+Then(/^I should see that the motion expired$/) do
+  find("#notifications-container").should have_content(I18n.t('notifications.motion_closed.by_expiry') + ": " + @motion.name)
+end
+
+Given(/^someone has closed a proposal in a group I belong to$/) do
+  @motion = FactoryGirl.create :motion
+  @group = @motion.group
+  @closer = FactoryGirl.create :user
+  @group.add_member!(@closer)
+  @group.add_member!(@user)
+  @motion.close!(@closer)
+end
+
+Then(/^I should see that someone closed the motion$/) do
+  find("#notifications-container").should have_content(@closer.name + " " + I18n.t('notifications.motion_closed.by_user'))
+end
+

--- a/spec/extras/notification_items/comment_liked_spec.rb
+++ b/spec/extras/notification_items/comment_liked_spec.rb
@@ -1,3 +1,5 @@
+require 'spec_helper'
+
 describe NotificationItems::CommentLiked do
   let(:notification) { stub(eventable: eventable) }
   let(:eventable) { stub(:eventable) }

--- a/spec/extras/notification_items/membership_requested_spec.rb
+++ b/spec/extras/notification_items/membership_requested_spec.rb
@@ -1,3 +1,5 @@
+require 'spec_helper'
+
 describe NotificationItems::MembershipRequested do
   let(:notification) { stub(:notification) }
   let(:item) { NotificationItems::MembershipRequested.new(notification) }

--- a/spec/extras/notification_items/motion_blocked_spec.rb
+++ b/spec/extras/notification_items/motion_blocked_spec.rb
@@ -1,3 +1,5 @@
+require 'spec_helper'
+
 describe NotificationItems::MotionBlocked do
   let(:notification) { stub(:notification) }
   let(:item) { NotificationItems::MotionBlocked.new(notification) }

--- a/spec/extras/notification_items/motion_closed_spec.rb
+++ b/spec/extras/notification_items/motion_closed_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+
 describe NotificationItems::MotionClosed do
   let(:notification) { stub(:notification) }
   let(:item) { NotificationItems::MotionClosed.new(notification) }
@@ -27,14 +28,13 @@ describe NotificationItems::MotionClosed do
     before { notification.stub_chain(:event, :user).and_return(nil) }
 
     it "#action_text returns a string" do
-      pending
       item.action_text.should == I18n.t('notifications.motion_closed.by_expiry') + ": "
     end
 
-    #it "#avatar returns the correct user for the notification avatar" do
-      #notification.stub_chain(:eventable, :author).and_return("Peter")
-      #item.avatar.should == notification.eventable.author
-    #end
+    it "#avatar returns the motion author" do
+      notification.stub_chain(:eventable, :author).and_return("Peter")
+      item.avatar.should == notification.eventable.author
+    end
   end
 
   it "#title returns the motion name" do

--- a/spec/extras/notification_items/motion_closing_soon_spec.rb
+++ b/spec/extras/notification_items/motion_closing_soon_spec.rb
@@ -1,11 +1,11 @@
+require 'spec_helper'
+
 describe NotificationItems::MotionClosingSoon do
   let(:notification) { stub(:notification) }
   let(:item) { NotificationItems::MotionClosingSoon.new(notification) }
 
-  it "#actor returns the current user" do
-    user = stub(:user)
-    notification.stub_chain(:eventable, :user).and_return(user)
-    item.actor.should == notification.eventable.user
+  it "#actor returns nil" do
+    item.actor.should == nil
   end
 
   it "#action_text returns a string" do

--- a/spec/extras/notification_items/new_comment_spec.rb
+++ b/spec/extras/notification_items/new_comment_spec.rb
@@ -1,3 +1,5 @@
+require 'spec_helper'
+
 describe NotificationItems::NewComment do
   let(:notification) { stub(:notification) }
   let(:item) { NotificationItems::NewComment.new(notification) }

--- a/spec/extras/notification_items/new_discussion_spec.rb
+++ b/spec/extras/notification_items/new_discussion_spec.rb
@@ -1,3 +1,5 @@
+require 'spec_helper'
+
 describe NotificationItems::NewDiscussion do
   let(:notification) { stub(:notification) }
   let(:item) { NotificationItems::NewDiscussion.new(notification) }

--- a/spec/extras/notification_items/new_motion_spec.rb
+++ b/spec/extras/notification_items/new_motion_spec.rb
@@ -1,3 +1,5 @@
+require 'spec_helper'
+
 describe NotificationItems::NewMotion do
   let(:notification) { stub(:notification) }
   let(:item) { NotificationItems::NewMotion.new(notification) }

--- a/spec/extras/notification_items/new_vote_spec.rb
+++ b/spec/extras/notification_items/new_vote_spec.rb
@@ -1,3 +1,5 @@
+require 'spec_helper'
+
 describe NotificationItems::NewVote do
   let(:notification) { stub(:notification) }
   let(:item) { NotificationItems::NewVote.new(notification) }

--- a/spec/extras/notification_items/user_added_to_group_spec.rb
+++ b/spec/extras/notification_items/user_added_to_group_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+
 describe NotificationItems::UserAddedToGroup do
   let(:notification) { stub(:notification) }
   let(:item) { NotificationItems::UserAddedToGroup.new(notification) }

--- a/spec/extras/notification_items/user_mentioned_spec.rb
+++ b/spec/extras/notification_items/user_mentioned_spec.rb
@@ -1,3 +1,5 @@
+require 'spec_helper'
+
 describe NotificationItems::UserMentioned do
   let(:notification) { stub(eventable: eventable) }
   let(:eventable) { stub(:eventable) }


### PR DESCRIPTION
@robguthrie this fixes the motion_closed notifications that you accidentally broke while you were fixing the notifications.

Not sure if you realised it, but those specs you commented out were actually legitimate failures.

All sorted now though. I've made the notification template a little bit more object-oriented. And also we've now got cukes for the notifications, which I think is going to be a good pattern for us in the future so that we can test all our notification logic in one place.
