### PR TITLE
[READY] Replace contact links with links to form

### DIFF
--- a/app/assets/stylesheets/pages.css.scss
+++ b/app/assets/stylesheets/pages.css.scss
@@ -430,13 +430,18 @@ body.pages.terms_of_service {
 }
 
 .container#contact_message {
+
+  abbr { border-bottom: none; }
+
   h1 {
     font-size: 50px;
     margin-bottom: 40px;
   }
   input[type="email"],
   input[type="text"] {
+    font-size: 1.4em;
     height: 28px;
+    line-height: 1.2;
     margin: 8px 0 10px 0;
     width: 360px;
   }

--- a/app/controllers/contact_messages_controller.rb
+++ b/app/controllers/contact_messages_controller.rb
@@ -18,7 +18,7 @@ class ContactMessagesController < BaseController
       flash[:success] = "Thanks! Someone from our team will get back to you shortly!"
       redirect_to root_path
     else
-      render 'contact_messages/new'
+      render 'new'
     end
   end
 end

--- a/app/views/contact_messages/new.html.haml
+++ b/app/views/contact_messages/new.html.haml
@@ -9,7 +9,7 @@
             = f.input :name, label: "Your name"
             = f.input :email, label: "Your email address"
             = f.input :message, label: "Your message"
-            = f.submit :submit, :value => "Send message", class: 'btn btn-info btn-large'
+            = f.submit :submit, :value => "Send message", class: 'btn btn-info btn-large', data: { disable_with: "Send message" }
         .span5.offset1#direct_contact
-          %p Fill out this form, or just drop us a line at <a href="mailto:contact@loomio.org">contact@loomio.org</a>
+          %p Fill out this form, or send an email to <a href="mailto:contact@loomio.org">contact@loomio.org</a>
           %p If you'd rather speak to someone directly, you can call Ben on +64 21 0232 5433

--- a/app/views/help/_feedback.html.haml
+++ b/app/views/help/_feedback.html.haml
@@ -2,7 +2,7 @@
   %h1= t :"help.get_in_touch"
 .row-fluid
   .span8
-    %p.extra-margin= t :"help.get_in_touch_description_html", link: new_contact_message_path
+    %p.extra-margin= t :"help.get_in_touch_description_html", link: contact_path
 .row-fluid#join-the-community
   %h1= t :"help.join_the_community"
 .row-fluid

--- a/app/views/pages/about.html.haml
+++ b/app/views/pages/about.html.haml
@@ -104,5 +104,5 @@
         .span6
           %h2 Contact
           %h3 Interested? Get in touch!
-          %p If you’d like to find out more about the project, drop us a line at <a href="mailto:contact@loomio.org">contact@loomio.org</a>
+          %p If you’d like to find out more about the project, <a href="#{contact_path}">drop us a line</a>.
           %p If you’d rather speak to someone directly, you can call Ben on +6421 0232 5433.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -431,7 +431,7 @@ en:
       you can use the proposal to get quick input into a decision.</p>
       <p>You can do things like finalise a document, approve an application, or sign-off on a piece of work.</p>
     get_in_touch: "Get in touch"
-    get_in_touch_description_html: "If you have any questions or feedback, fill out this <a href='%{link}'>form</a> or send us an email at <a href='mailto:contact@loomio.org'>contact@loomio.org</a>."
+    get_in_touch_description_html: "If you have any questions or feedback, <a href='%{link}'>drop us a line</a>."
     getting_started: "Getting started"
     getting_started_description: "On the left, the group discusses a topic, exchanging ideas and information. When there’s a decision for the group to make, it comes up on the right."
     getting_the_most: 'Getting the most out of Loomio'


### PR DESCRIPTION
Changed contact information on about page so there is a link to the contact form.
Only found the one instance of a reference to contacting us that didn't already link to the contact form and wasn't payment related (for these instances we are still using accounts@loomio).
Made small language changes to avoid repitition
Small stylistic changes to contact page
