### PR TITLE
[READY to merge] filter new memberships on inbox for new members

### DIFF
--- a/app/models/discussion.rb
+++ b/app/models/discussion.rb
@@ -5,6 +5,7 @@ class Discussion < ActiveRecord::Base
   # default_scope -> {where(is_deleted: false)}
   scope :active_since, lambda {|some_time| where('created_at >= ? or last_comment_at >= ?', some_time, some_time)}
   scope :order_by_latest_comment, order('last_comment_at DESC')
+  scope :last_comment_after, lambda {|time| where('last_comment_at > ?', time)}
 
   validates_presence_of :title, :group, :author
   validates :title, :length => { :maximum => 150 }

--- a/features/inbox.feature
+++ b/features/inbox.feature
@@ -82,3 +82,8 @@ Feature: Inbox
     #And I mark the discussion as hidden
     #And there is more activity on the discussion
     #Then the discussion should not show in inbox
+
+  Scenario: User joins new group and only sees recent activity
+    When I join a group
+    And I visit the inbox
+    Then I should only see that groups recent discussions and current motions

--- a/features/step_definitions/inbox_steps.rb
+++ b/features/step_definitions/inbox_steps.rb
@@ -110,3 +110,18 @@ Then(/^all the discussions in the group should be marked as read$/) do
   sleep(1)
   Queries::VisibleDiscussions.new(user: @user, groups: [@group]).unread.size.should == 0
 end
+
+When(/^I join a group$/) do
+  @group = FactoryGirl.create(:group)
+  @old_discussion = FactoryGirl.create(:discussion, group: @group, created_at: 3.weeks.ago)
+  @motion = FactoryGirl.create(:motion, discussion: @old_discussion)
+  @new_discussion = FactoryGirl.create(:discussion, group: @group, created_at: 2.hours.ago)
+  @group.add_member!(@user)
+end
+
+Then(/^I should only see that groups recent discussions and current motions$/) do
+  page.should_not have_content @old_discussion.title
+  page.should have_content @motion.title
+  page.should have_content @new_discussion.title
+end
+

--- a/spec/extras/inbox_spec.rb
+++ b/spec/extras/inbox_spec.rb
@@ -3,6 +3,8 @@ require 'spec_helper'
 describe Inbox do
   context '#unread_discussions_for(group)' do
     let(:user) {FactoryGirl.create(:user)}
+    let(:group) {FactoryGirl.create(:group)}
+    let(:discussion) {FactoryGirl.create(:discussion, group: group)}
 
     subject do
       inbox = Inbox.new(user)
@@ -10,5 +12,4 @@ describe Inbox do
       inbox
     end
   end
-
 end


### PR DESCRIPTION
this feature is to address the experience of a new user joining a group and being overwhelmed by a massive unread count in their inbox for that group.

it modifies the inbox so that only comments up to 1 week before the member joined are counted towards the inbox
