### PR TITLE
[ready to merge] Dark-grey group names, 'Clear' bottom alignment

### DIFF
--- a/app/assets/stylesheets/inbox.css.scss
+++ b/app/assets/stylesheets/inbox.css.scss
@@ -25,13 +25,16 @@
 .inbox-group {
   h3 {
     margin: 0.7em 0 0.3em 0;
+    a {
+      color: $dark-grey;
+    }
   }
   .mark-all-as-read {
     a{
       margin-right: .9em;
     }
     text-align: right;
-    margin-top: 1.84em;
+    margin-top: 1.2em;
   }
 }
 


### PR DESCRIPTION
looks like this:
![image](https://f.cloud.github.com/assets/1380991/1435318/66486706-413b-11e3-8022-c0ea829c6671.png)
