### PR TITLE
[READY] add event sequence id to identify sequence within discussions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,7 @@ gem 'roadie', '~> 2.4.1'
 gem 'valid_email', '~> 0.0.4'
 gem 'font-awesome-sass-rails'
 gem 'rabl'
+gem 'sequenced'
 
 # Gems used only for assets and not required
 # in production environments by default.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -401,6 +401,9 @@ GEM
       multi_json (~> 1.0)
       rubyzip (< 1.0.0)
       websocket (~> 1.0.4)
+    sequenced (1.4.0)
+      activerecord (>= 3.0)
+      activesupport (>= 3.0)
     shoulda-matchers (2.3.0)
       activesupport (>= 3.0.0)
     simple_form (2.1.0)
@@ -550,6 +553,7 @@ DEPENDENCIES
   ruby-prof
   sass-rails
   selenium-webdriver (~> 2.35.1)
+  sequenced
   shoulda-matchers (~> 2.3.0)
   simple_form (~> 2.1.0)
   spork-rails (~> 3.2.1)

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -9,18 +9,13 @@ class CommentsController < BaseController
 
   def like
     @comment = Comment.find(params[:id])
-    if can? :like_comments, @comment.discussion
-      like = (params[:like]=='true')
-      if like
-        comment_vote = @comment.like current_user
-        Events::CommentLiked.publish!(comment_vote)
-      else
-        @comment.unlike current_user
-        @comment.reload
-      end
-      render :template => "comments/comment_likes"
+
+    if params[:like] == 'true'
+      DiscussionService.like_comment(current_user, @comment)
     else
-      head :bad_request
+      DiscussionService.unlike_comment(current_user, @comment)
     end
+
+    render :template => "comments/comment_likes"
   end
 end

--- a/app/controllers/discussions_controller.rb
+++ b/app/controllers/discussions_controller.rb
@@ -1,6 +1,6 @@
 class DiscussionsController < GroupBaseController
   include DiscussionsHelper
-  load_and_authorize_resource :except => [:new, :create, :index]
+  load_and_authorize_resource :except => [:new, :create, :index, :add_comment]
   before_filter :authenticate_user!, :except => [:show, :index]
   after_filter :mark_as_read, only: :show
 
@@ -106,17 +106,13 @@ class DiscussionsController < GroupBaseController
   end
 
   def add_comment
-    if params[:comment].present? || params[:attachments].present?
-      @discussion = Discussion.find(params[:id])
-      @comment = @discussion.add_comment(current_user, params[:comment],
-                                         uses_markdown: params[:uses_markdown], attachments: params[:attachments])
+    @discussion = Discussion.find params[:id]
+    build_comment
+    if DiscussionService.add_comment(@comment)
       current_user.update_attributes(uses_markdown: params[:uses_markdown])
       @discussion.as_read_by(current_user).viewed!
-      unless request.xhr?
-        redirect_to @discussion
-      end
     else
-      head :ok
+      head :ok and return
     end
   end
 
@@ -174,6 +170,18 @@ class DiscussionsController < GroupBaseController
   end
 
   private
+  def build_comment
+    @comment = Comment.new(body: params[:comment],
+                           uses_markdown: params[:uses_markdown])
+
+    attachment_ids = Array(params[:attachment_ids]).map(&:to_i)
+
+    @comment.discussion = @discussion
+    @comment.author = current_user
+    @comment.attachment_ids = attachment_ids
+    @comment.attachments_count = attachment_ids.size
+    @comment
+  end
 
   def mark_as_read
     if @reader and @activity and @activity.last

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -15,9 +15,6 @@ class Comment < ActiveRecord::Base
   validate :attachments_owned_by_author
 
   after_initialize :set_defaults
-  after_create :update_discussion_last_comment_at
-  after_create :fire_new_comment_event
-
   default_scope include: :user
 
   delegate :name, :to => :user, :prefix => :user
@@ -30,6 +27,7 @@ class Comment < ActiveRecord::Base
   serialize :liker_ids_and_names, Hash
 
   alias_method :author, :user
+  alias_method :author=, :user=
 
   # Helper class method that allows you to build a comment
   # by passing a discussion object, a user_id, and comment text
@@ -97,16 +95,6 @@ class Comment < ActiveRecord::Base
     def has_body_or_attachment
       if body.blank? && attachments.blank?
         errors.add(:body, "Comment cannot be empty")
-      end
-    end
-
-    def fire_new_comment_event
-      Events::NewComment.publish!(self)
-    end
-
-    def update_discussion_last_comment_at
-      if discussion.present?
-        discussion.update_attribute(:last_comment_at, created_at)
       end
     end
 end

--- a/app/models/discussion.rb
+++ b/app/models/discussion.rb
@@ -46,12 +46,13 @@ class Discussion < ActiveRecord::Base
     end
   end
 
-  def add_comment(user, comment, options={} )
-    if user.can?(:add_comment, self)
-      comment = Comment.build_from self, user, comment, options
-      comment.save!
-      comment
-    end
+  def add_comment(author, body, options = {})
+    options[:body] = body
+    comment = Comment.new(options)
+    comment.author = author
+    comment.discussion = self
+    DiscussionService.add_comment(comment)
+    comment
   end
 
   def voting_motions

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -4,13 +4,16 @@ class Event < ActiveRecord::Base
              motion_closing_soon motion_closed membership_requested invitation_accepted
              user_added_to_group membership_request_approved comment_liked user_mentioned]
 
-  has_many :notifications, :dependent => :destroy
-  belongs_to :eventable, :polymorphic => true
+  has_many :notifications, dependent: :destroy
+  belongs_to :eventable, polymorphic: true
   belongs_to :discussion, counter_cache: :items_count
   belongs_to :user
 
   validates_inclusion_of :kind, :in => KINDS
   validates_presence_of :eventable
+
+  acts_as_sequenced scope: :discussion_id, column: :sequence_id, skip: lambda {|e| e.discussion.nil? }
+
 
   def notify!(user)
     notifications.create!(user: user)

--- a/app/models/events/new_comment.rb
+++ b/app/models/events/new_comment.rb
@@ -2,7 +2,7 @@ class Events::NewComment < Event
   after_create :notify_users!
 
   def self.publish!(comment)
-    create!(:kind => "new_comment", 
+    create!(:kind => "new_comment",
             :eventable => comment,
             :discussion_id => comment.discussion.id)
   end

--- a/app/services/discussion_service.rb
+++ b/app/services/discussion_service.rb
@@ -1,0 +1,27 @@
+class DiscussionService
+  def self.unlike_comment(user, comment)
+    comment.unlike(user)
+  end
+
+  def self.like_comment(user, comment)
+    user.ability.can?(:like_comments, comment.discussion)
+    comment_vote = comment.like(user)
+    Events::CommentLiked.publish!(comment_vote)
+  end
+
+  def self.add_comment(user_or_comment, comment = nil)
+    if comment.nil?
+      comment = user_or_comment
+      author = comment.author
+    else
+      author = user_or_comment
+    end
+
+    author.ability.authorize! :add_comment, comment.discussion
+    return false unless comment.save
+
+    event = Events::NewComment.publish!(comment)
+    comment.discussion.update_attribute(:last_comment_at, comment.created_at)
+    event
+  end
+end

--- a/db/migrate/20131029013350_add_discussion_item_number_to_events.rb
+++ b/db/migrate/20131029013350_add_discussion_item_number_to_events.rb
@@ -1,0 +1,6 @@
+class AddDiscussionItemNumberToEvents < ActiveRecord::Migration
+  def change
+    add_column :events, :sequence_id, :integer, default: nil, null: true
+    add_index :events, [:discussion_id, :sequence_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20131024030111) do
+ActiveRecord::Schema.define(:version => 20131029013350) do
 
   create_table "active_admin_comments", :force => true do |t|
     t.string   "resource_id",   :null => false
@@ -237,9 +237,11 @@ ActiveRecord::Schema.define(:version => 20131024030111) do
     t.string   "eventable_type"
     t.integer  "user_id"
     t.integer  "discussion_id"
+    t.integer  "sequence_id"
   end
 
   add_index "events", ["created_at"], :name => "index_events_on_created_at"
+  add_index "events", ["discussion_id", "sequence_id"], :name => "index_events_on_discussion_id_and_sequence_id", :unique => true
   add_index "events", ["discussion_id"], :name => "index_events_on_discussion_id"
   add_index "events", ["eventable_type", "eventable_id"], :name => "index_events_on_eventable_type_and_eventable_id"
 

--- a/features/step_definitions/comment_delete_steps.rb
+++ b/features/step_definitions/comment_delete_steps.rb
@@ -1,7 +1,10 @@
 Given(/^the discussion has a comment$/) do
   @commenter = FactoryGirl.create :user
   @group.add_member! @commenter
-  @discussion.add_comment @commenter, "post to be deleted", uses_markdown: false
+  @comment = Comment.new(body: 'post to be deleted')
+  @comment.author = @commenter
+  @comment.discussion = @discussion
+  DiscussionService.add_comment(@comment)
 end
 
 When /^I click the delete button on a post$/ do

--- a/features/step_definitions/discussion_pagination_steps.rb
+++ b/features/step_definitions/discussion_pagination_steps.rb
@@ -1,6 +1,9 @@
 Given(/^a discussion has over (\d+) posts$/) do |arg1|
   51.times do
-    FactoryGirl.create(:comment, discussion: @discussion, user: @user)
+    comment = Comment.new(body: 'hi')
+    comment.author = @user
+    comment.discussion = @discussion
+    DiscussionService.add_comment(comment)
   end
 end
 

--- a/features/step_definitions/inbox_steps.rb
+++ b/features/step_definitions/inbox_steps.rb
@@ -90,7 +90,10 @@ end
 Given(/^I have read the discussion but there is a new comment$/) do
   @discussion.as_read_by(@user).viewed!
   @discussion.group.add_member!(@discussion.author)
-  @discussion.add_comment(@discussion.author, 'hi')
+  @comment = Comment.new(body: 'hi')
+  @comment.author = @user
+  @comment.discussion = @discussion
+  DiscussionService.add_comment(@comment)
 end
 
 Given(/^I belong to a group with more than max per inbox group discussions$/) do

--- a/features/step_definitions/mention_user_steps.rb
+++ b/features/step_definitions/mention_user_steps.rb
@@ -18,7 +18,10 @@ When /^I click on "(.*?)" in the menu that pops up$/ do |arg1|
 end
 
 When /^a comment exists mentioning "(.*?)"$/ do |text|
-  @discussion.add_comment @user, "Hey #{text}", uses_markdown: false
+  @comment = Comment.new(body: "Hey #{text}")
+  @comment.author = @user
+  @comment.discussion = @discussion
+  DiscussionService.add_comment(@comment)
 end
 
 When /^I submit a comment mentioning "(.*?)"$/ do |mention|

--- a/features/step_definitions/see_number_of_new_comments_steps.rb
+++ b/features/step_definitions/see_number_of_new_comments_steps.rb
@@ -1,7 +1,10 @@
 Given /^someone comments on the discussion$/ do
   @commenter = FactoryGirl.create :user
   @group.add_member! @commenter
-  @discussion.add_comment @commenter, "hey there", uses_markdown: false
+  @comment = Comment.new(body: "hey there")
+  @comment.author = @commenter
+  @comment.discussion = @discussion
+  DiscussionService.add_comment(@comment)
 end
 
 When /^I visit the dashboard$/ do

--- a/features/step_definitions/view_chronological_disucssion_steps.rb
+++ b/features/step_definitions/view_chronological_disucssion_steps.rb
@@ -5,8 +5,15 @@ end
 Given(/^there are two comments$/) do
   @commenter = FactoryGirl.create :user
   @group.add_member! @commenter
-  @first_comment = @discussion.add_comment @commenter, "old comment", uses_markdown: false
-  @second_comment = @discussion.add_comment @commenter, "new comment", uses_markdown: false
+  @first_comment = Comment.new(body: 'old comment')
+  @first_comment.author = @commenter
+  @first_comment.discussion = @discussion
+  @second_comment = Comment.new(body: 'new comment')
+  @second_comment.author = @commenter
+  @second_comment.discussion = @discussion
+  DiscussionService.add_comment @first_comment
+  DiscussionService.add_comment @second_comment
+
   @discussion.reload
 end
 
@@ -21,20 +28,11 @@ Given(/^there is a discussion that I have previously viewed$/) do
   reader.viewed!
 end
 
-Given(/^I have previously viewed the second page of the discussion$/) do
-  reader = @discussion.as_read_by(@user)
-  reader.viewed!
-end
 
 Given(/^there has been new activity$/) do
   @third_comment = @discussion.add_comment @commenter, "newest comment", uses_markdown: false
 end
 
-Given(/^now there is new activity$/) do
-  10.times do
-    FactoryGirl.create(:comment, discussion: @discussion, user: @commenter)
-  end
-end
 
 Then(/^I should not see the new activity indicator$/) do
   page.should_not have_css(".dog-ear")
@@ -48,11 +46,28 @@ Given(/^there is a two page discussion$/) do
   @commenter = FactoryGirl.create :user
   @group.add_member! @commenter
   60.times do
-    FactoryGirl.create(:comment, discussion: @discussion, user: @commenter)
+    comment = Comment.new(body: 'yo wassup')
+    comment.author = @commenter
+    comment.discussion = @discussion
+    DiscussionService.add_comment(comment)
+  end
+end
+
+Given(/^I have previously viewed the second page of the discussion$/) do
+  @discussion.reload
+  reader = @discussion.as_read_by(@user)
+  reader.viewed!
+end
+
+Given(/^now there is new activity$/) do
+  10.times do
+    comment = FactoryGirl.build(:comment, discussion: @discussion, user: @commenter)
+    DiscussionService.add_comment(comment)
   end
 end
 
 Then(/^I should see the second page$/) do
+  view_screenshot
   find(".pagination > ul li:nth-child(3).active")
 end
 

--- a/lib/tasks/upgrade_tasks.rake
+++ b/lib/tasks/upgrade_tasks.rake
@@ -1,4 +1,18 @@
 namespace :upgrade_tasks do
+  task :'2013-10-add-discussion-item-number' => :environment do
+    ActiveRecord::Base.record_timestamps = false
+    begin
+      Discussion.find_each do |d|
+        d.items.order('created_at asc').each do |event|
+          event.save
+        end
+        puts d.id if (d.id % 100) == 0
+      end
+    ensure
+      ActiveRecord::Base.record_timestamps = true  # don't forget to enable it again!
+    end
+  end
+
   task :'2013-10-part2-update_item_counts_post_counter_caches' => :environment do
     puts 'Updating discussions.items_count'
     Discussion.find_each do |d|

--- a/spec/controllers/discussions_controller_spec.rb
+++ b/spec/controllers/discussions_controller_spec.rb
@@ -111,60 +111,29 @@ describe DiscussionsController do
       end
     end
 
-    describe "adding a comment" do
+    describe "add_comment" do
+      let(:comment) { double(:comment).as_null_object }
       before do
+        Discussion.stub(:find).and_return(discussion)
+        DiscussionService.stub(:add_comment)
         Event.stub(:new_comment!)
-        @comment = mock_model(Comment, :valid? => true)
-        discussion.stub(add_comment: @comment)
+        Comment.stub(:new).and_return(comment)
       end
 
-      context 'without any text' do
+      context 'invalid comment' do
         it 'does not add a comment' do
-          discussion.should_not_receive(:add_comment)
+          DiscussionService.should_receive(:add_comment).and_return(false)
+          user.should_not_receive(:update_attributes)
           xhr :post, :add_comment, comment: "", id: discussion.id, uses_markdown: false
         end
-
-        it 'returns head :ok' do
-          controller.should_receive(:head).with(:ok)
-          xhr :post, :add_comment, comment: "", id: discussion.id, uses_markdown: false
-        end
-
       end
 
-      context 'without text, but with an attachment' do
+      context 'valid comment' do
         it 'adds a comment' do
-          discussion.should_receive(:add_comment)
-          xhr :post, :add_comment, comment: "", id: discussion.id, uses_markdown: false, attachments: 2
-        end
-      end
-
-      context 'javascript has failed' do
-        it 'redirects to discussion' do
-          post :add_comment, comment: "Hello!", id: discussion.id, uses_markdown: false
-          response.should redirect_to discussion
-        end
-      end
-
-      it "checks permissions" do
-        app_controller.should_receive(:authorize!).and_return(true)
-        xhr :post, :add_comment, comment: "Hello!", id: discussion.id, uses_markdown: false
-      end
-
-      it "calls add_comment on discussion" do
-        uses_markdown = false
-        discussion.should_receive(:add_comment).with(user, "Hello!", uses_markdown: uses_markdown, attachments: nil)
-        xhr :post, :add_comment, comment: "Hello!", id: discussion.id, uses_markdown: uses_markdown
-      end
-
-      context "unsuccessfully" do
-        before do
-          discussion.stub(:add_comment).
-            and_return(mock_model(Comment, :valid? => false))
-        end
-
-        it "does not fire new_comment event" do
-          Event.should_not_receive(:new_comment!)
-          xhr :post, :add_comment, comment: "Hello!", id: discussion.id, global_uses_markdown: false
+          DiscussionService.should_receive(:add_comment).
+            with(comment).and_return(true)
+          user.should_receive(:update_attributes)
+          xhr :post, :add_comment, comment: "", id: discussion.id, uses_markdown: false, attachments: [2]
         end
       end
     end

--- a/spec/controllers/groups_controller_spec.rb
+++ b/spec/controllers/groups_controller_spec.rb
@@ -41,7 +41,7 @@ describe GroupsController do
       response.should be_success
     end
 
-    it "create subgroup", focus: true do
+    it "create subgroup" do
       post :create, :group => {parent_id: group.id, name: 'subgroup'}
       assigns(:group).parent.should eq(group)
       assigns(:group).admins.should include(user)

--- a/spec/controllers/votes_controller_spec.rb
+++ b/spec/controllers/votes_controller_spec.rb
@@ -18,7 +18,7 @@ describe VotesController do
 
     context 'proposal is open' do
 
-      describe "casting a vote", focus: true do
+      describe "casting a vote" do
         it 'redirects to previous url' do
           post :create, @vote_args
           response.should redirect_to(@previous_url)

--- a/spec/extras/collects_recent_activity_by_group_spec.rb
+++ b/spec/extras/collects_recent_activity_by_group_spec.rb
@@ -36,7 +36,10 @@ describe CollectsRecentActivityByGroup do
           @discussion = FactoryGirl.create :discussion,
                                           {group: group, created_at: 2.days.ago} 
           
-          @discussion.add_comment(@discussion.author, 'hi')
+          @comment = Comment.new(body: 'hi')
+          @comment.author = @discussion.author
+          @comment.discussion = @discussion
+          DiscussionService.add_comment(@comment)
         end
         it 'returns the discussion' do
           recent_activity[group.full_name][:discussions].should include @discussion

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -9,7 +9,7 @@ describe "User abilities" do
   let(:ability) { Ability.new(user) }
   subject { ability }
 
-  context "Loomio admin deactivates other_user", focus: true do
+  context "Loomio admin deactivates other_user" do
     before do
       user.is_admin = true
     end
@@ -40,8 +40,8 @@ describe "User abilities" do
     let(:discussion) { create(:discussion, group: group) }
     let(:new_discussion) { user.authored_discussions.new(
                            group: group, title: "new discussion") }
-    let(:user_comment) { discussion.add_comment(user, "hello", uses_markdown: false) }
-    let(:another_user_comment) { discussion.add_comment(other_user, "hello", uses_markdown: false) }
+    let(:user_comment) { discussion.add_comment(user, "hello") }
+    let(:another_user_comment) { discussion.add_comment(other_user, "hello") }
     let(:user_motion) { create(:motion, author: user, discussion: discussion) }
     let(:other_users_motion) { create(:motion, author: other_user, discussion: discussion) }
     let(:new_motion) { Motion.new(discussion_id: discussion.id) }

--- a/spec/models/discussion_reader_spec.rb
+++ b/spec/models/discussion_reader_spec.rb
@@ -56,7 +56,7 @@ describe DiscussionReader do
       it {should == 1}
     end
 
-    context '2 read, 1 unread', focus: true do
+    context '2 read, 1 unread' do
       before do
         discussion.add_comment(other_user, 'hi')
         discussion.add_comment(other_user, 'hi')

--- a/spec/models/discussion_spec.rb
+++ b/spec/models/discussion_spec.rb
@@ -29,12 +29,6 @@ describe Discussion do
     discussion.comments.should include(comment)
   end
 
-  it "group non-member cannot add comment" do
-    discussion = create(:discussion)
-    comment = discussion.add_comment(create(:user), "this is a test comment", uses_markdown: false)
-    discussion.comments.should_not include(comment)
-  end
-
   it "automatically populates last_comment_at with discussion.created at" do
     discussion = create(:discussion)
     discussion.last_comment_at.should == discussion.created_at

--- a/spec/services/discussion_service_spec.rb
+++ b/spec/services/discussion_service_spec.rb
@@ -1,0 +1,112 @@
+require_relative '../../app/services/discussion_service'
+
+module Events
+  class NewComment
+  end
+  class CommentLiked
+  end
+end
+
+describe 'DiscussionService' do
+  let(:comment_vote) { double(:comment_vote) }
+  let(:ability) { double(:ability, :authorize! => true) }
+  let(:user) { double(:user, ability: ability) }
+  let(:comment) { double(:comment,
+                         save: true,
+                         'author=' => nil,
+                         created_at: :a_time,
+                         discussion: discussion,
+                         author: user) }
+
+
+  let(:discussion) { double(:discussion, update_attribute: true) }
+  let(:event) { double(:event) }
+
+  describe 'unlike_comment' do
+    after do
+      DiscussionService.unlike_comment(user, comment)
+    end
+
+    it 'calls unlike on the comment' do
+      comment.should_receive(:unlike).with(user)
+    end
+  end
+
+  describe 'like_comment' do
+    before do
+      Events::CommentLiked.stub(:publish!)
+      ability.stub(:can?)
+      comment.stub(:like).and_return(comment_vote)
+    end
+
+    after do
+      DiscussionService.like_comment(user, comment)
+    end
+
+    it 'checks the user can like the comment' do
+      ability.should_receive(:can?).with(:like_comments, discussion)
+    end
+
+    it 'creates a comment vote' do
+      comment.should_receive(:like).with(user).and_return(comment_vote)
+    end
+
+    it 'publishes a like comment event' do
+      Events::CommentLiked.should_receive(:publish!).with(comment_vote)
+    end
+  end
+
+  describe 'add_comment' do
+    before do
+      Events::NewComment.stub(:publish!).and_return(event)
+    end
+
+    after do
+      DiscussionService.add_comment(comment)
+    end
+
+    it 'authorizes that the user can add the comment' do
+      ability.should_receive(:authorize!).with(:add_comment, discussion)
+    end
+
+    it 'saves the comment' do
+      comment.should_receive(:save).and_return(true)
+    end
+
+    context 'comment is valid' do
+      before do
+        comment.stub(:save).and_return(true)
+      end
+
+      it 'fires a NewComment event' do
+        Events::NewComment.should_receive(:publish!).with(comment)
+      end
+
+      it 'updates discussion last_comment_at' do
+        discussion.should_receive(:update_attribute).with(:last_comment_at, comment.created_at)
+      end
+
+      it 'returns the event created' do
+        DiscussionService.add_comment(comment).should == event
+      end
+    end
+
+    context 'comment is invalid' do
+      before do
+        comment.stub(:save).and_return(false)
+      end
+
+      it 'returns false' do
+        DiscussionService.add_comment(comment).should == false
+      end
+
+      it 'does not create new comment event' do
+        Events::NewComment.should_not_receive(:publish!)
+      end
+
+      it 'does not update discussion' do
+        discussion.should_not_receive(:update_attribute)
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### Note: after this is merged we need to run the data migration rake task

:white_check_mark: :  **CR** 

:white_check_mark:  : **QA** 

> :white_check_mark: pull down locally, check app loads
> 
> _test core functionality of feature:_
> :white_check_mark: liking
> :white_check_mark: unliking
> 
> _interact with everything in proximity of the core feature:_
> :white_check_mark: posting comments
> :white_check_mark: edit discussion title
> :white_check_mark: start new discussion  
> 
> :white_check_mark: logged out functionality
> :ok: public/ private functionality- NA
> 
> :ok: test in IE 8,9 - no changes relevant to IE
> :ok: test in production environment - NA

---

:white_check_mark: : **CO signoff** 
:ok: : **DO signoff** - nothing changed in interface

:question: : **PO signoff**

---

useful symbols :white_check_mark: :ok: :x: :question: 
