### PR TITLE
change length of title span

### DIFF
--- a/app/views/groups/_title.html.haml
+++ b/app/views/groups/_title.html.haml
@@ -1,7 +1,7 @@
 .group-title
   .row
     - if group
-      .span10
+      .span9
         %h1.home-title
           = link_to t(:home), "/"
           = content_tag :span, "\u25B6", class: 'name-separator'


### PR DESCRIPTION
Title on group page is overflowing.
Pivitol ticket #1105 
