### PR TITLE
[QA failed] play nicely if we get a old post request when adding comment

### DIFF
--- a/app/controllers/discussions_controller.rb
+++ b/app/controllers/discussions_controller.rb
@@ -103,11 +103,25 @@ class DiscussionsController < GroupBaseController
   def add_comment
     @discussion = Discussion.find params[:id]
     build_comment
-    if DiscussionService.add_comment(@comment)
-      current_user.update_attributes(uses_markdown: params[:uses_markdown])
-      @discussion.as_read_by(current_user).viewed!
+
+    if success = DiscussionService.add_comment(@comment)
+      # great
     else
-      head :ok and return
+      flash[:error] = "Failed to add your comment"
+    end
+
+    respond_to do |format|
+      # render js response, or head :ok if failed to add comment
+      format.js do
+        if success
+          render
+        else
+          head :ok
+        end
+      end
+
+      # if javascript disabled or failed, this will redirect to discussion
+      format.html { redirect_to @discussion }
     end
   end
 

--- a/app/services/discussion_service.rb
+++ b/app/services/discussion_service.rb
@@ -22,6 +22,8 @@ class DiscussionService
 
     event = Events::NewComment.publish!(comment)
     comment.discussion.update_attribute(:last_comment_at, comment.created_at)
+    author.update_attribute(:uses_markdown, comment.uses_markdown)
+    comment.discussion.as_read_by(author).viewed!
     event
   end
 
@@ -31,7 +33,7 @@ class DiscussionService
 
     return false unless discussion.save
 
-    user.update_attributes(uses_markdown: discussion.uses_markdown)
+    user.update_attribute(:uses_markdown, discussion.uses_markdown)
     Events::NewDiscussion.publish!(discussion)
   end
 

--- a/features/step_definitions/discussion_pagination_steps.rb
+++ b/features/step_definitions/discussion_pagination_steps.rb
@@ -1,8 +1,6 @@
 Given(/^a discussion has over (\d+) posts$/) do |arg1|
   51.times do
-    comment = Comment.new(body: 'hi')
-    comment.author = @user
-    comment.discussion = @discussion
+    comment = FactoryGirl.build(:comment, discussion: @discussion)
     DiscussionService.add_comment(comment)
   end
 end

--- a/features/step_definitions/inbox_steps.rb
+++ b/features/step_definitions/inbox_steps.rb
@@ -90,9 +90,7 @@ end
 Given(/^I have read the discussion but there is a new comment$/) do
   @discussion.as_read_by(@user).viewed!
   @discussion.group.add_member!(@discussion.author)
-  @comment = Comment.new(body: 'hi')
-  @comment.author = @user
-  @comment.discussion = @discussion
+  @comment = FactoryGirl.build(:comment, discussion: @discussion)
   DiscussionService.add_comment(@comment)
 end
 

--- a/spec/controllers/discussions_controller_spec.rb
+++ b/spec/controllers/discussions_controller_spec.rb
@@ -134,7 +134,6 @@ describe DiscussionsController do
         it 'adds a comment' do
           DiscussionService.should_receive(:add_comment).
             with(comment).and_return(true)
-          user.should_receive(:update_attributes)
           xhr :post, :add_comment, comment: "", id: discussion.id, uses_markdown: false, attachments: [2]
         end
       end

--- a/spec/services/discussion_service_spec.rb
+++ b/spec/services/discussion_service_spec.rb
@@ -12,9 +12,11 @@ end
 describe 'DiscussionService' do
   let(:comment_vote) { double(:comment_vote) }
   let(:ability) { double(:ability, :authorize! => true) }
-  let(:user) { double(:user, ability: ability, update_attributes: true) }
+  let(:user) { double(:user, ability: ability, update_attribute: true) }
+  let(:discussion_reader) { double(:discussion_reader, :viewed! => :viewed) }
   let(:discussion) { double(:discussion, author: user,
                                          save: true,
+                                         as_read_by: discussion_reader,
                                          uses_markdown: true,
                                          update_attribute: true,
                                          update_attributes: true,
@@ -23,6 +25,7 @@ describe 'DiscussionService' do
                          save: true,
                          'author=' => nil,
                          created_at: :a_time,
+                         uses_markdown: true,
                          discussion: discussion,
                          author: user) }
   let(:event) { double(:event) }
@@ -97,6 +100,14 @@ describe 'DiscussionService' do
         discussion.should_receive(:update_attribute).with(:last_comment_at, comment.created_at)
       end
 
+      it 'updates user uses_markdown' do
+        user.should_receive(:update_attribute).with(:uses_markdown, comment.uses_markdown)
+      end
+
+      it 'marks the discussion as viewed by the user' do
+        discussion_reader.should_receive(:viewed!)
+      end
+
       it 'returns the event created' do
         DiscussionService.add_comment(comment).should == event
       end
@@ -136,7 +147,7 @@ describe 'DiscussionService' do
       before { discussion.stub(:save).and_return(true) }
 
       it 'updates user markdown-preference' do
-        user.should_receive(:update_attributes).with(uses_markdown: discussion.uses_markdown).and_return(true)
+        user.should_receive(:update_attribute).with(:uses_markdown, discussion.uses_markdown).and_return(true)
         DiscussionService.start_discussion(discussion)
       end
 


### PR DESCRIPTION
**CR** : :white_check_mark: 

**QA** : :x:

> _test core functionality of feature:_
> :white_check_mark: comment in a discussion
> :white_check_mark: posted with JS disabled
> :x: when DiscussionService fails, page doesn't reload, so no flash..... user won't know what happened
> 
> _test functionality adjacent to this feature:_
> :question: - can't think of any relevant...
> 
> :ok: logged out functionality - NA
> 
> :question: test in IE 8,9 
> :ok: test in production environment - NA I hope 

**CO signoff** : :question:
**DO signoff** : :question:

**PO signoff** : :question:

---

useful symbols :white_check_mark: :ok: :x: :question: 
