### PR TITLE
[needs QA] fix client side validation - edit group descreption

### DIFF
--- a/app/assets/javascripts/validations.js.coffee
+++ b/app/assets/javascripts/validations.js.coffee
@@ -12,7 +12,7 @@ $ -> # Remove error class on field if not empty
     hidePresenceErrorMessageFor($(this))
 
 $ -> # Character counter for limiting input
-  $(".validate-length").keyup () ->
+  $(".validate-length").bind 'input propertychange', ->
     $(".error-message").hide()
     max = 250 if $(this).hasClass('limit-250')
     max = 150 if $(this).hasClass('limit-150')

--- a/app/views/groups/edit_description.js.erb
+++ b/app/views/groups/edit_description.js.erb
@@ -1,4 +1,3 @@
-var description = $("#description-input").val()
 $(".long-description").html("<%= j render_rich_text(@description, false) %>")
 $(".description-body").show()
 $("#description-edit-form").hide()


### PR DESCRIPTION
**CR** : :white_check_mark:

**QA** : :question:

we've fixed client side validation. problem was right-click to paste not triggering character counter update.

**NOTE:** server-side there is a validation, but the _edit_description_ action in `group_controller` doesn't catch a failed save. this fix doesn't address that, but makes it very unlikely that a user could reach that point
