### PR TITLE
[ready for signoff] Close motions reliably. Depends on VotesController rebuild and proposal-outcome. Needs QA

### DIFF
--- a/app/controllers/motions_controller.rb
+++ b/app/controllers/motions_controller.rb
@@ -60,8 +60,7 @@ class MotionsController < GroupBaseController
   end
 
   def close
-    resource
-    @motion.close! current_user
+    MotionService.close(@motion, current_user)
     redirect_to discussion_url(@motion.discussion, proposal: @motion)
   end
 

--- a/app/controllers/votes_controller.rb
+++ b/app/controllers/votes_controller.rb
@@ -3,7 +3,7 @@ class VotesController < BaseController
 
   def new
     @vote = motion.most_recent_vote_of(current_user) || Vote.new
-    @vote.position = params[:position]
+    @vote.position = params[:position] if params[:position]
   end
 
   def create

--- a/app/models/discussion.rb
+++ b/app/models/discussion.rb
@@ -71,11 +71,7 @@ class Discussion < ActiveRecord::Base
   end
 
   def current_motion
-    motion = voting_motions.last
-    if motion
-      motion.close_if_expired
-      motion if motion.voting?
-    end
+    voting_motions.last
   end
 
   def number_of_comments_since(time)

--- a/app/services/motion_service.rb
+++ b/app/services/motion_service.rb
@@ -1,4 +1,22 @@
 class MotionService
+  def self.close_all_lapsed_motions
+    Motion.lapsed_but_not_closed.each do |motion|
+      close(motion)
+    end
+  end
+
+  def self.close(motion, user = nil)
+    # this line is required because motions are not being
+    # archived when groups get archived so they dangle
+    # TODO ensure that motions get archived with groups
+    return false unless motion.group.present?
+
+    motion.store_users_that_didnt_vote
+    motion.closed_at = Time.now
+    motion.save!
+    Events::MotionClosed.publish!(motion, user)
+  end
+
   def self.create_outcome(motion, motion_params, user)
     user.ability.authorize! :create_outcome, motion
 

--- a/features/motions/close_elapsed_motions.feature
+++ b/features/motions/close_elapsed_motions.feature
@@ -1,0 +1,9 @@
+Feature: Close lapsed motions
+  As a computer running loomio
+  In order to close motions at the time they are scheduled to close
+  I close lapsed motions
+
+  Scenario:
+    Given there is an unclosed motion with closing_at in the past
+    When I close lapsed motions
+    Then the motion should be closed

--- a/features/step_definitions/close_elapsed_motions_steps.rb
+++ b/features/step_definitions/close_elapsed_motions_steps.rb
@@ -1,0 +1,14 @@
+Given(/^there is an unclosed motion with closing_at in the past$/) do
+  @motion = FactoryGirl.create :motion, close_at_date: Date.yesterday, close_at_time: '00:00'
+  @motion.closed?.should be_false
+  @motion.voting?.should be_true
+end
+
+When(/^I close lapsed motions$/) do
+  MotionService.close_all_lapsed_motions
+end
+
+Then(/^the motion should be closed$/) do
+  @motion.reload
+  @motion.closed?.should be_true
+end

--- a/features/step_definitions/notifications_steps.rb
+++ b/features/step_definitions/notifications_steps.rb
@@ -2,6 +2,7 @@ Given(/^I have a proposal which has expired$/) do
   @motion = FactoryGirl.create :motion, author: @user
   @motion.close_at_date = Date.parse((Time.zone.now - 10.days).to_s)
   @motion.save
+  MotionService.close_all_lapsed_motions
 end
 
 When(/^I click the notifications dropdown$/) do
@@ -18,7 +19,7 @@ Given(/^someone has closed a proposal in a group I belong to$/) do
   @closer = FactoryGirl.create :user
   @group.add_member!(@closer)
   @group.add_member!(@user)
-  @motion.close!(@closer)
+  MotionService.close(@motion, @closer)
 end
 
 Then(/^I should see that someone closed the motion$/) do

--- a/features/step_definitions/proposal_outcome_steps.rb
+++ b/features/step_definitions/proposal_outcome_steps.rb
@@ -63,7 +63,7 @@ Then(/^I should see the outcome has been edited in the activity feed$/) do
 end
 
 Given(/^a proposal outcome has been sent$/) do
-  @motion.close!
+  MotionService.close(@motion)
   MotionService.create_outcome(@motion,
                               {outcome: 'This is what we do.'},
                               @user)

--- a/features/step_definitions/translate_emails_steps.rb
+++ b/features/step_definitions/translate_emails_steps.rb
@@ -98,7 +98,7 @@ Given(/^"(.*?)" has closed their proposal$/) do |arg1|
   group = FactoryGirl.create :group
   @discussion = create_discussion group: group
   @motion = FactoryGirl.create :motion, discussion: @discussion, author: author
-  @motion.close!(author)
+  MotionService.close(@motion, author)
 end
 
 Then(/^the proposal closed email should be delivered to "(.*?)" in Spanish$/) do |arg1|

--- a/lib/tasks/loomio.rake
+++ b/lib/tasks/loomio.rake
@@ -1,0 +1,5 @@
+namespace :loomio do
+  task :close_lapsed_motions => :environment do
+    MotionService.close_all_lapsed_motions
+  end
+end

--- a/spec/controllers/motions_controller_spec.rb
+++ b/spec/controllers/motions_controller_spec.rb
@@ -8,10 +8,9 @@ describe MotionsController do
   let(:previous_url) { root_url }
 
   before :each do
-    Motion.stub(:find).with(motion.id.to_s).and_return(motion)
-    Group.stub(:find).with(group.id.to_s).and_return(group)
-    Discussion.stub(:find).with(discussion.id.to_s).and_return(discussion)
-    user.stub(:update_motion_read_log).with(motion)
+    Motion.stub(:find).and_return(motion)
+    Group.stub(:find).and_return(group)
+    Discussion.stub(:find).and_return(discussion)
     request.env["HTTP_REFERER"] = previous_url
   end
 
@@ -66,11 +65,11 @@ describe MotionsController do
     context "closing a motion" do
       before do
         controller.stub(:authorize!).with(:close, motion).and_return(true)
-        motion.stub(:close!)
+        MotionService.stub(:close)
       end
 
       it "closes the motion" do
-        motion.should_receive(:close!).with(user)
+        MotionService.should_receive(:close).with(motion, user)
         put :close, :id => motion.id
       end
 

--- a/spec/extras/collects_recent_activity_by_group_spec.rb
+++ b/spec/extras/collects_recent_activity_by_group_spec.rb
@@ -61,7 +61,7 @@ describe CollectsRecentActivityByGroup do
           @discussion = create_discussion group: group, created_at: 2.days.ago, last_comment_at: 2.days.ago
 
           @motion = FactoryGirl.create :motion, discussion: @discussion
-          @motion.close!
+          MotionService.close(@motion)
         end
         it 'does not return the proposal' do
           recent_activity[group.full_name].should be_nil

--- a/spec/extras/queries/unvoted_motions_spec.rb
+++ b/spec/extras/queries/unvoted_motions_spec.rb
@@ -39,7 +39,7 @@ describe Queries::UnvotedMotions do
 
     context 'there is a closed motion in the group' do
       it 'does not return the motion' do
-        motion.close!(user)
+        MotionService.close(motion, user)
         Queries::UnvotedMotions.for(user, group).should_not include(motion)
       end
     end

--- a/spec/models/discussion_spec.rb
+++ b/spec/models/discussion_spec.rb
@@ -145,7 +145,7 @@ describe Discussion do
       @group.add_member! current_motion_author
       previous_motion = create(:motion, :discussion => @discussion,
                              :author => previous_motion_author)
-      previous_motion.close!
+      MotionService.close(previous_motion)
       current_motion = create(:motion, :discussion => @discussion,
                              :author => current_motion_author)
 

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -52,14 +52,14 @@ describe Group do
 
     it "should not return motions that belong to the group but are closed" do
       @group = motion.group
-      motion.close!
+      MotionService.close(motion)
       @group.voting_motions.should_not include(motion)
     end
   end
 
   describe "#closed_motions" do
     it "returns motions that belong to the group and are open" do
-      motion.close!
+      MotionService.close(motion)
       @group = motion.group
       @group.closed_motions.should include(motion)
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -86,7 +86,8 @@ describe User do
 
     it "should not return motions that belong to the group but are closed'" do
       motion = create(:motion, author: user)
-      motion.close!
+      MotionService.close(motion)
+
       user.voting_motions.should_not include(motion)
     end
   end
@@ -94,7 +95,7 @@ describe User do
   describe "closed_motions" do
     it "returns motions that belong to the group and are closed" do
       motion = create(:motion, author: user)
-      motion.close!
+      MotionService.close(motion)
       user.closed_motions.should include(motion)
     end
 

--- a/spec/models/vote_spec.rb
+++ b/spec/models/vote_spec.rb
@@ -26,24 +26,6 @@ describe Vote do
     vote.should have(1).errors_on(:position)
   end
 
-  it 'motion should only accept votes from users who belong to motion.group' do
-    user2 = build(:user)
-    user2.save
-    vote = Vote.new(position: 'block')
-    vote.motion = motion
-    vote.user = user2
-    vote.should_not be_valid
-  end
-
-  it "motion should only accept votes during the motion's voting phase" do
-    motion.close!
-    vote = Vote.new(position: "yes")
-    vote.motion = motion
-    vote.user = user
-    vote.save
-    vote.errors.messages[:position].first.should match(/can only be modified while the motion is in voting phase./)
-  end
-
   it 'sends notification email to author if block is issued' do
     MotionMailer.should_receive(:motion_blocked).with(kind_of(Vote))
       .and_return(double(deliver: true))

--- a/spec/services/motion_service_spec.rb
+++ b/spec/services/motion_service_spec.rb
@@ -5,10 +5,16 @@ module Events
   end
   class MotionOutcomeUpdated
   end
+  class MotionClosed
+  end
+end
+
+class Motion
 end
 
 describe 'MotionService' do
-  let(:motion) { double(:motion, update_attribute: true, outcome: "") }
+  let(:group) { double(:group, present?: true) }
+  let(:motion) { double(:motion, update_attribute: true, outcome: "", group: group) }
   let(:ability) { double(:ability, :authorize! => true) }
   let(:user) { double(:user, ability: ability) }
   let(:motion_params) { {outcome: "We won!"} }
@@ -19,6 +25,45 @@ describe 'MotionService' do
   before do
     Events::MotionOutcomeCreated.stub(:publish!).and_return(event)
     Events::MotionOutcomeUpdated.stub(:publish!).and_return(event)
+  end
+
+  describe '.close_lapsed_motions' do
+    it 'closes lapsed but not closed motions' do
+      lapsed_motions = [motion]
+      Motion.should_receive(:lapsed_but_not_closed).and_return(lapsed_motions)
+      MotionService.should_receive(:close).with(motion)
+      MotionService.close_all_lapsed_motions
+    end
+  end
+
+  describe '.close' do
+    before do
+      Events::MotionClosed.stub(:publish!)
+      motion.stub(:closed_at=)
+      motion.stub(:save!)
+      motion.stub(:store_users_that_didnt_vote)
+    end
+
+    after do
+      MotionService.close(motion, user)
+    end
+    
+    it 'stores users that did not vote' do
+      motion.should_receive(:store_users_that_didnt_vote)
+    end
+
+    it 'sets closed_at' do
+      motion.should_receive(:closed_at=)
+    end
+
+    it 'fires motion closed event' do
+      Events::MotionClosed.should_receive(:publish!).with(motion, user)
+    end
+
+    it 'saves the motion' do
+      motion.should_receive(:save!)
+      MotionService.close(motion)
+    end
   end
 
   describe '.create_outcome' do


### PR DESCRIPTION
**CR**: :white_check_mark:

**QA**: :white_check_mark:

> :white_check_mark: pull down locally, check app loads
> 
> _test core functionality of feature:_
> :white_check_mark: set up cron job on clone, watched it close a motion + create event
> :ok: didn't see it create email on close (mail server not up) but this doesn't concern this feature
> 
> _test functionality adjacent to this feature:_
> :white_check_mark: created a motion
> :white_check_mark: closing motion early not yet working 
> 
> :ok: public/ private functionality _NA_*
> :ok: logged out functionality **NA**
> 
> :ok: test in IE 8,9 **NA**
> :white_check_mark: test in production environment

---

**CO signoff**: :question:
**DO signoff**: :ok: no visual/ UI changes made 

**PO signoff**: :ok: happy for it to deploy, but slightly scared

---

notes
This removes the unpredicatable "check if motion is closed when you touch a discussion" with "close all elapsed motions with an external cron job"

We need to configure our various heroku instances to call rake loomio:close_elapsed_motions (hourly would be ok) as we deploy this
