### PR TITLE
Alternate invitation message

### DIFF
--- a/app/views/groups/_invite_users.html.haml
+++ b/app/views/groups/_invite_users.html.haml
@@ -1,5 +1,4 @@
 %h1= t("invitation.invite_people")
-%br
 .control-group
   %p= t("invitation.recipients")
   = text_area_tag 'invitees', nil, class: 'validate-emails', placeholder: t("invitation.invitees_placeholder")

--- a/app/views/groups/invitations/new.html.haml
+++ b/app/views/groups/invitations/new.html.haml
@@ -1,12 +1,20 @@
 = render '/groups/title', group: @group
 = simple_form_for(@invite_people, url: group_invitations_path(@group), method: :post) do |f|
   .row
-    .span5
+    .span6
       = render 'groups/invite_users', form: f, group: @group
       = @group.invitations_remaining
       = t :invitations_remaining
       %br
       %br
       = f.submit t("invitation.send_invitations"), :class => "btn btn-info btn-large run-validations", :data => { disable_with: t("invitation.send_invitations") }
-
       =render "application/hint", text: t(:"hint.invitation"), anchor: 'writing-a-great-invitation'
+    .span5.offset1{style: 'margin-top:75px;'}
+      - unless @group.is_secret?
+        %p
+          %i.icon-star
+          = t :"invitation.alternate"
+        %p
+          %strong= new_group_membership_request_url(@group)
+
+

--- a/app/views/pages/home.html.haml
+++ b/app/views/pages/home.html.haml
@@ -26,14 +26,14 @@
               =link_to "Diaspora Community", group_path(id: 194)
             %p
               The Diaspora Project works with the goal of establishing a decentralized social platform. It is Free and Open Source software, and community-driven.
-        / .row-fluid.featured-row
-        /   .span2.featured-image
-        /     =link_to image_tag("blag.jpg"), group_path(id: 1031)
-        /   .span9.flush
-        /     %h3
-        /       =link_to "Big Live Arts Group", group_path(id: 1031)
-        /     %p
-        /       Developing a supportive and critically engaged community within the performing arts industry, anchored by principles of diversity, inclusion, openness and transparency.
+        .row-fluid.featured-row
+          .span2.featured-image
+            =link_to image_tag("blag.jpg"), group_path(id: 1031)
+          .span9.flush
+            %h3
+              =link_to "Big Live Arts Group", group_path(id: 1031)
+            %p
+              Developing a supportive and critically engaged community within the performing arts industry, anchored by principles of diversity, inclusion, openness and transparency.
         .row-fluid.featured-row
           .span2.featured-image
             =link_to image_tag("loomio-community.jpg"), group_path(id: 3)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -611,6 +611,7 @@ en:
   #
 
   invitation:
+    alternate: "Alternatively, share this link and anyone can ask to join:"
     no_invitations_left: "Sorry you don't have any invitations left"
     no_invitations_left_get_more: "Please email contact@loomio.org and we'll see what we can do to help you"
     invitation_not_found:  'Could not find invitation with that token. Please ask for a new invitation from the sender.'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -66,8 +66,8 @@ Loomio::Application.routes.draw do
     resources :discussions, only: [:index, :new]
   end
 
-  get 'groups/:group_id/request_membership',   to: 'groups/membership_requests#new',          as: :new_group_membership_request
-  post 'groups/:group_id/membership_requests', to: 'groups/membership_requests#create'  ,       as: :group_membership_requests
+  get 'groups/:group_id/ask_to_join',          to: 'groups/membership_requests#new',          as: :new_group_membership_request
+  post 'groups/:group_id/membership_requests', to: 'groups/membership_requests#create',       as: :group_membership_requests
   delete 'membership_requests/:id/cancel',     to: 'groups/membership_requests#cancel',       as: :cancel_membership_request
 
   get 'groups/:group_id/membership_requests',  to: 'groups/manage_membership_requests#index', as: :group_membership_requests


### PR DESCRIPTION
[QA needed]
- add message on invitation page ofnon-secret groups: 'share this link and anyone can ask to join'
- rename /request_membership to /ask_to_join
- put BLAG back on the front page because it is public now
