### PR TITLE
~ Updated ENV variables for SMTP services

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -62,21 +62,21 @@ Loomio::Application.configure do
 
   config.action_mailer.perform_deliveries = true
 
-  # Send emails using SendGrid
+  # Send emails using SMTP service
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.smtp_settings = {
-    :address        => 'smtp.sendgrid.net',
-    :port           => '587',
+    :address        => ENV['SMTP_SERVER'],
+    :port           => ENV['SMTP_PORT'],
     :authentication => :plain,
-    :user_name      => ENV['SENDGRID_USERNAME'],
-    :password       => ENV['SENDGRID_PASSWORD'],
-    :domain         => 'loomio.org'
+    :user_name      => ENV['SMTP_USERNAME'],
+    :password       => ENV['SMTP_PASSWORD'],
+    :domain         => ENV['SMTP_DOMAIN']
   }
 
   config.action_mailer.raise_delivery_errors = true
 
   config.action_mailer.default_url_options = {
-    :host => 'www.loomio.org',
+    :host => ENV['SMTP_DOMAIN'],
   }
 
   # Store avatars on Amazon S3

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -61,15 +61,15 @@ Loomio::Application.configure do
   }
 
   if ENV['ENABLE_STAGING_EMAILS']
-    # Send emails using SendGrid
+    # Send emails using SMTP service
     config.action_mailer.delivery_method = :smtp
     config.action_mailer.smtp_settings = {
-      :address        => 'smtp.sendgrid.net',
-      :port           => '587',
+      :address        => ENV['SMTP_SERVER'],
+      :port           => ENV['SMTP_PORT'],
       :authentication => :plain,
-      :user_name      => ENV['SENDGRID_USERNAME'],
-      :password       => ENV['SENDGRID_PASSWORD'],
-      :domain         => 'loomio.org'
+      :user_name      => ENV['SMTP_USERNAME'],
+      :password       => ENV['SMTP_PASSWORD'],
+      :domain         => ENV['SMTP_DOMAIN']
     }
     config.action_mailer.raise_delivery_errors = true
     # Email admin when server gets exceptions!


### PR DESCRIPTION
As per chatting with @robguthrie I updated these so that the SMTP settings back be more flexible for alternate services aside from Sendgrid (e.g. Mailgun, Mandrill, Postmark).

These new ENV variables are generically enough named they be more intuitive on Heroku and non Herokue servers as well!
