### PR TITLE
hide invitations form on subgroup

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -67,7 +67,8 @@ class Ability
     end
 
     can :invite_outsiders, Group do |group|
-      if group.is_a_subgroup? and group.parent_is_hidden?
+      # if group.is_a_subgroup? and group.parent_is_hidden?
+      if group.is_a_subgroup?
         false
       else
         true

--- a/features/invitations/invitation_to_join_group.feature
+++ b/features/invitations/invitation_to_join_group.feature
@@ -51,10 +51,10 @@ Feature: Invitation to join group
     And "David" is a member of the group
     When I visit the subgroup page
     And I click invite people
-    And I enter "new@user.com" in the invitations field
+    # And I enter "new@user.com" in the invitations field
     And I select "David" from the list of members
     And I confirm the selection
-    Then "new@user.com" should be invited to join the subgroup
+    # Then "new@user.com" should be invited to join the subgroup 
     And I should see "David" as a member of the subgroup
     And "David" should receive a notification that they have been added
 

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -209,7 +209,7 @@ describe "User abilities" do
     end
     it { should_not be_able_to(:view_payment_details, sub_group) }
     it { should_not be_able_to(:choose_subscription_plan, sub_group) }
-    it { should be_able_to(:invite_outsiders, sub_group) }
+    # it { should be_able_to(:invite_outsiders, sub_group) }
   end
 
   context "non-member of a group" do


### PR DESCRIPTION
just a bandaid while we fix the groups-tree that breaks for members of subgroups that don't belong to the parent
