### PR TITLE
Fix migrations

### DIFF
--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -73,12 +73,6 @@ Loomio::Application.configure do
     }
     config.action_mailer.raise_delivery_errors = true
     # Email admin when server gets exceptions!
-    config.middleware.use ExceptionNotification::Rack,
-      :email => {
-        :email_prefix => "[Loomio STAGING Exception] ",
-        :sender_address => %{"Exception Notifier" <staging-exceptions@loomio.org>},
-        :exception_recipients => [ENV['EXCEPTION_RECIPIENT']]
-      }
   else
     config.action_mailer.delivery_method = :test
   end

--- a/db/migrate/20120510004528_add_column_discussion_id_to_motion_read_log.rb
+++ b/db/migrate/20120510004528_add_column_discussion_id_to_motion_read_log.rb
@@ -1,4 +1,7 @@
 class AddColumnDiscussionIdToMotionReadLog < ActiveRecord::Migration
+  class MotionReadLog < ActiveRecord::Base #this helps migration find table
+  end
+
   def up
     add_column :motion_read_logs, :discussion_id, :integer
     MotionReadLog.reset_column_information


### PR DESCRIPTION
## how to fix a broken migration (of type renamed model)
#### the problem:

I had a staging sever where I was trying to set up a db from fresh. 
Here's the migration error : 

```
==  AddColumnDiscussionIdToMotionReadLog: migrating ===========================
-- add_column(:motion_read_logs, :discussion_id, :integer)
   -> 0.0041s
rake aborted!
An error has occurred, this and all later migrations canceled:

uninitialized constant AddColumnDiscussionIdToMotionReadLog::MotionReadLog/app/db/migrate/20120510004528_add_column_discussion_id_to_motion_read_log.rb:4:in `up'
```

the offending file:

``` ruby
class AddColumnDiscussionIdToMotionReadLog < ActiveRecord::Migration
  def up
    add_column :motion_read_logs, :discussion_id, :integer
=>  MotionReadLog.reset_column_information
    MotionReadLog.all.each do |log|
      motion = Motion.find_by_id(log.motion_id)

   ...
```
#### what's causing the problem:

the model `MotionReadLog` doesn't exist, because in the current code the it has been renamed (several times) and ended up at `MotionReader`.

the calls `MotionReadLog.reset_column_information` and `MotionReadLog.all` in the migration would normally use ActiveRecord::Base magic to look for a table called `motion_read_logs` ... but because the model doesn't exist, the magic fails. 
#### quick fix:

fake the model

``` ruby
class AddColumnDiscussionIdToMotionReadLog < ActiveRecord::Migration
  class MotionReadLog < ActiveRecord::Base #this helps migration find table
  end

  def up
    add_column :motion_read_logs, :discussion_id, :integer
    MotionReadLog.reset_column_information
    MotionReadLog.all.each do |log|
      motion = Motion.find_by_id(log.motion_id)
      if motion

...
```
