### PR TITLE
Feature/start group path

### DIFF
--- a/app/assets/stylesheets/groups.css.scss
+++ b/app/assets/stylesheets/groups.css.scss
@@ -164,7 +164,7 @@ body.groups {
   text-align: center;
 }
 
-body.group_setup.setup, body.groups.edit, body.groups.add_subgroup {
+body.group_setup.setup, body.groups.new, body.groups.edit, body.groups.add_subgroup {
   form.edit_group, form.new_group {
     .control-group.radio_buttons { margin-bottom: 1.6em; }
     input[type="text"] {
@@ -207,5 +207,14 @@ body.group_setup.setup, body.groups.edit, body.groups.add_subgroup {
   .info-box {
     width: 290px;
     margin-top: 1.1em
+  }
+}
+
+body.groups.new {
+  .control-group.group_name {
+    margin-top: 30px;
+  }
+  .info-box {
+    margin-top: 65px;
   }
 }

--- a/app/controllers/groups/group_setup_controller.rb
+++ b/app/controllers/groups/group_setup_controller.rb
@@ -8,7 +8,7 @@ class Groups::GroupSetupController < GroupBaseController
 
   def finish
     if @group.update_attributes(permitted_params.group)
-      @group.update_attribute(:setup_completed_at, Time.zone.now.utc)
+      @group.mark_as_setup!
       InvitePeopleMailer.delay.welcome(@group)
       redirect_to @group
     else

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,7 +1,7 @@
 class GroupsController < GroupBaseController
   before_filter :authenticate_user!, except: :show
 
-  before_filter :load_resource_by_key, except: :create
+  before_filter :load_resource_by_key, :except => [:create, :new]
   authorize_resource except: :create
 
   before_filter :ensure_group_is_setup, only: :show
@@ -17,20 +17,25 @@ class GroupsController < GroupBaseController
     @subgroup.members_invitable_by = parent.members_invitable_by
   end
 
-  #for create group
-  # NOTE (JL): This seems to only be for creating subgroups. Should
-  # be more clear
   def create
     @group = Group.new(permitted_params.group)
     authorize!(:create, @group)
+    @group.mark_as_setup!
     if @group.save
       @group.add_admin! current_user
       flash[:success] = t("success.group_created")
       redirect_to @group
+    elsif @group.is_a_subgroup?
+        @subgroup = @group
+        render 'groups/add_subgroup'
     else
-      @subgroup = @group
-      render 'groups/add_subgroup'
+      render 'form'
     end
+  end
+
+  def new
+    @group = Group.new
+    @group.payment_plan = 'undetermined'
   end
 
   def update

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -77,8 +77,10 @@ class Ability
     end
 
     can :create, Group do |group|
-      if group.parent_id.present?
-        @member_group_ids.include?(group.parent_id)
+      if group.is_top_level?
+        true
+      elsif @member_group_ids.include?(group.parent_id)
+        true
       else
         false
       end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -270,6 +270,10 @@ class Group < ActiveRecord::Base
     self.setup_completed_at.present?
   end
 
+  def mark_as_setup!
+    self.update_attribute(:setup_completed_at, Time.zone.now.utc)
+  end
+
   def update_full_name_if_name_changed
     if changes.include?('name')
       update_full_name

--- a/app/views/application/_groups_dropdown.html.haml
+++ b/app/views/application/_groups_dropdown.html.haml
@@ -5,4 +5,4 @@
   %ul.dropdown-menu
     #group-dropdown-items
     %li.group-item.new-group
-      =link_to t(:request_new_group), new_group_request_path(:ltm_source => 'groups_dropdown')
+      =link_to t(:request_new_group), new_group_path

--- a/app/views/dashboard/_groups.html.haml
+++ b/app/views/dashboard/_groups.html.haml
@@ -2,4 +2,4 @@
   %h4= t :groups
   %ul#dashboard-groups-list
     = render '/application/groups_tree'
-    = link_to t(:start_a_group), new_group_request_path(ltm_source: 'dashboard'), id: 'request-new-group', class: 'bottom-panel-link'
+    = link_to t(:start_a_group), new_group_path(ltm_source: 'dashboard'), id: 'request-new-group', class: 'bottom-panel-link'

--- a/app/views/dashboard/show.html.haml
+++ b/app/views/dashboard/show.html.haml
@@ -28,5 +28,5 @@
       =render '/application/see_closed_motions'
     =render '/application/closed_motions', user: current_user, group: nil
 - else
-  = link_to t(:start_a_group), new_group_request_path
+  = link_to t(:start_a_group), new_group_path
   = t(:request_new_group_details)

--- a/app/views/group_requests/new.html.haml
+++ b/app/views/group_requests/new.html.haml
@@ -4,10 +4,6 @@
       %h1 Start your group
 .row
   .span5.offset1
-    = render 'form', submit_label: "Start group!", placeholder: "e.g. Neighbourhood Support Group"
+    = render 'form', submit_label: t(:start_group), placeholder: "e.g. Neighbourhood Support Group"
   .span4
-    .info-box#informal-group
-      %h2 Loomio is for everyone!
-      %p We have a payment model that suits any group, even those with no money :)
-      %p
-        = link_to "Find out more", pricing_path
+    = render 'groups/payment_model_info'

--- a/app/views/groups/_payment_model_info.html.haml
+++ b/app/views/groups/_payment_model_info.html.haml
@@ -1,0 +1,5 @@
+.info-box#informal-group
+      %h2=t :'group_setup.payment_model.header'
+      %p=t :'group_setup.payment_model.info'
+      %p
+      = link_to t(:'group_setup.payment_model.link'), pricing_path

--- a/app/views/groups/new.html.haml
+++ b/app/views/groups/new.html.haml
@@ -1,0 +1,7 @@
+.row
+  .span6
+    #intro
+      %h1 Start your group
+      = render 'form', group: @group, submit_text: t(:start_group)
+  .span4.offset1
+    = render 'payment_model_info'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -717,6 +717,10 @@ en:
     desc_header: "You're almost there!"
     desc_html: "As the group coordinator, you’re responsible for setting up and managing your Loomio group. After you choose a few settings, you can get into your new group, start a discussion or two, and send out some invitations! <p>When thinking about the simplest way you can describe your group, ask yourself: What do you want to achieve together? What types of decisions will you be making? Who will be involved?</p>"
     submit: "Take me to my group!"
+    payment_model:
+      header: Loomio is for everyone!
+      info: We have a payment model that suits any group, even those with no money :)
+      link: Find out more
 
   simple_form:
     "yes": 'Yes'
@@ -947,6 +951,7 @@ en:
   send_email: "Send email"
   show_more: "Show More"
   start_a_group: "Start a group"
+  start_group: "Start group!"
   starting: "Starting"
   subject: "Subject"
   terms_of_service_html: "By clicking %{button_text}, you agree to Loomio's <a href='%{link_path}' target='_blank'>Terms of service</a>"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,7 @@ Loomio::Application.routes.draw do
   end
 
   get "/groups", to: 'public_groups#index', as: :public_groups
+  get "/new_group", to: 'groups#new'
 
   resource :search, only: :show
 

--- a/features/groups/start_new_group.feature
+++ b/features/groups/start_new_group.feature
@@ -27,13 +27,8 @@ Scenario: Guest creates group
 Scenario: User creates group
   Given I am logged in
   When I go to start a new group from the navbar
-  When I fill in the group name and submit the form
-  Then I should see the thank you page
-  And I should recieve an email with an invitation link
-  When I click the invitation link
-  And I setup the group
-  And the example content should be created
-  Then I should see the group page with a contribute link
+  And I complete and submit the form
+  Then I should be taken to the new group
 
 @javascript
  Scenario: Logged out user creates group

--- a/features/step_definitions/start_new_group_steps.rb
+++ b/features/step_definitions/start_new_group_steps.rb
@@ -33,10 +33,11 @@ When(/^I click the invitation link$/) do
   # click_email_link_matching(invitation_url(@group_request.token))
 end
 
-When(/^I fill in the group name and submit the form$/) do
+When(/^I complete and submit the form$/) do
   @group_name = "Hermans Herbs"
-  fill_in :group_request_name, with: @group_name
-  click_on 'sign-up-submit'
+  fill_in :group_name, with: @group_name
+  fill_in :group_description, with: "A collection of the finest herbs"
+  click_on 'Start group!'
 end
 
 When(/^I sign in to Loomio$/) do
@@ -68,6 +69,10 @@ end
 Then(/^I should see the group page with a contribute link$/) do
   page.should have_css("body.groups.show")
   page.should have_css("#contribute")
+end
+
+Then(/^I should be taken to the new group$/) do
+  page.should have_css("body.groups.show")
 end
 
 Then(/^I should see the start group form with errors$/) do

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -5,9 +5,12 @@ describe "User abilities" do
   let(:user) { create(:user) }
   let(:other_user) { create(:user) }
   let(:non_member) { create(:user) }
+  let(:group) { create(:group) }
 
   let(:ability) { Ability.new(user) }
   subject { ability }
+
+  it { should be_able_to(:create, group) }
 
   context "member of a group" do
     let(:group) { create(:group) }


### PR DESCRIPTION
Ready to merge 

Signed in user can make new group by submitting single form, no more email invite/group-setup etc.
- Start new group as signed in user.
- Start new group as visitor.
- Ensure that logging out before submitting new group form as signed in user prompts sign-in.
