### PR TITLE
Inline translation of comments, discussions, motions and votes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,6 +53,7 @@ gem 'sequenced', '~> 1.4.0'
 gem 'closure_tree', '~> 4.3.0'
 gem 'ruby-progressbar', '1.4.1'
 gem 'bing_translator', '~> 4.0.0'
+gem 'activerecord-postgres-hstore'
 
 # Gems used only for assets and not required
 # in production environments by default.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,6 +42,10 @@ GEM
       activesupport (= 3.2.16)
       arel (~> 3.0.2)
       tzinfo (~> 0.3.29)
+    activerecord-postgres-hstore (0.7.7)
+      activerecord (>= 3.1)
+      pg-hstore (>= 1.1.5)
+      rake
     activeresource (3.2.16)
       activemodel (= 3.2.16)
       activesupport (= 3.2.16)
@@ -307,6 +311,7 @@ GEM
     parallel_tests (0.16.5)
       parallel
     pg (0.17.1)
+    pg-hstore (1.2.0)
     pg_search (0.7.2)
       activerecord (>= 3.1)
       activesupport (>= 3.1)
@@ -497,6 +502,7 @@ PLATFORMS
 DEPENDENCIES
   aasm (~> 3.0.3)
   activeadmin!
+  activerecord-postgres-hstore
   airbrake (~> 3.1.14)
   awesome_print (~> 1.0.2)
   better_errors (~> 1.0.1)

--- a/app/assets/javascripts/discussions.js.coffee
+++ b/app/assets/javascripts/discussions.js.coffee
@@ -18,8 +18,10 @@ $ ->
 
 # Show translation div
 $ ->
-  $('.activity-item-container').on 'click', '.translate-comment', (event) ->
-    $(this).slideUp().closest('.activity-item-body').find('.activity-item-translation').slideDown()
+  $('.translate-parent').on 'click', '.translate-link', (event) ->
+    parent = $(this).closest('.translate-parent')
+    $(this).slideUp()
+    parent.find('.translated').not(parent.find('.translate-parent .translated')).slideDown()
 
 # Global Markdown (new discussion & comments)
 $ ->

--- a/app/assets/stylesheets/discussions.css.scss
+++ b/app/assets/stylesheets/discussions.css.scss
@@ -445,11 +445,6 @@ body.discussions.show {
         }
         p:last-child{margin-bottom: 2px;}
       }
-      .activity-item-translation {
-        display: none;
-        padding: 0 0 5px 5px;
-        font-style: italic;
-      }
       .activity-item-likes{
         color: $dark-grey;
         font-size: $font-tiny;
@@ -701,3 +696,10 @@ div.jqplot-table-legend-swatch{
   margin-right: -26px;
   width: 0;
 }
+
+.translated {
+  display: none;
+  padding: 0 0 5px 5px;
+  font-style: italic;
+}
+

--- a/app/assets/stylesheets/main.css.scss
+++ b/app/assets/stylesheets/main.css.scss
@@ -289,7 +289,8 @@ ul.selector-list {
 }
 
 // edit description dropdown for group and discussion
-.edit-description {
+.edit-description,
+.description-body .translate-link {
   color: $mid-grey;
   text-decoration: underline;
   &:hover { color: $dark-grey }

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,7 +1,6 @@
 class CommentsController < BaseController
   load_and_authorize_resource only: :destroy
-  load_resource only: [:like, :translate]
-  skip_before_filter :authenticate_user!, only: :translate
+  load_resource only: [:like]
 
   def destroy
     CommentDeleter.new(@comment).delete_comment
@@ -17,13 +16,6 @@ class CommentsController < BaseController
     end
 
     render :template => "comments/comment_likes"
-  end
-  
-  def translate
-    @translation = @comment.translate @comment.author.primary_language, I18n.locale.to_s
-    @success = @translation.present? && @translation != @comment.body
-    
-    render :template => "comments/comment_translations"
   end
 
 end

--- a/app/controllers/translations_controller.rb
+++ b/app/controllers/translations_controller.rb
@@ -1,0 +1,12 @@
+class TranslationsController < ApplicationController
+ 
+  def create  
+    model = params[:model].to_s.downcase
+    instance = model.humanize.constantize.get_instance(params[:id])
+    authorize! :show, instance
+
+    @translation = TranslationService.new.translate(instance).as_json.with_indifferent_access if TranslationService.available?
+    render :template => "#{model.pluralize}/#{model}_translations"
+  end
+  
+end

--- a/app/helpers/translations_helper.rb
+++ b/app/helpers/translations_helper.rb
@@ -1,0 +1,25 @@
+module TranslationsHelper
+  
+  def translate_link_for(model, css='')
+    model_name = model.class.to_s.downcase
+    link_to t(:translate_this_string, language: current_language), translate_path(model_name, model.id_field), method: :post, remote: true, class: "translate-link #{css}", id: "translate-#{model_name}-#{model.id_field}" 
+  end
+  
+  def get_translation(translation, field, show_error = true)
+    message = if valid_translation? translation, field 
+                translation[field]
+              elsif show_error                         
+                t(:failed_translation)
+              else                                          
+                '' 
+              end
+    escape_javascript(message).html_safe
+  end
+  
+  private
+  
+  def valid_translation?(translation, field)
+    translation.present? && translation.has_key?(field)
+  end
+  
+end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -165,7 +165,19 @@ class Ability
     can [:create, :vote], Motion do |motion|
       motion.voting? && @member_group_ids.include?(motion.group.id)
     end
-
+    
+    can [:show], Comment do |comment|
+      can?(:show, comment.discussion)      
+    end
+    
+    can [:show], Motion do |motion|
+      can?(:show, motion.discussion)      
+    end
+    
+    can [:show], Vote do |vote|
+      can?(:show, vote.motion)      
+    end
+    
     can [:destroy,
          :close,
          :create_outcome,

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,9 +1,9 @@
 class Comment < ActiveRecord::Base
   include Twitter::Extractor
-  include Translatable
 
   has_paper_trail
-
+  is_translatable on: :body
+  
   belongs_to :discussion, counter_cache: true
   belongs_to :user
 
@@ -24,6 +24,7 @@ class Comment < ActiveRecord::Base
   delegate :group, :to => :discussion
   delegate :full_name, :to => :group, :prefix => :group
   delegate :title, :to => :discussion, :prefix => :discussion
+  delegate :language, to: :user
 
   serialize :liker_ids_and_names, Hash
 

--- a/app/models/discussion.rb
+++ b/app/models/discussion.rb
@@ -1,4 +1,5 @@
 class Discussion < ActiveRecord::Base
+
   PER_PAGE = 50
   paginates_per PER_PAGE
 
@@ -16,7 +17,8 @@ class Discussion < ActiveRecord::Base
   validates :title, :length => { :maximum => 150 }
   validates_inclusion_of :uses_markdown, :in => [true,false]
   validate :privacy_is_permitted_by_group
-
+  
+  is_translatable on: [:title, :description], load_via: :find_by_key!, id_field: :key
   has_paper_trail :only => [:title, :description]
 
   belongs_to :group, :counter_cache => true
@@ -39,6 +41,7 @@ class Discussion < ActiveRecord::Base
   delegate :full_name, :to => :group, :prefix => :group
   delegate :email, :to => :author, :prefix => :author
   delegate :name_and_email, :to => :author, prefix: :author
+  delegate :language, to: :author
 
   before_create :set_last_comment_at
 
@@ -179,7 +182,6 @@ class Discussion < ActiveRecord::Base
   def group_default_is_private?
     ['hidden', 'private'].include? group.privacy
   end
-
 
   private
   def private_is_not_nil

--- a/app/models/motion.rb
+++ b/app/models/motion.rb
@@ -18,6 +18,8 @@ class Motion < ActiveRecord::Base
   validates_length_of :name, :maximum => 250
   validates_length_of :outcome, :maximum => 250
 
+  is_translatable on: [:name, :description]
+
   include PgSearch
   pg_search_scope :search, against: [:name, :description],
     using: {tsearch: {dictionary: "english"}}
@@ -28,6 +30,7 @@ class Motion < ActiveRecord::Base
   delegate :users, :full_name, :to => :group, :prefix => :group
   delegate :email_new_motion?, to: :group, prefix: :group
   delegate :name_and_email, to: :user, prefix: :author
+  delegate :language, to: :user
 
   after_initialize :set_default_close_at_date_and_time
   before_validation :set_closing_at
@@ -228,7 +231,7 @@ class Motion < ActiveRecord::Base
     update_attribute(:did_not_votes_count, did_not_votes.count)
     reload
   end
-
+  
   private
     def find_or_new_motion_reader_for(user)
       if self.motion_readers.where(user_id: user.id).exists?

--- a/app/models/translation.rb
+++ b/app/models/translation.rb
@@ -1,4 +1,4 @@
-class Translation
+class Translation < ActiveRecord::Base
   LANGUAGES = {'English' => 'en',
                'български' => 'bg',
                'Català' => 'ca',
@@ -19,6 +19,18 @@ class Translation
                             'తెలుగు' => 'te',
                             'Gaelic (Irish)' => 'ga'}
 
+  belongs_to :translatable, polymorphic: true
+  
+  serialize :fields, ActiveRecord::Coders::Hstore
+  
+  scope :to_language, ->(language) { where(language: language) }
+
+  validates_presence_of :translatable, :language
+  
+  def as_json
+    { id: translatable_id }.merge(fields)
+  end
+  
   def self.language(locale)
     LANGUAGES.key(locale)
   end
@@ -36,4 +48,5 @@ class Translation
       title: "#{I18n.t(:change_language, language: language[0])}",
       text: "#{language[0]}" }
   end
+  
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -131,6 +131,7 @@ class User < ActiveRecord::Base
   def primary_language
     language_preference.split(',').first if language_preference    
   end
+  alias :language :primary_language
 
   # Provide can? and cannot? as methods for checking permissions
   def ability

--- a/app/models/vote.rb
+++ b/app/models/vote.rb
@@ -1,4 +1,5 @@
 class Vote < ActiveRecord::Base
+
   class UserCanVoteValidator < ActiveModel::EachValidator
     def validate_each(object, attribute, value)
       unless value && object.motion.can_be_voted_on_by?(User.find(value))
@@ -19,6 +20,7 @@ class Vote < ActiveRecord::Base
 
   belongs_to :motion, counter_cache: true
   belongs_to :user
+
   has_many :events, :as => :eventable, :dependent => :destroy
 
   validates_presence_of :motion, :user, :position
@@ -26,6 +28,8 @@ class Vote < ActiveRecord::Base
   validates_length_of :statement, maximum: 250
   validates :user_id, user_can_vote: true
   validates :position, :statement, closable: true
+
+  is_translatable on: :statement
 
   scope :for_user, lambda {|user_id| where(:user_id => user_id)}
 
@@ -36,6 +40,7 @@ class Vote < ActiveRecord::Base
   delegate :author, :to => :discussion, :prefix => :discussion
   delegate :name, :to => :motion, :prefix => :motion
   delegate :name, :full_name, :to => :group, :prefix => :group
+  delegate :language, :to => :user
 
   before_create :age_previous_votes
   after_save :update_motion_vote_counts, :send_notifications

--- a/app/services/translation_service.rb
+++ b/app/services/translation_service.rb
@@ -1,0 +1,37 @@
+class TranslationService
+  def initialize(translator = BingTranslator.new(ENV.fetch('BING_TRANSLATE_APPID', nil), ENV.fetch('BING_TRANSLATE_SECRET', nil)))
+    @translator = translator
+    raise TranslationUnavailableError.new unless self.class.available?
+  end
+  
+  def translate(model, to: I18n.locale)
+    if model.translations.to_language(to).exists?
+      translation = model.translations.to_language(to).first
+    else
+      translation = Translation.new translatable: model, language: to, fields: {}
+    end
+    
+    model.class.translatable_fields.each do |field|
+      translation.fields[field.to_s] ||= @translator.translate(model.send(field), from: model.language_field, to: to)
+    end
+    translation.save
+    translation
+  end
+
+  def self.available?
+    ENV.fetch('BING_TRANSLATE_APPID', nil) && 
+    ENV.fetch('BING_TRANSLATE_SECRET', nil) &&
+    true # don't return the secret!
+  end
+  
+  def self.can_translate?(translatable)
+    self.available? && translatable.language_field != I18n.locale.to_s
+  end
+
+end
+
+class TranslationUnavailableError < StandardError
+  def to_s
+    "Unable to instantiate BingTranslator: Please ensure that the ENV variables 'BING_TRANSLATE_APPID' and 'BING_TRANSLATE_SECRET' "
+  end
+end

--- a/app/views/comments/_comment.html.haml
+++ b/app/views/comments/_comment.html.haml
@@ -1,5 +1,5 @@
 -unread ||= nil
-%div{id: "comment-container-#{comment.id}"}
+%div.translate-parent{id: "comment-container-#{comment.id}"}
   %a{class: "comment-anchor", id: "comment-#{comment.id}"}
   .content-container{class: unread}
     .activity-item-avatar.medium-user-avatar
@@ -10,7 +10,7 @@
           =link_to comment.user_name, user_path(comment.user), class: "user-name"
         .activity-item-header
           ~ add_mention_links(render_rich_text(comment.body.to_s.force_encoding("UTF-8"), comment.uses_markdown?)).html_safe
-          .activity-item-translation= t(:loading)
+          .activity-item-translation.translated= t(:loading)
       -if comment.attachments_count > 0
         -comment.attachments.each do |a|
           .comment-attachment

--- a/app/views/comments/_comment_likes.html.haml
+++ b/app/views/comments/_comment_likes.html.haml
@@ -9,9 +9,9 @@
   - if can? :destroy, comment
     = " · "
     = link_to t(:delete), "#", 'data-title' => t(:delete_comment), 'data-body' => t(:confirm_delete_comment), 'data-confirm-path' => comment_path(comment), 'data-method-type' => 'delete', class: 'confirm-dialog', id: "delete-comment-#{comment.id}"
-  - if I18n.locale.to_s != comment.author.primary_language
-    = " . "
-    = link_to t(:translate_this_string, language: current_language), translate_comment_path(id: comment), method: :post, remote: true, class: 'translate-comment', id: "translate-comment-#{comment.id}", rel: 'nofollow'
+  - if TranslationService.can_translate? comment
+    = " · "
+    = translate_link_for comment
 - if comment.liker_ids_and_names.size > 0
   .activity-item-likes
     - liker_links = comment.liker_ids_and_names.map { |id, name| name }

--- a/app/views/comments/comment_translations.js.erb
+++ b/app/views/comments/comment_translations.js.erb
@@ -1,3 +1,2 @@
-comment_id = <%= @comment.id.to_s %>
-parent = $("#comment-container-" + comment_id).find(".activity-item-header")
-parent.find(".activity-item-translation").html("<%= escape_javascript(@success ? @translation : 'Unable to complete translation').html_safe %>");
+body = "<%= get_translation @translation, :body %>";
+$('#comment-container-<%= @translation[:id].to_s %>').find('.translated').html(body);

--- a/app/views/discussions/_description.html.haml
+++ b/app/views/discussions/_description.html.haml
@@ -2,10 +2,12 @@
   .description-body
     .long-description
       = render_rich_text(description, description_markdown_setting)
-
+    .translated-description.translated
+      = t(:loading)
     - if can? :update_description, discussion
       = link_to t(:edit_discussion_context), "#", class: "edit-description edit-discussion-description bottom-panel-link", id: 'edit_description'
-
+    - if TranslationService.can_translate? discussion
+      = translate_link_for discussion
   - if can? :update_description, discussion
     = form_tag update_description_discussion_path(discussion), :id => "description-edit-form", :class => "hidden" do |f|
       = hidden_field_tag 'id'

--- a/app/views/discussions/_title.html.haml
+++ b/app/views/discussions/_title.html.haml
@@ -1,7 +1,8 @@
-.clearfix
+.clearfix.discussion-header-container
   .discussion-title-container
     %h2#discussion-title
       = discussion.title
       = render 'discussions/privacy_icon', discussion: discussion
   - if can?(:edit, discussion) || can?(:move, discussion) || can?(:destroy, discussion)
     =render "discussions/options", discussion: discussion
+  .discussion-title-translation.translated= t(:loading)

--- a/app/views/discussions/discussion_translations.js
+++ b/app/views/discussions/discussion_translations.js
@@ -1,0 +1,4 @@
+title = "<%= get_translation @translation, :title %>";
+description = "<%= get_translation @translation, :description %>";
+$('.discussion-header-container').find('.translated').html(title);
+$('#discussion-context').find('.translated').html(description);

--- a/app/views/discussions/show.html.haml
+++ b/app/views/discussions/show.html.haml
@@ -4,7 +4,7 @@
     =render '/groups/title', group: @group, discussion: @discussion
   .span3#button-container
     = request_membership_button(@group)
-.row
+.row.translate-parent{id: "discussion-#{@discussion.key}" }
   .span12
     .selector-panel
       = render 'title', discussion: @discussion

--- a/app/views/motions/_motion.html.haml
+++ b/app/views/motions/_motion.html.haml
@@ -1,10 +1,12 @@
-.motion
+.motion.translate-parent{id:"motion-#{motion.id}"}
   .row
     .span4.motion-header-info
       .clearfix
         %h3.motion-title.word-break= motion.name
         - if motion.closed?
           %span.label.label-important= t(:closed)
+        .translated-title.translated
+          = t(:loading)
       #closing-info
         - if motion.voting?
           = t(:proposal_closing_when, when: time_ago_in_words(motion.closing_at))
@@ -14,6 +16,8 @@
         = t(:proposed_when_by_who, when: time_ago_in_words(motion.created_at), who: motion.author_name)
     .span2.motion-admin-buttons
       = render '/motions/admin_buttons', motion: motion unless motion.closed?
+      - if TranslationService.can_translate? motion
+        = translate_link_for motion, 'btn btn-small'
   .row
     .span5
       =render "motions/outcome_statement", motion: motion, this_group: this_group if motion.closed?
@@ -23,7 +27,8 @@
       .description
         .long-description
           = render_rich_text(motion.description, false)
-
+        .translated-description.translated
+          = t(:loading)
   .pie{id: "graph_#{motion.id}"}
   .percentage-to-vote
     - if motion.closed?

--- a/app/views/motions/_votes_table_vote.html.haml
+++ b/app/views/motions/_votes_table_vote.html.haml
@@ -1,6 +1,9 @@
-.position-row.clearfix
+.position-row.translate-parent.clearfix{id: "vote-#{vote.id}"}
   %div{ :class => 'activity-icon ' + vote_icon_name(vote.position) }
   = link_to vote.user_name, user_path(vote.user), class: 'user-name'
   - if vote.can_be_edited_by?(current_user) && motion.voting?
     =link_to "edit", new_motion_vote_path(motion), class: 'btn btn-mini', id: 'edit-vote'
   %span.word-break~ vote.statement
+  .translated-position.translated= t(:loading)
+  - if TranslationService.can_translate? vote
+    =translate_link_for vote

--- a/app/views/motions/motion_translations.js.erb
+++ b/app/views/motions/motion_translations.js.erb
@@ -1,0 +1,5 @@
+title = "<%= get_translation @translation, :title %>";
+description = "<%= get_translation @translation, :description %>";
+motion = $('#motion-<%= @translation[:id].to_s %>');
+motion.find('.translated-title').html(title);
+motion.find('.translated-description').html(description);

--- a/app/views/votes/vote_translations.js.erb
+++ b/app/views/votes/vote_translations.js.erb
@@ -1,0 +1,2 @@
+statement = "<%= get_translation @translation, :statement %>";
+$('#vote-<%= @translation[:id] %>').find('.translated-position').html(statement);

--- a/config/initializers/is_translatable.rb
+++ b/config/initializers/is_translatable.rb
@@ -1,0 +1,27 @@
+module IsTranslatable
+  module Model
+    
+    def self.included(base)
+      base.send :extend, ClassMethods
+    end
+
+    module ClassMethods
+      def is_translatable(on: [], load_via: :find, id_field: :id, language_field: :language)
+        return unless TranslationService.available?
+        
+        define_singleton_method :translatable_fields, -> { Array on }
+        define_singleton_method :get_instance, ->(id) { send load_via, id }
+        
+        define_method :id_field, -> { send id_field }
+        define_method :language_field, -> { send language_field }
+        
+        send :include, Translatable
+      end
+    end
+
+  end
+end
+
+ActiveSupport.on_load(:active_record) do
+  include IsTranslatable::Model
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -954,6 +954,7 @@ en:
   more: "More..."
   translate: "Help translate Loomio!"
   translate_this_string: "Translate to %{language}"
+  failed_translation: "Unable to complete translation"
   options: "Options"
   other: "Other"
   ok_got_it: "Okay, got it!"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -136,7 +136,6 @@ Loomio::Application.routes.draw do
 
   resources :comments , only: :destroy do
     post :like, on: :member
-    post :translate, on: :member
   end
 
   resources :attachments, only: [:create, :new] do
@@ -175,6 +174,8 @@ Loomio::Application.routes.draw do
   end
 
   match '/announcements/:id/hide', to: 'announcements#hide', as: 'hide_announcement'
+    
+  post '/translate/:model/:id', to: 'translations#create', as: :translate
 
   get '/users/invitation/accept' => redirect {|params, request|  "/invitations/#{request.query_string.gsub('invitation_token=','')}"}
   get '/group_requests/:id/start_new_group' => redirect {|params, request|  "/invitations/#{request.query_string.gsub('token=','')}"}

--- a/db/migrate/20140207033248_create_translations.rb
+++ b/db/migrate/20140207033248_create_translations.rb
@@ -1,0 +1,12 @@
+class CreateTranslations < ActiveRecord::Migration
+  def change
+  	create_table :translations do |t|
+  		t.integer :translatable_id
+  		t.string :translatable_type
+  		t.string :translatable_field
+  		t.text :translation
+  		t.string :language
+  		t.timestamps
+  	end
+  end
+end

--- a/db/migrate/20140214205508_setup_hstore.rb
+++ b/db/migrate/20140214205508_setup_hstore.rb
@@ -1,0 +1,9 @@
+class SetupHstore < ActiveRecord::Migration
+  def change
+    execute "CREATE EXTENSION IF NOT EXISTS hstore"
+  end
+
+  def down
+    execute "DROP EXTENSION IF EXISTS hstore"
+  end
+end

--- a/db/migrate/20140214205509_add_hstore_to_translations.rb
+++ b/db/migrate/20140214205509_add_hstore_to_translations.rb
@@ -1,0 +1,7 @@
+class AddHstoreToTranslations < ActiveRecord::Migration
+  def change
+    add_column :translations, :fields, :hstore
+    remove_column :translations, :translation
+    remove_column :translations, :translatable_field
+  end
+end

--- a/db/migrate/20140214233354_add_index_to_hstore.rb
+++ b/db/migrate/20140214233354_add_index_to_hstore.rb
@@ -1,0 +1,9 @@
+class AddIndexToHstore < ActiveRecord::Migration
+  def up
+    execute "CREATE INDEX translations_gin_fields ON translations USING GIN(fields)"
+  end
+  
+  def down
+    execute "DROP INDEX translations_gin_fields"    
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -484,6 +484,17 @@ ActiveRecord::Schema.define(:version => 20140215042942) do
 
   add_index "test", ["age"], :name => "test_age_key", :unique => true
 
+  create_table "translations", :force => true do |t|
+    t.integer  "translatable_id"
+    t.string   "translatable_type"
+    t.string   "translatable_field"
+    t.string   "language"
+    t.datetime "created_at",         :null => false
+    t.datetime "updated_at",         :null => false
+    t.hstore   "fields"
+  end
+
+  add_index "translations", ["fields"], :name => "translations_gin_fields"
   create_table "users", :force => true do |t|
     t.string   "email",                                                       :default => "",         :null => false
     t.string   "encrypted_password",                           :limit => 128, :default => ""

--- a/features/discussions/comment_translate.feature
+++ b/features/discussions/comment_translate.feature
@@ -1,0 +1,54 @@
+Feature: Translate a comment into a different language
+  To allow a user to read a discussion regardless of his native language
+  A user must be able to translate comments in a different language
+
+  @javascript
+  Scenario: Comment in a different language
+    Given I am logged in
+    And I speak French
+    And I am a member of a group
+    And there is a discussion in the group
+    And there is a comment in the discussion
+    And the translator exists and can translate
+    And the comment is written by an English speaker
+    When I visit the discussion page
+    Then I should see a link to translate the comment
+    
+  @javascript
+  Scenario: Comment in the same language
+    Given I am logged in
+    And I speak English
+    And I am a member of a group
+    And there is a discussion in the group
+    And there is a comment in the discussion
+    And the comment is written by an English speaker
+    When I visit the discussion page
+    Then I should not see a link to translate the comment
+
+  @javascript
+  Scenario: Clicking translate link performs successful translation
+   	Given I am logged in
+    And I speak French
+    And I am a member of a group
+    And there is a discussion in the group
+    And there is a comment in the discussion
+    And the comment is written by an English speaker
+    And the translator exists and can translate
+    When I visit the discussion page
+ 	And I click on the translate link
+  	And I wait 5 seconds
+  	Then the translation should appear 
+  
+  @javascript
+  Scenario: Clicking translate link shows error message for failed translation
+   	Given I am logged in
+    And I speak French
+    And I am a member of a group
+    And there is a discussion in the group
+    And there is a comment in the discussion
+    And the comment is written by an English speaker
+    And the translator exists and cannot translate
+    When I visit the discussion page
+ 	And I click on the translate link
+  	And I wait 5 seconds
+  	Then a failure to translate message should appear   

--- a/features/step_definitions/comment_create_steps.rb
+++ b/features/step_definitions/comment_create_steps.rb
@@ -1,3 +1,17 @@
+Given /^there is a comment in the discussion$/ do
+  comment_author = FactoryGirl.create :user
+  @comment = FactoryGirl.create :comment, discussion: @discussion, user: comment_author, body: "Test comment!"
+  DiscussionService.add_comment @comment
+end
+
+Given /^the comment is written by an English speaker$/ do
+  @comment.author.update_attributes language_preference: :en
+end
+
+Given /^the comment is written by a French speaker$/ do
+  @comment.author.update_attributes language_preference: :fr
+end
+
 When /^I write and submit a comment$/ do
   @comment_text = 'Test comment,'
   @comment_markdown_text = ' also i like http://xkcd.org and also _markdown_'

--- a/features/step_definitions/comment_translate_steps.rb
+++ b/features/step_definitions/comment_translate_steps.rb
@@ -1,0 +1,37 @@
+Given /^the translator exists and can translate$/ do 
+  Discussion.any_instance.stub(:id_field).and_return(1)
+  Comment.any_instance.stub(:id_field).and_return(1)
+  Comment.stub(:get_instance).and_return(@comment)
+  TranslationService.stub(:available?).and_return(true)
+  TranslationService.stub(:can_translate?).with(anything()).and_return(true)
+  TranslationService.any_instance.stub(:translate).with(anything()).and_return({id: 1, body: 'successful translation' })
+end
+
+Given /^the translator exists and cannot translate$/ do
+  Discussion.any_instance.stub(:id_field).and_return(1)
+  Comment.any_instance.stub(:id_field).and_return(1)
+  Comment.stub(:get_instance).and_return(@comment)
+  TranslationService.stub(:available?).and_return(true)
+  TranslationService.stub(:can_translate?).with(anything()).and_return(true)
+  TranslationService.any_instance.stub(:translate).with(anything()).and_return({ id: 1, body: 'Unable to complete translation' })
+end
+
+When /^I click on the translate link$/ do
+  click_link 'translate-comment-1'
+end
+
+Then /^I should see a link to translate the comment$/ do
+  page.should have_css('#translate-comment-1')
+end
+
+Then /^I should not see a link to translate the comment$/ do
+  page.should have_no_css('#translate-comment-1')
+end
+
+Then /^the translation should appear$/ do
+  page.should have_content('successful translation')
+end
+
+Then /^a failure to translate message should appear$/ do
+  page.should have_content('Unable to complete translation')
+end

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -16,6 +16,14 @@ Given /^I am logged in$/ do
   login_automatically @user
 end
 
+Given /^I speak English$/ do
+  @user.update_attributes(language_preference: :en)
+end
+
+Given /^I speak French$/ do
+  @user.update_attributes(language_preference: :fr) 
+end
+
 Given /^I prefer markdown$/ do
   @user.update_attributes(uses_markdown: true)
 end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -24,6 +24,7 @@ describe "User abilities" do
     let(:user_comment) { discussion.add_comment(user, "hello") }
     let(:another_user_comment) { discussion.add_comment(other_user, "hello") }
     let(:user_motion) { create(:motion, author: user, discussion: discussion) }
+    let(:user_vote) { create(:vote, user: user, motion: user_motion)}
     let(:other_users_motion) { create(:motion, author: other_user, discussion: discussion) }
     let(:new_motion) { Motion.new(discussion_id: discussion.id) }
     let(:closed_motion) { create(:motion, discussion: discussion, closed_at: 1.day.ago) }
@@ -77,6 +78,9 @@ describe "User abilities" do
     it { should be_able_to(:vote, other_users_motion) }
     it { should_not be_able_to(:vote, closed_motion) }
 
+    it { should be_able_to(:show, user_comment) }
+    it { should be_able_to(:show, user_motion) }
+    it { should be_able_to(:show, user_vote) }
 
     it "cannot remove themselves if they are the only member of the group" do
       group.memberships.where("memberships.id != ?", @membership.id).destroy_all
@@ -226,6 +230,7 @@ describe "User abilities" do
       let(:discussion) { create_discussion group: group, private: true }
       let(:new_motion) { Motion.new(discussion_id: discussion.id) }
       let(:motion) { create(:motion, discussion: discussion) }
+      let(:vote) { create(:vote, user: discussion.author, motion: motion) }
       let(:new_discussion) { user.authored_discussions.new(
                              group: group, title: "new discussion") }
       let(:another_user_comment) { discussion.add_comment(discussion.author, "hello", uses_markdown: false) }
@@ -256,6 +261,11 @@ describe "User abilities" do
       it { should_not be_able_to(:destroy, another_user_comment) }
 
       it { should_not be_able_to(:vote, motion) }
+      
+      it { should_not be_able_to(:show, another_user_comment) }
+      it { should_not be_able_to(:show, motion) }
+      it { should_not be_able_to(:show, vote) }
+      
     end
 
     context "public group" do


### PR DESCRIPTION
- Adds translation caching, so we don't have to query bing every time we create a translation
- Adds a translation controller to handle generic translation requests
- Add front-end translation option for Discussion, Motion, and Vote objects
