### PR TITLE
fixes nil to string conversion when AWS key not set

### DIFF
--- a/app/helpers/upload_helper.rb
+++ b/app/helpers/upload_helper.rb
@@ -80,7 +80,7 @@ module UploadHelper
       Base64.encode64(
         OpenSSL::HMAC.digest(
           OpenSSL::Digest::Digest.new('sha1'),
-          @options[:aws_secret_access_key], policy
+          @options[:aws_secret_access_key] || "", policy
         )
       ).gsub("\n", "")
     end


### PR DESCRIPTION
Implicit nil to string conversion errors kept appearing when trying to view a thread if no AWS secret key was set.
