### PR TITLE
refactor modals and vote buttons

### DIFF
--- a/app/controllers/groups/membership_requests_controller.rb
+++ b/app/controllers/groups/membership_requests_controller.rb
@@ -55,6 +55,6 @@ class Groups::MembershipRequestsController < BaseController
   end
 
   def load_group
-    @group ||= GroupDecorator.new Group.find(params[:group_id])
+    @group ||= GroupDecorator.new Group.find_by_key!(params[:group_id])
   end
 end

--- a/app/controllers/motions_controller.rb
+++ b/app/controllers/motions_controller.rb
@@ -99,7 +99,7 @@ class MotionsController < GroupBaseController
 
   private
     def load_resource_by_key
-      @motion ||= Motion.find_by_key(params[:id])
+      @motion ||= Motion.find_by_key!(params[:id])
     end
 
     def group

--- a/app/helpers/groups_helper.rb
+++ b/app/helpers/groups_helper.rb
@@ -18,7 +18,7 @@ module GroupsHelper
       ( group.created_at < 1.month.ago ) &&
       !group.has_subscription_plan? &&
       !group.has_manual_subscription? &&
-      !group.is_sub_group? &&
+      !group.is_a_subgroup? &&
       ( I18n.locale == :en )
   end
 
@@ -38,29 +38,17 @@ module GroupsHelper
     end
   end
 
-  # sorry, not gonna bother refactoring this right now (Jon)
   def request_membership_button(group)
     if visitor?
-      if group.is_a_parent?
-        request_membership_icon_button(group)
-      else
-        disabled_request_membership_button(group)
-      end
+      request_membership_icon_button(group)
     else
       return if group.users_include?(current_user)
-      membership_request = group.membership_requests.where(requestor_id: current_user.id, response: nil).first
+
+      membership_request = group.membership_requests.pending.requested_by(current_user).first
       if membership_request.present?
         cancel_membership_request_button(membership_request)
       else
-        if group.is_a_parent?
-          request_membership_icon_button(group)
-        else
-          if group.user_is_a_parent_member?(current_user)
-            request_membership_icon_button(group)
-          else
-            disabled_request_membership_button(group)
-          end
-        end
+        request_membership_icon_button(group)
       end
     end
   end

--- a/app/helpers/motions_helper.rb
+++ b/app/helpers/motions_helper.rb
@@ -1,7 +1,7 @@
 module MotionsHelper
 
   def display_vote_buttons?(motion, user)
-    motion.voting? && (not motion.user_has_voted?(user)) && motion.group.users_include?(user)
+    motion.voting? && (not motion.user_has_voted?(user))
   end
 
   def time_select_options

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -105,10 +105,14 @@ class Ability
     end
 
     can :request_membership, Group do |group|
-      if group.is_sub_group?
-        group.parent.members.include?(user) and can?(:show, group)
+      if group.archived?
+        false
+      elsif group.is_not_hidden?
+        true
+      elsif group.is_a_subgroup? and group.viewable_by_parent_members? and @member_group_ids.include?(group.parent_id) # assumes group is hidden
+        true
       else
-        can?(:show, group)
+        false
       end
     end
 

--- a/app/models/discussion.rb
+++ b/app/models/discussion.rb
@@ -146,8 +146,12 @@ class Discussion < ActiveRecord::Base
     self.private == false
   end
 
+  def private
+    self.private?
+  end
+
   def private?
-    if self[:private].nil? and group.present?
+    if self[:private].nil? and group.present?  # this is some hideously unconfident code. discussions have a validation on private col
       group_default_is_private?
     else
       self[:private]
@@ -158,9 +162,6 @@ class Discussion < ActiveRecord::Base
     self[:private] = group_default_is_private? if group.present?
   end
 
-  def private
-    self.private?
-  end
 
   def group_default_is_private?
     ['hidden', 'private'].include? group.privacy

--- a/app/models/membership_request.rb
+++ b/app/models/membership_request.rb
@@ -13,6 +13,9 @@ class MembershipRequest < ActiveRecord::Base
   belongs_to :user, foreign_key: 'requestor_id' # duplicate relationship for eager loading
   belongs_to :responder, class_name: 'User'
 
+  scope :pending, -> { where response: nil }
+  scope :requested_by, ->(user) { where requestor_id: user.id }
+
   delegate :admins,               to: :group, prefix: true
   delegate :members,              to: :group, prefix: true
   delegate :membership_requests,  to: :group, prefix: true

--- a/app/views/discussions/_add_comment.html.haml
+++ b/app/views/discussions/_add_comment.html.haml
@@ -1,5 +1,5 @@
-- if can? :add_comment, discussion
-  - if last_page?
+- if last_page?
+  - if can? :add_comment, discussion
     = form_tag add_comment_discussion_path(discussion), :remote => true, id: "new-comment-form" do
       = render 'avatar', user: current_user
       #comment-input{ data: {group: @group.id, autocomplete_path: members_autocomplete_group_path(@group) } }
@@ -39,5 +39,5 @@
       %script#template-upload--comment-input{type: "text/x-tmpl"}
         %input{type: 'hidden', name: "attachments[]", value: '{%=o.id%}', data: { 'attachment-id' => "{%=o.id%}" }}
 
-- else
-  = render "add_comment_placeholder"
+  - else
+    = render "add_comment_placeholder"

--- a/app/views/discussions/_add_comment_placeholder.html.haml
+++ b/app/views/discussions/_add_comment_placeholder.html.haml
@@ -5,14 +5,3 @@
 
   = text_area_tag 'comment_placeholder', "", id: 'new-comment', placeholder: t(:comment_form_placeholder), class: 'js-prompt-visitor-to-authenticate'
   = submit_tag t(:comment_form_submit_button), class: "btn btn-small submit js-prompt-visitor-to-authenticate", id: 'post-new-comment', :data => {:disable_with => t(:comment_form_submit_button)}
-
-
-.modal.hide#prompt-visitor-to-authenticate
-  .modal-header
-    %h3= t :"prompt_visitor_to_authenticate.header"
-    %button.close{"data-dismiss" => "modal"}×
-  .modal-body
-    =t :"prompt_visitor_to_authenticate.body_html"
-  .modal-footer
-    =link_to t(:log_in), new_user_session_path, class: "btn btn-large btn-success"
-    =link_to t(:ask_to_join_group), group_ask_to_join_path(@group), class: "btn btn-large btn-primary", id: "align-button"

--- a/app/views/discussions/_prompt_visitor_to_authenticate_modal.html.haml
+++ b/app/views/discussions/_prompt_visitor_to_authenticate_modal.html.haml
@@ -1,0 +1,9 @@
+.modal.hide#prompt-visitor-to-authenticate
+  .modal-header
+    %h3= t :"prompt_visitor_to_authenticate.header"
+    %button.close{"data-dismiss" => "modal"}×
+  .modal-body
+    =t :"prompt_visitor_to_authenticate.body_html"
+  .modal-footer
+    =link_to t(:log_in), new_user_session_path, class: "btn btn-large btn-success"
+    =link_to t(:ask_to_join_group), group_ask_to_join_path(@group), class: "btn btn-large btn-primary", id: "align-button"

--- a/app/views/discussions/show.html.haml
+++ b/app/views/discussions/show.html.haml
@@ -63,3 +63,6 @@
                         %li.selector-item= render closed_motion, this_group: @group
                       - else
                         %li.selector-item= render '/motions/motion_preview', motion: closed_motion, this_group: @group
+
+- unless current_user
+  = render 'discussions/prompt_visitor_to_authenticate_modal'

--- a/app/views/motions/_cast_vote.haml
+++ b/app/views/motions/_cast_vote.haml
@@ -1,0 +1,24 @@
+- if prompt_visitor_to_authenticate ||= false
+  - prompt_class = 'js-prompt-visitor-to-authenticate'
+  - prompt_link = '#'
+- else
+  - prompt_class = ''
+
+%h3= t :state_your_position
+.vote-buttons.clearfix
+  =link_to image_tag("hand-yes.png", :title => t(:yes_position), :alt => t(:yes_position)),
+           prompt_link || new_motion_vote_path(motion_id: motion.id, position: 'yes'),
+           "title" => t(:yes_position), "data-content" => t(:yes_details),
+           class: "position btn vote-yes #{prompt_class}", id: "yes-vote"
+  =link_to image_tag("hand-abstain.png", :title => t(:abstain_position), :alt => t(:abstain_position)),
+           prompt_link || new_motion_vote_path(motion_id: motion.id, position: 'abstain'),
+           "title" => t(:abstain_position), "data-content" => t(:abstain_details),
+           class: "position btn vote-abstain #{prompt_class}", id: "abstain-vote"
+  =link_to image_tag("hand-no.png", :title => t(:no_position), :alt => t(:no_position)),
+           prompt_link || new_motion_vote_path(motion_id: motion.id, position: 'no'),
+           "title" => t(:no_position), "data-content" => t(:no_details),
+           class: "position btn vote-disagree #{prompt_class}", id: "no-vote"
+  =link_to image_tag("hand-block.png", :title => t(:block_position), :alt => t(:block_position)),
+           prompt_link || new_motion_vote_path(motion_id: motion.id, position: 'block'),
+           "title" => t(:block_position), "data-content" => t(:block_details),
+           class: "position btn vote-block #{prompt_class}", id: "block-vote"

--- a/app/views/motions/_motion.html.haml
+++ b/app/views/motions/_motion.html.haml
@@ -32,25 +32,11 @@
       = t(:engagement_on_open_proposal, percent: motion.percent_voted, :numerator => (motion.group_size_when_voting - motion.members_not_voted_count), denominator:  motion.group_size_when_voting)
 
   .votes
-    - if display_vote_buttons?(motion, current_user)
-      %h3= t :state_your_position
-      .vote-buttons.clearfix
-        =link_to image_tag("hand-yes.png", :title => t(:yes_position), :alt => t(:yes_position)),
-                 new_motion_vote_path(motion_id: motion.id, position: 'yes'),
-                 "title" => t(:yes_position), "data-content" => t(:yes_details),
-                 class: "position btn vote-yes", id: "yes-vote"
-        =link_to image_tag("hand-abstain.png", :title => t(:abstain_position), :alt => t(:abstain_position)),
-                 new_motion_vote_path(motion_id: motion.id, position: 'abstain'),
-                 "title" => t(:abstain_position), "data-content" => t(:abstain_details),
-                 class: "position btn vote-abstain", id: "abstain-vote"
-        =link_to image_tag("hand-no.png", :title => t(:no_position), :alt => t(:no_position)),
-                 new_motion_vote_path(motion_id: motion.id, position: 'no'),
-                 "title" => t(:no_position), "data-content" => t(:no_details),
-                 class: "position btn vote-disagree", id: "no-vote"
-        =link_to image_tag("hand-block.png", :title => t(:block_position), :alt => t(:block_position)),
-                 new_motion_vote_path(motion_id: motion.id, position: 'block'),
-                 "title" => t(:block_position), "data-content" => t(:block_details),
-                 class: "position btn vote-block", id: "block-vote"
+    - if can? :vote, motion
+      - if display_vote_buttons?(motion, current_user)
+        = render 'motions/cast_vote', motion: motion
+    - else
+      = render 'motions/cast_vote', motion: motion, prompt_visitor_to_authenticate: true
 
     .votes-table= render "motions/votes_table", motion: motion
 

--- a/features/groups/membership_request.feature
+++ b/features/groups/membership_request.feature
@@ -66,11 +66,13 @@ Feature: Individual requests group membership
     When I visit the request membership page for the sub-group
     Then I should be redirected to the dashboard
 
-  Scenario: User cannot request membership to a sub-group if they are not member of parent
+  Scenario: User can request membership to a sub-group if they are not member of parent
     Given I am logged in
     And a public sub-group exists
-    When I visit the request membership page for the sub-group
-    Then I should be redirected to the dashboard
+    When I visit the sub-group page
+    And I click "Ask to join group"
+    And I fill in and submit the Request membership form (introduction only)
+    Then I should see a flash message confirming my membership request
 
   Scenario: User with pending membership request cannot submit new request
     Given I am logged in

--- a/spec/controllers/motions_controller_spec.rb
+++ b/spec/controllers/motions_controller_spec.rb
@@ -8,7 +8,7 @@ describe MotionsController do
   let(:previous_url) { root_url }
 
   before :each do
-    Motion.stub(:find_by_key).with(motion.key).and_return motion
+    Motion.stub(:find_by_key!).with(motion.key).and_return motion
     Group.stub(:find).and_return(group)
     Discussion.stub(:find).and_return(discussion)
     request.env["HTTP_REFERER"] = previous_url
@@ -84,7 +84,7 @@ describe MotionsController do
         controller.stub(:authorize!).with(:edit_close_date, motion).and_return(true)
       end
       it "checks user has permission" do
-        Motion.stub(:find_by_key).with(motion.key).and_return FactoryGirl.create(:motion, :discussion => discussion)
+        Motion.stub(:find_by_key!).with(motion.key).and_return FactoryGirl.create(:motion, :discussion => discussion)
         controller.should_receive(:authorize!)
         put :edit_close_date, :id => motion.key, :motion => { close_at_date: Time.now,
                           close_at_time: "05:00", close_at_time_zone: "Wellington" }

--- a/spec/helpers/motion_helper_spec.rb
+++ b/spec/helpers/motion_helper_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe MotionsHelper do
-  describe "display_vote_buttons?(motion)" do
+  describe "display_vote_buttons?(motion, user)" do
     before do
       @user = double :user
       @motion = mock_model(Motion)
@@ -17,12 +17,6 @@ describe MotionsHelper do
     end
     context "user has voted" do
       before { @motion.stub(:user_has_voted?).and_return(true) }
-      it "returns false" do
-        display_vote_buttons?(@motion, @user).should == false
-      end
-    end
-    context "user does not belong to the group" do
-      before { @motion.stub_chain(:group, :users_include?).and_return(false)}
       it "returns false" do
         display_vote_buttons?(@motion, @user).should == false
       end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -33,50 +33,49 @@ describe "User abilities" do
       @other_membership = group.add_member!(other_user)
     end
 
-    it { should be_able_to(:create, subgroup) }
-    it { should be_able_to(:show, group) }
+    it { should     be_able_to(:create, subgroup) }
+    it { should     be_able_to(:show, group) }
     it { should_not be_able_to(:update, group) }
     it { should_not be_able_to(:email_members, group) }
-    it { should be_able_to(:add_subgroup, group) }
-    it { should be_able_to(:create, subgroup) }
+    it { should     be_able_to(:add_subgroup, group) }
+    it { should     be_able_to(:create, subgroup) }
     it { should_not be_able_to(:create, subgroup_for_another_group) }
     it { should_not be_able_to(:view_payment_details, group) }
     it { should_not be_able_to(:choose_subscription_plan, group) }
-    it { should be_able_to(:new_proposal, discussion) }
-    it { should be_able_to(:add_comment, discussion) }
-    it { should be_able_to(:update_description, discussion) }
-    it { should be_able_to(:edit_description, group) }
-    it { should be_able_to(:show_description_history, discussion) }
-    it { should be_able_to(:preview_version, discussion) }
-    it { should be_able_to(:update_version, discussion) }
+    it { should     be_able_to(:new_proposal, discussion) }
+    it { should     be_able_to(:add_comment, discussion) }
+    it { should     be_able_to(:update_description, discussion) }
+    it { should     be_able_to(:edit_description, group) }
+    it { should     be_able_to(:show_description_history, discussion) }
+    it { should     be_able_to(:preview_version, discussion) }
+    it { should     be_able_to(:update_version, discussion) }
     it { should_not be_able_to(:move, discussion) }
     it { should_not be_able_to(:update, discussion) }
-    it { should be_able_to(:update, user_discussion) }
-    it { should be_able_to(:show, Discussion) }
-    it { should be_able_to(:unfollow, Discussion) }
-    it { should be_able_to(:destroy, user_comment) }
+    it { should     be_able_to(:update, user_discussion) }
+    it { should     be_able_to(:show, Discussion) }
+    it { should     be_able_to(:unfollow, Discussion) }
+    it { should     be_able_to(:destroy, user_comment) }
     it { should_not be_able_to(:destroy, discussion) }
     it { should_not be_able_to(:destroy, another_user_comment) }
-    it { should be_able_to(:like_comments, discussion) }
-    it { should be_able_to(:create, new_discussion) }
+    it { should     be_able_to(:like_comments, discussion) }
+    it { should     be_able_to(:create, new_discussion) }
     it { should_not be_able_to(:make_admin, @membership) }
     it { should_not be_able_to(:make_admin, @other_membership) }
     it { should_not be_able_to(:destroy, @other_membership) }
-    it { should be_able_to(:destroy, @membership) }
-    it { should be_able_to(:create, new_motion) }
-    it { should be_able_to(:close, user_motion) }
-    it { should be_able_to(:create_outcome, user_motion) }
-    it { should be_able_to(:edit_close_date, user_motion) }
-    it { should be_able_to(:destroy, user_motion) }
+    it { should     be_able_to(:destroy, @membership) }
+    it { should     be_able_to(:create, new_motion) }
+    it { should     be_able_to(:close, user_motion) }
+    it { should     be_able_to(:create_outcome, user_motion) }
+    it { should     be_able_to(:edit_close_date, user_motion) }
+    it { should     be_able_to(:destroy, user_motion) }
     it { should_not be_able_to(:destroy, other_users_motion) }
     it { should_not be_able_to(:close, other_users_motion) }
     it { should_not be_able_to(:create_outcome, other_users_motion) }
     it { should_not be_able_to(:edit_close_date, other_users_motion) }
 
-    it { should be_able_to(:vote, user_motion) }
-    it { should be_able_to(:vote, other_users_motion) }
+    it { should     be_able_to(:vote, user_motion) }
+    it { should     be_able_to(:vote, other_users_motion) }
     it { should_not be_able_to(:vote, closed_motion) }
-
 
     it "cannot remove themselves if they are the only member of the group" do
       group.memberships.where("memberships.id != ?", @membership.id).destroy_all
@@ -372,6 +371,13 @@ describe "User abilities" do
                               viewable_by_parent_members: true) }
       it { should_not be_able_to(:show, subgroup) }
       it { should_not be_able_to(:request_membership, subgroup) }
+    end
+
+    context "subgroup which is non-hidden" do
+      let(:group) { create :group}
+      let(:subgroup) { create(:group, parent: group, privacy: 'private') }
+
+      it { should be_able_to(:request_membership, subgroup) }
     end
   end
 


### PR DESCRIPTION
changes i've made: 

> +for logger out users
> - made the comment box appear on only last page of discussion (instead of every page)
> - put the authentication/ ask to join modal in the show page so it's only ever rendered once
> - a refactor of the vote buttons into a partial. 

note that the return_to does not take the users to the voting page, because the vote links needed to be disabled from redirecting. there might be a better solution
