### PR TITLE
change attachment location col to type :text

### DIFF
--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -5,8 +5,19 @@ class Attachment < ActiveRecord::Base
   validates_presence_of :filename, :location, :user_id
 
   def is_an_image?
-    extension = self.filename.split('.').last.downcase
-    %w[jpg jpeg png].include?(extension)
+    %w[jpg jpeg png gif].include?(filetype)
+  end
+
+  def truncated_filename(length = 30)
+    if filename.length > length
+      filename.truncate(length) + filetype
+    else
+      filename
+    end
+  end
+
+  def filetype
+    filename.split('.').last.downcase
   end
 end
 

--- a/app/views/comments/_comment.html.haml
+++ b/app/views/comments/_comment.html.haml
@@ -15,13 +15,12 @@
         -comment.attachments.each do |a|
           .comment-attachment
             %img{src: '/assets/paperclip22.png', class: 'paperclip'}
-            =link_to a.filename, a.location, { target: 'blank' }
+            =link_to a.truncated_filename(38), a.location, { target: 'blank' }
             -fileSizeText = (a.filesize >= 1048576) ? (a.filesize/1048576.0).round(1).to_s + ' MB' : (a.filesize/1024.0).round.to_s + ' kB';
             ="("+fileSizeText+")"
 
-            -if a.filesize < 1048576
-              -if a.is_an_image?
-                =link_to image_tag(a.location), a.location, { target: 'blank', class: 'attachment-image' }
+            -if a.is_an_image? && a.filesize < 1048576
+              =link_to image_tag(a.location), a.location, { target: 'blank', class: 'attachment-image' }
 
       .comment-time-and-likes
         =render 'comments/comment_likes', comment: comment

--- a/db/migrate/20140227000252_change_attachment_location_column_to_text.rb
+++ b/db/migrate/20140227000252_change_attachment_location_column_to_text.rb
@@ -1,0 +1,9 @@
+class ChangeAttachmentLocationColumnToText < ActiveRecord::Migration
+  def up
+   change_column :attachments, :location, :text
+  end
+
+  def down
+   change_column :attachments, :location, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20140222234734) do
+ActiveRecord::Schema.define(:version => 20140227000252) do
 
   create_table "active_admin_comments", :force => true do |t|
     t.string   "resource_id",   :null => false
@@ -50,7 +50,7 @@ ActiveRecord::Schema.define(:version => 20140222234734) do
   create_table "attachments", :force => true do |t|
     t.integer  "user_id"
     t.string   "filename"
-    t.string   "location"
+    t.text     "location"
     t.integer  "comment_id"
     t.datetime "created_at", :null => false
     t.datetime "updated_at", :null => false


### PR DESCRIPTION
can confirm that the migration preserves existing attachments (click links on clone)

also tested this locally and on clone with md5 hashes:

``` ruby
Digest::MD5.hexdigest(Attachment.all.map(&:location).join(''))
```
### Local :white_check_mark:

> before_migration `599085c43db994c56e365e3eb6ad4989`
> after_migration    `599085c43db994c56e365e3eb6ad4989`
### Clone :white_check_mark:

> before_migration `352d2fa09d9fdbaf56ad825ddc8b582b`
> after_migration    `352d2fa09d9fdbaf56ad825ddc8b582b`
