### PR TITLE
move dashboard to its own route

### DIFF
--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -7,7 +7,7 @@ class Admin::BaseController < ApplicationController
   def require_admin
     unless current_user.is_admin?
       flash[:error] = "You need to be a system admin for that"
-      redirect_to root_path
+      redirect_to dashboard_path
     end
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,7 +12,7 @@ class ApplicationController < ActionController::Base
   rescue_from CanCan::AccessDenied do |exception|
     if current_user
       flash[:error] = t("error.access_denied")
-      redirect_to root_url
+      redirect_to dashboard_path
     else
       store_location
       authenticate_user!
@@ -25,6 +25,14 @@ class ApplicationController < ActionController::Base
     current_user || LoggedOutUser.new
   end
 
+  def dashboard_or_root_path
+    if current_user
+      dashboard_path
+    else
+      root_path
+    end
+  end
+
   def store_location
     session['user_return_to'] = request.original_url
   end
@@ -34,7 +42,7 @@ class ApplicationController < ActionController::Base
   end
 
   def after_sign_in_path_for(resource)
-    path = session['user_return_to'] || root_path
+    path = session['user_return_to'] || dashboard_path
     clear_stored_location
     path
   end
@@ -49,8 +57,6 @@ class ApplicationController < ActionController::Base
 
 
   before_filter :configure_permitted_parameters, if: :devise_controller?
-
-  protected
 
   def configure_permitted_parameters
     devise_parameter_sanitizer.for(:sign_up) do |u|

--- a/app/controllers/contact_messages_controller.rb
+++ b/app/controllers/contact_messages_controller.rb
@@ -16,10 +16,11 @@ class ContactMessagesController < BaseController
   	if @contact_message.save
       ContactMessageMailer.delay.contact_message_email(@contact_message)
       flash[:success] = "Thanks! Someone from our team will get back to you shortly!"
-      redirect_to root_path
+
+      redirect_to dashboard_or_root_path
     else
       render 'new'
     end
   end
-end
 
+end

--- a/app/controllers/discussions_redirect_controller.rb
+++ b/app/controllers/discussions_redirect_controller.rb
@@ -13,8 +13,8 @@ class DiscussionsRedirectController < ApplicationController
 
     def reject_new_ids
       if params[:id].to_i > BLOCK_ID_GREATER_THAN
-        flash[:error] = "use keys to access records with id greater than > #{BLOCK_ID_GREATER_THAN}"
-        redirect_to root_path
+        flash[:error] = "use keys to access records with id greater than #{BLOCK_ID_GREATER_THAN}"
+        redirect_to dashboard_path
       end
     end
 

--- a/app/controllers/groups/memberships_controller.rb
+++ b/app/controllers/groups/memberships_controller.rb
@@ -29,7 +29,7 @@ class Groups::MembershipsController < GroupBaseController
     @membership.destroy
     if current_user == @membership.user
       flash[:notice] = t("notice.you_have_left_group", which_group: @membership.group.name)
-      redirect_to root_path
+      redirect_to dashboard_path
     else
       flash[:notice] = t("notice.member_removed")
       redirect_to [@membership.group, :memberships]

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -76,7 +76,7 @@ class GroupsController < GroupBaseController
   def archive
     @group.archive!
     flash[:success] = t("success.group_archived")
-    redirect_to root_path
+    redirect_to dashboard_path
   end
 
   def hide_next_steps

--- a/app/controllers/motions_redirect_controller.rb
+++ b/app/controllers/motions_redirect_controller.rb
@@ -14,8 +14,8 @@ class MotionsRedirectController < ApplicationController
 
     def reject_new_ids
       if params[:id].to_i > BLOCK_ID_GREATER_THAN
-        flash[:error] = "use keys to access records with id greater than > #{BLOCK_ID_GREATER_THAN}"
-        redirect_to root_path
+        flash[:error] = "use keys to access records with id greater than #{BLOCK_ID_GREATER_THAN}"
+        redirect_to dashboard_path
       end
     end
 

--- a/app/controllers/users/email_preferences_controller.rb
+++ b/app/controllers/users/email_preferences_controller.rb
@@ -10,7 +10,7 @@ class Users::EmailPreferencesController < BaseController
     resource
     if resource.update_attributes(permitted_params.email_preferences)
       flash[:notice] = "Your email settings have been updated."
-      redirect_to root_url
+      redirect_to dashboard_or_root_path
     else
       flash[:error] = "Failed to update settings"
       render :edit

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,7 +3,7 @@ class UsersController < BaseController
     @user = User.find_by_key!(params[:id])
     unless current_user.in_same_group_as?(@user)
       flash[:error] = t("error.cant_view_member_profile")
-      redirect_to root_url
+      redirect_to dashboard_path
     end
   end
 
@@ -11,7 +11,7 @@ class UsersController < BaseController
     if current_user.update_attributes(permitted_params.user)
       set_locale
       flash[:notice] = t("notice.settings_updated")
-      redirect_to root_url
+      redirect_to dashboard_path
     else
       @user = current_user
       flash[:error] = t("error.settings_not_updated")

--- a/app/controllers/votes_controller.rb
+++ b/app/controllers/votes_controller.rb
@@ -26,7 +26,7 @@ class VotesController < BaseController
     def require_user_can_vote
       unless can?(:vote, motion)
         flash[:notice] = "You don't have permission to vote on the motion"
-        redirect_to root_url
+        redirect_to dashboard_path
       end
     end
 

--- a/app/views/application/_header.html.haml
+++ b/app/views/application/_header.html.haml
@@ -6,7 +6,7 @@
         %ul.nav-bar-list.clearfix
           - if user_signed_in?
             %li.nav-item#logo-home
-              %a.nav-logo-link{:href => "/"}
+              %a.nav-logo-link{:href => dashboard_path}
                 = image_tag(navbar_logo_path, :alt => "Loomio")
             = render 'inbox'
             = render 'notifications_dropdown'

--- a/app/views/groups/_title.html.haml
+++ b/app/views/groups/_title.html.haml
@@ -1,6 +1,6 @@
 .group-title
   %h1.home-title
-    = link_to t(:home), "/"
+    = link_to t(:home), dashboard_path
     = content_tag :span, "\u25B6", class: 'name-separator'
     - if @group
       - if @group.is_a_subgroup?

--- a/app/views/layouts/pages.html.haml
+++ b/app/views/layouts/pages.html.haml
@@ -28,19 +28,19 @@
               =link_to t(:'devise.sessions.sign_in'), new_user_session_path, class: 'btn btn-info'
           .span3 &nbsp;
           .span6
-            =link_to image_tag("logo-426px-mauve-matte.png"), "/"
+            =link_to image_tag("logo-426px-mauve-matte.png"), root_path
             %h2 collaborative decision-making
         .frontpage-nav
-          =link_to('Purpose', '/purpose')
+          =link_to 'Purpose', purpose_path
           %span &middot;
 
-          =link_to('How it works', '/purpose#how-it-works')
+          =link_to 'How it works', purpose_path(anchor: 'how-it-works')
           %span &middot;
 
-          =link_to('Pricing', '/pricing')
+          =link_to 'Pricing', pricing_path
           %span &middot;
 
-          =link_to('About us', '/about')
+          =link_to 'About us', about_path
           %span &middot;
 
           =link_to('Blog', blog_path)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -184,10 +184,7 @@ Loomio::Application.routes.draw do
     get :thanks, on: :collection
   end
 
-  authenticated do
-    root :to => 'dashboard#show'
-  end
-
+  get '/dashboard', to: 'dashboard#show', as: 'dashboard'
   root :to => 'pages#home'
 
   scope controller: 'pages' do

--- a/features/announcements.feature
+++ b/features/announcements.feature
@@ -14,7 +14,7 @@ Feature: Announcements
     Given there is an announcement
     When I load the dashboard
     And I dismiss the announcement
-    And I reload the page
+    And I reload the dashboard
     Then I should not see the announcement
 
   Scenario: User does not see announcements when starting group

--- a/features/step_definitions/announcements_steps.rb
+++ b/features/step_definitions/announcements_steps.rb
@@ -4,7 +4,7 @@ Given /^there is an announcement$/ do
 end
 
 When /^I load the dashboard$/ do
-  visit '/'
+  visit dashboard_path
 end
 
 Then /^I should see the announcement$/ do
@@ -15,8 +15,8 @@ When /^I dismiss the announcement$/ do
   find('.close.dismiss-announcement').click()
 end
 
-When /^I reload the page$/ do
-  visit '/'
+When /^I reload the dashboard$/ do
+  visit dashboard_path
 end
 
 Then /^I should not see the announcement$/ do

--- a/features/step_definitions/see_number_of_new_comments_steps.rb
+++ b/features/step_definitions/see_number_of_new_comments_steps.rb
@@ -8,7 +8,7 @@ Given /^someone comments on the discussion$/ do
 end
 
 When /^I visit the dashboard$/ do
-  visit root_path
+  visit dashboard_path
 end
 
 Then(/^I should see that the discussion has (\d+) unread$/) do |arg1|

--- a/public/500.html
+++ b/public/500.html
@@ -45,7 +45,7 @@
 <body>
   <!-- This file lives in public/500.html -->
   <div id="error-container">
-    <a href="/" title="Return Home">
+    <a href="/dashboard" title="Return Home">
       <h1 id="header">Loomio</h1>
     </a>
     <div class="content">

--- a/spec/controllers/groups_controller_spec.rb
+++ b/spec/controllers/groups_controller_spec.rb
@@ -74,7 +74,7 @@ describe GroupsController do
 
         it "sets flash and redirects to the dashboard" do
           flash[:success].should =~ /Group archived successfully/
-          response.should redirect_to '/'
+          response.should redirect_to '/dashboard'
         end
       end
     end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -24,10 +24,10 @@ describe UsersController do
       post :update, :id => 999, :user => {:name => "Peter Chilltooth"}
       flash[:error].should =~ /Your settings did not get updated./
     end
-    it "redirects to root on success" do
+    it "redirects to dashboard on success" do
       user.stub(:save).and_return(true)
       post :update, :id => 999, :user => {:name => "Peter Chilltooth"}
-      response.should redirect_to(root_url)
+      response.should redirect_to(dashboard_path)
     end
     it "redirects to user settings on failure" do
       user.stub(:save).and_return(false)


### PR DESCRIPTION
this splits the concept of 'home' so that `loomio.org` will always show the frontpage.

when you're logged in, if you want to see your dashboard that is now at   `loomio.org/dashboard`

``` ruby
root_path should == '/'
dashboard_path should == '/dashboard'
```

there are a number of places in the app where completion of actions should return you to your dashboard. these are things like saving settings, or being rejected from trying to access a group you're trying to access, and clicking the loomio logo in the nav-bar 
