### PR TITLE
minimally functional crowd page

### DIFF
--- a/app/assets/stylesheets/pages.css.scss
+++ b/app/assets/stylesheets/pages.css.scss
@@ -546,6 +546,10 @@ body.pages.terms_of_service {
     text-align: center;
     img { width: 600px; }
   }
+  .plain-white-link {
+    color: #ffffff;
+    &:hover { text-decoration: none; }
+  }
 }
 
 .container#contact_message {

--- a/app/views/pages/crowd.html.haml
+++ b/app/views/pages/crowd.html.haml
@@ -18,15 +18,15 @@
       .row-fluid
         .span4.offset2
           %button.btn.btn-block.btn-large.btn-success
-            1. Join the Thunderclap
+            =link_to "1. Join the Thunderclap", "https://www.google.com/url?q=https%3A%2F%2Fwww.thunderclap.it%2Fprojects%2F9310-bring-loomio-to-the-world&sa=D&sntz=1&usg=AFQjCNGpVAuu49PT7AqrTXB1lFzD7q_Lbg", target: '_blank', class: 'plain-white-link'
           %br
           %p Thunderclap will auto-share the campaign for you the day we launch.
         .span4
           %button.btn.btn-block.btn-large.btn-primary
-            2. Join the mailing list
+            =link_to "2. Join the mailing list", 'http://eepurl.com/Pr8Xz', target: '_blank', class: 'plain-white-link'
           %br
           %p We'll let you know when we launch the campaign.
-  
+
   %section
     .inner-container
       .row-fluid
@@ -34,8 +34,8 @@
           %h2
             Loomio is free open-source software
             %br
-            for anyone, anywhere 
-            %br 
+            for anyone, anywhere
+            %br
             to participate in decisions that affect them.
             %br
             %br
@@ -97,7 +97,7 @@
             It needs to be
             %strong open,
             to include everyone.
-          %p So we’re building 100% free and open source. We're building public infrastructure for decision-making, held in the commons. 
+          %p So we’re building 100% free and open source. We're building public infrastructure for decision-making, held in the commons.
 
 
   %section
@@ -109,7 +109,7 @@
             We’re launching March 11th 2014.
             %br
           %br
-          %p We’ve done all the research and design, now we just have to fund the development needed to release it to the world. 
+          %p We’ve done all the research and design, now we just have to fund the development needed to release it to the world.
           %p We’re crowdfunding so that the project will be driven by the community of people who want it to happen, not by advertisers or corporate interests.
 
 
@@ -134,8 +134,8 @@
       .row-fluid
         .span8.offset2
           %h3 More Information
-          %p 
-            An amazing team of open-source developers and social justice activists in Wellington, New Zealand, has come together to make this happen. 
+          %p
+            An amazing team of open-source developers and social justice activists in Wellington, New Zealand, has come together to make this happen.
             = link_to "Find out more.", about_path
           %p
             %strong Contact us


### PR DESCRIPTION
![image](https://f.cloud.github.com/assets/2665886/2300288/ba6abade-a0e8-11e3-814c-563d43bd3df8.png)

[:question:] mail-chimp subscription page needs design/ colour
[:question:] default is that subscribers have to click confirm in email they are sent. good?
[:question:] open link in new page

possible extensions:
[  ] facebook integration
[  ] in-page form for mailchimp 
