### PR TITLE
remove ie7 asset from precompile

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -7,9 +7,6 @@
     /[if lt IE 9]
       =javascript_include_tag 'ie8'
 
-    /[if lt IE 8]
-      = stylesheet_link_tag 'ie7', media: "all"
-
     = stylesheet_link_tag    "application"
     = javascript_include_tag "application"
     = csrf_meta_tags

--- a/config/application.rb
+++ b/config/application.rb
@@ -66,7 +66,7 @@ module Loomio
     # Enable roadie (email css-->inline style gem)
     config.roadie.enable = true
 
-    config.assets.precompile += %w(ie7.css ie8.js active_admin.css active_admin.js frontpage.js frontpage.css active_admin/print.css)
+    config.assets.precompile += %w(ie8.js active_admin.css active_admin.js frontpage.js frontpage.css active_admin/print.css)
 
     config.quiet_assets = true
   end

--- a/config/loomio.yml
+++ b/config/loomio.yml
@@ -1,8 +1,8 @@
 required:
   # when/if we find required keys, we should load them into an array like so:
   # - REQUIRED_KEY
-  # - REQUIRED_KEY_2 
-  
+  # - REQUIRED_KEY_2
+
 optional:
   SECRET_COOKIE_TOKEN: ""
   EXCEPTION_RECIPIENT: ""
@@ -15,6 +15,6 @@ optional:
   BING_TRANSLATION_SECRET: ""
   NAVBAR_LOGO_PATH: top-bar-loomio.png
   NAVBAR_CONTRIBUTE: show
-  CANONICAL_HOST: loomio.org
+  # CANONICAL_HOST: loomio.org
   FOG_DIRECTORY: ""
   TAG_MANAGER_ID: ""


### PR DESCRIPTION
@jdoud there was a little gotcha on the asset front that crashed production
please have a quick look to see how to avoid in future 

@robguthrie this is depoyed at [clone.loomio.org](clone.loomio.org)
everything looks dandy
