### PR TITLE
Changed #visible_to_the_public to include 'Mostly Private' groups

### DIFF
--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -37,7 +37,7 @@ class Group < ActiveRecord::Base
         order('memberships_count DESC')
 
   scope :visible_to_the_public,
-        where(privacy: 'public').
+        where(privacy: ['public', 'private']).
         parents_only
 
   scope :manual_subscription, -> { where(payment_plan: 'manual_subscription') }

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -305,4 +305,20 @@ describe Group do
     end
   end
 
+  describe "visible_to_the_public" do
+    let(:private_group) { FactoryGirl.create(:group, privacy: 'private') }
+    let(:hidden_group) { FactoryGirl.create(:group, privacy: 'hidden') }
+
+    before do
+      private_group
+      hidden_group
+      group
+    end
+
+    subject { Group.visible_to_the_public }
+    it { should include group }
+    it { should include private_group }
+    it { should_not include hidden_group }
+  end
+
 end


### PR DESCRIPTION
'Mostly Private' groups were not showing up on the group index.  Tests included in group_spec

Before

![image](https://f.cloud.github.com/assets/4204461/2432291/fc71ee12-ad5d-11e3-934a-94d3d677c5ae.png)

After

![image](https://f.cloud.github.com/assets/4204461/2432293/1d766aca-ad5e-11e3-9d35-66a051e768c8.png)
