### PR TITLE
raise visibility of revision history in activity feed

### DIFF
--- a/app/assets/stylesheets/unstructured/_discussions.css.scss
+++ b/app/assets/stylesheets/unstructured/_discussions.css.scss
@@ -428,6 +428,11 @@ body.discussions.show {
         color: $mid-grey;
         font-style: italic;
         word-wrap: break-word;
+        .see-description-history {
+          color: #999;
+          font-style: normal;
+          font-size: 0.9em;
+        }
       }
 
       .activity-item-header{

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -373,6 +373,7 @@ en:
     started_html: "Started %{when} ago by <a href='%{link}' class='%{link_class}'>%{who}</a>"
     last_edited_html: "Last edited %{when} ago by <a href='%{link}' class='%{link_class}'>%{who}</a>"
     see_revision_history: "See revision history"
+    see_history: "See history"
 
   description_history:
     header: "Revision history"

--- a/extras/discussion_items/discussion_description_edited.rb
+++ b/extras/discussion_items/discussion_description_edited.rb
@@ -22,7 +22,7 @@ class DiscussionItems::DiscussionDescriptionEdited < DiscussionItem
   end
 
   def body
-    ""
+    "<a href='/d/#{@discussion.key}/show_description_history' class='see-description-history' data-method='post' data-remote='true' rel='nofollow'>(#{I18n.t(:"discussion_context.see_history")})</a>".html_safe
   end
 
   def time


### PR DESCRIPTION
code is a little smelly, but a sweet little functional extension.
design informed by jon

![image](https://cloud.githubusercontent.com/assets/2665886/2786145/3765e150-cb6c-11e3-9461-e3046911c5ce.png)
