### PR TITLE
Set rake version in gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source 'http://rubygems.org'
 
 ruby '2.0.0'
 gem 'rails', '~> 3.2.17'
+gem 'rake', '~> 10.2.1'
 gem 'haml-rails', '~> 0.4.0'
 gem 'devise', '~> 3.2.0'
 gem 'omniauth', '~> 1.2.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -608,6 +608,7 @@ DEPENDENCIES
   rack_session_access (~> 0.1.1)
   rails (~> 3.2.17)
   rails-backbone (~> 0.7.2)
+  rake (~> 10.2.1)
   rb-fchange (~> 0.0.5)
   rb-fsevent (~> 0.9.1)
   rb-inotify (~> 0.8.8)


### PR DESCRIPTION
I've been having some issues developing on Loomio recently because I have Rails 3 and Rails 4 apps running on my machine, and so I have a higher version of rake installed than Rails 3.2 can support. 
This leads to issues because Rails will use the highest version of the gem it can find if it's not specified.

Any opposition to setting the rake version in the Gemfile to prevent this?
