### PR TITLE
Fix team image width on homepage

### DIFF
--- a/app/assets/stylesheets/marketing/splash.css.scss
+++ b/app/assets/stylesheets/marketing/splash.css.scss
@@ -678,4 +678,7 @@ a:hover { text-decoration: none; }
   .alert{
     border-radius: 0;
   }
+  img.full-width {
+    width: 100%;
+  }
 }

--- a/app/views/marketing/index.html.haml
+++ b/app/views/marketing/index.html.haml
@@ -160,7 +160,7 @@
           %blockquote= t(:'frontpage.quote.header.sifry_html')
 
       .row
-        = image_tag 'team.png', class: 'img-responsive', alt: 'The Loomio team'
+        = image_tag 'team.png', class: 'img-responsive full-width', alt: 'The Loomio team'
 
       .row.team
         %a{href: about_path, class: 'block-link'}


### PR DESCRIPTION
Think this oughta do it for #1509; tested it out on small (320x480), medium (1024x768), and large (2560x1440) screens
