### PR TITLE
Update discussion counts on archive

### DIFF
--- a/app/models/discussion.rb
+++ b/app/models/discussion.rb
@@ -70,7 +70,9 @@ class Discussion < ActiveRecord::Base
   end
 
   def archive!
-    self.update_attribute(:archived_at, DateTime.now)
+    return if is_archived?
+    self.update_attribute :archived_at, DateTime.now and
+    Group.update_counters(group_id, discussions_count: -1) and true
   end
 
   def is_archived?

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -190,6 +190,10 @@ class Group < ActiveRecord::Base
     motions.closed
   end
 
+  def motions_count
+    discussions.published.sum :motions_count
+  end
+
   def archive!
     self.discussions.each(&:archive!)
     self.update_attribute(:archived_at, DateTime.now)

--- a/app/models/motion.rb
+++ b/app/models/motion.rb
@@ -6,8 +6,8 @@ class Motion < ActiveRecord::Base
   belongs_to :author, class_name: 'User'
   belongs_to :user, foreign_key: 'author_id' # duplicate author relationship for eager loading
   belongs_to :outcome_author, class_name: 'User'
-  belongs_to :discussion
-  # has_one :group, through: :discussion
+  belongs_to :discussion, counter_cache: true
+
   has_many :votes, dependent: :destroy, include: :user
   has_many :unique_votes, class_name: 'Vote', conditions: { age: 0 }, include: :user
   has_many :did_not_votes, dependent: :destroy, include: :user
@@ -99,7 +99,7 @@ class Motion < ActiveRecord::Base
   def can_be_edited?
     !persisted? || (voting? && (!has_votes? || group.motions_can_be_edited?))
   end
-
+  
   # number of final votes
   def total_votes_count
     vote_counts.values.sum
@@ -238,4 +238,5 @@ class Motion < ActiveRecord::Base
     def fire_new_motion_event
       Events::NewMotion.publish!(self)
     end
+
 end

--- a/db/migrate/20140608052627_update_counter_caches.rb
+++ b/db/migrate/20140608052627_update_counter_caches.rb
@@ -1,0 +1,29 @@
+class UpdateCounterCaches < ActiveRecord::Migration
+  def up
+    remove_column :groups, :motions_count
+    add_column :discussions, :motions_count, :integer, default: 0
+
+    Discussion.reset_column_information
+    Group.reset_column_information
+
+    Group.update_all discussions_count: 0
+    Discussion.update_all motions_count: 0
+
+    progress_bar = ProgressBar.create( format: "(\e[32m%c/%C\e[0m) %a |%B| \e[31m%e\e[0m ", progress_mark: "\e[32m/\e[0m", total: Group.count )
+
+    Group.find_each do |group|
+      progress_bar.increment
+      discussion_ids = Discussion.published.where(group_id: group.id).pluck(:id)
+      Group.update_counters group.id, discussions_count: discussion_ids.size if discussion_ids.size > 0
+      discussion_ids.each do |discussion_id|
+        motion_ids = Motion.where(discussion_id: discussion_id).pluck(:id)
+        Discussion.update_counters discussion_id, motions_count: motion_ids.size if motion_ids.size > 0 
+      end
+    end
+  end
+
+  def down
+    remove_column :discussions, :motions_count
+    add_column :groups, :motions_count, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -196,6 +196,7 @@ ActiveRecord::Schema.define(:version => 20140702205123) do
     t.string   "key"
     t.string   "iframe_src"
     t.datetime "last_activity_at"
+    t.integer  "motions_count",    :default => 0
   end
 
   add_index "discussions", ["author_id"], :name => "index_discussions_on_author_id"
@@ -337,7 +338,6 @@ ActiveRecord::Schema.define(:version => 20140702205123) do
     t.string   "sectors"
     t.string   "other_sector"
     t.integer  "discussions_count",                  :default => 0,              :null => false
-    t.integer  "motions_count",                      :default => 0,              :null => false
     t.string   "country_name"
     t.datetime "setup_completed_at"
     t.boolean  "next_steps_completed",               :default => false,          :null => false
@@ -582,6 +582,7 @@ ActiveRecord::Schema.define(:version => 20140702205123) do
     t.string   "key"
     t.string   "detected_locale"
     t.boolean  "subscribed_to_missed_yesterday_email",                        :default => true,       :null => false
+    t.string   "email_api_key"
   end
 
   add_index "users", ["email"], :name => "index_users_on_email", :unique => true

--- a/spec/models/discussion_spec.rb
+++ b/spec/models/discussion_spec.rb
@@ -106,6 +106,32 @@ describe Discussion do
     end
   end
 
+  describe "#motions_count" do
+    before do
+      @user = create(:user)
+      @group = create(:group)
+      @discussion = create(:discussion, group: @group)
+      @motion = create(:motion, discussion: @discussion)
+    end
+
+    it "returns a count of motions" do
+      @discussion.reload.motions_count.should == 1
+    end
+
+    it "updates correctly after creating a motion" do
+      expect {
+        @discussion.motions.create(attributes_for(:motion).merge({ author: @user }))
+      }.to change { @discussion.reload.motions_count }.by(1)
+    end
+
+    it "updates correctly after deleting a motion" do
+      expect {
+        @motion.destroy
+      }.to change { @discussion.reload.motions_count }.by(-1)
+    end
+
+  end
+
   describe "#activity" do
     it "returns all the activity for the discussion" do
       @user = create :user

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -32,6 +32,76 @@ describe Group do
     end
   end
 
+  context "children counting" do
+
+    describe "#motions_count" do
+      before do
+        @group = create(:group)
+        @user = create(:user)
+        @discussion = create(:discussion, group: @group)
+        @motion = create(:motion, discussion: @discussion)
+      end
+
+      it "returns a count of motions" do
+        @group.reload.motions_count.should == 1
+      end
+
+      it "updates correctly after creating a motion" do
+        expect {
+          @discussion.motions.create(attributes_for(:motion).merge({ author: @user }))
+        }.to change { @group.reload.motions_count }.by(1)
+      end
+
+      it "updates correctly after deleting a motion" do
+        expect {
+          @motion.destroy
+        }.to change { @group.reload.motions_count }.by(-1)
+      end
+
+      it "updates correctly after its discussion is destroyed" do
+        expect {
+          @discussion.destroy
+        }.to change { @group.reload.motions_count }.by(-1)
+      end
+
+      it "updates correctly after its discussion is archived" do
+        expect {
+          @discussion.archive!
+        }.to change { @group.reload.motions_count }.by(-1)
+      end
+
+    end
+
+    describe "#discussions_count" do
+      before do
+        @group = create(:group)
+        @user = create(:user)
+      end
+
+      it "returns a count of discussions" do
+        expect { 
+          @group.discussions.create(attributes_for(:discussion).merge({ author: @user }))
+        }.to change { @group.reload.discussions_count }.by(1)
+      end
+
+      it "updates correctly after archiving a discussion" do
+        @group.discussions.create(attributes_for(:discussion).merge({ author: @user }))
+        @group.reload.discussions_count.should == 1
+        expect {
+          @group.discussions.first.archive!
+        }.to change { @group.reload.discussions_count }.by(-1)
+      end
+
+      it "updates correctly after deleting a discussion" do
+        @group.discussions.create(attributes_for(:discussion).merge({ author: @user }))
+        @group.reload.discussions_count.should == 1
+        expect {
+          @group.discussions.first.destroy
+        }.to change { @group.reload.discussions_count }.by(-1)
+      end
+    end
+  end
+
   describe "#voting_motions" do
     it "returns motions that belong to the group and are open" do
       @group = motion.group


### PR DESCRIPTION
For issue #1494 

I didn't see any attempt at counting motions per group other than a DB column, so left that for another pull request.

Is there a concept of unarchiving? If so we'll want to increment the counter if a discussion comes back to life somehow.
