### PR TITLE
Scroll to first unread comment on discussion page load

### DIFF
--- a/app/assets/javascripts/discussions.js.coffee
+++ b/app/assets/javascripts/discussions.js.coffee
@@ -7,6 +7,11 @@ $ ->
 
 $ ->
   if $("body.discussions.show").length > 0
+
+    if $('#js-dog-ear').length > 0
+      $('html,body').animate
+        scrollTop: $('#js-dog-ear').offset().top - 75
+
     autocomplete_path = $('#comment-input').data('autocomplete-path')
     $("textarea").atwho
       at: '@'


### PR DESCRIPTION
Hey @robguthrie @rdbartlett @jdoud, check out this little feature;

It'll scroll to the first unread comment in a discussion if it exists when you visit the discussion page (based on whether the dog-eared blue line exists or not)
