### PR TITLE
Update Rails to 3.2.19

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'http://rubygems.org'
 
 ruby '2.1.2'
-gem 'rails', '~> 3.2.18'
+gem 'rails', '~> 3.2.19'
 gem 'rake', '~> 10.3.1'
 gem 'haml-rails', '~> 0.4.0'
 gem 'devise', '~> 3.2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -635,7 +635,7 @@ DEPENDENCIES
   rabl (~> 0.9.3)
   rack-canonical-host (~> 0.0.9)
   rack_session_access (~> 0.1.1)
-  rails (~> 3.2.18)
+  rails (~> 3.2.19)
   rails-backbone (~> 0.7.2)
   rake (~> 10.3.1)
   rb-fchange (~> 0.0.5)


### PR DESCRIPTION
I see there is some ongoing work to upgrade to [Rails 4](https://github.com/loomio/loomio/pull/1567), which is awesome! But I think it's wise to update to the latest security release of Rails 3.2 in the meantime.

I ran RSpec and Cucumber locally and it's all green :)

Link to the CVEs: https://groups.google.com/forum/#!msg/rubyonrails-security/wDxePLJGZdI/WP7EasCJTA4J
