### PR TITLE
Moving private discussions

### DIFF
--- a/app/assets/javascripts/discussions.js.coffee
+++ b/app/assets/javascripts/discussions.js.coffee
@@ -63,19 +63,26 @@ $ ->
     title: "Jump to latest unread activity"
 
 # moving discussion
-warn_if_moving_discussion_to_private_group = ->
-  $('.move-discussion-form .warn-move-will-make-private').hide()
-  private_discussion = $(".move-discussion-form").data('private-discussion')
-  unless private_discussion
-    hidden_group_ids = String($(".move-discussion-form").data('hidden-group-ids')).split(' ')
-    selected_group_id = $("select[name=destination_group_id]").val()
-    if _.include(hidden_group_ids, selected_group_id)
-      $('.move-discussion-form .warn-move-will-make-private').show()
+warn_if_moving_discussion = ->
+  form = $('.move-discussion-form')
+  form.find('.warn-move').hide()
+  
+  selected_group_id = form.find("select[name=destination_group_id]").val()
+
+  if form.data('private-discussion')
+    group_ids = String(form.data('public-group-ids')).split(' ')
+    target = form.find '.warn-move-will-make-public'
+  else
+    group_ids = String(form.data('hidden-group-ids')).split(' ')
+    target = form.find '.warn-move-will-make-private'
+
+  if _.include(group_ids, selected_group_id)
+    target.show()
 
 $ ->
-  warn_if_moving_discussion_to_private_group()
+  warn_if_moving_discussion()
   $(".move-discussion-form select").on 'change', (e) ->
-    warn_if_moving_discussion_to_private_group()
+    warn_if_moving_discussion()
 
 $ ->
   $(".js-prompt-user-to-join-or-authenticate").on "click", (e) ->

--- a/app/assets/stylesheets/unstructured/_discussions.css.scss
+++ b/app/assets/stylesheets/unstructured/_discussions.css.scss
@@ -125,7 +125,7 @@ body.discussions.show {
     margin: 10px 12px 0 44px;
   }
 
-  .warn-move-will-make-private { padding: 0 15px 15px; }
+  .warn-move { padding: 0 15px 15px; }
 
   #options-dropdown {
     font-size: 1.4em;

--- a/app/controllers/discussions_controller.rb
+++ b/app/controllers/discussions_controller.rb
@@ -87,6 +87,10 @@ class DiscussionsController < GroupBaseController
       @motion_reader = MotionReader.for(user: current_user_or_visitor, motion: @motion)
     end
 
+    if can?(:move, @discussion)
+      @destination_groups = current_user_or_visitor.groups.order(:name).uniq.reject { |g| g.id == @group.id }
+    end
+
     @discussion_reader = DiscussionReader.for(user: current_user_or_visitor, discussion: @discussion)
 
     @closed_motions = @discussion.closed_motions

--- a/app/helpers/move_discussions_helper.rb
+++ b/app/helpers/move_discussions_helper.rb
@@ -1,9 +1,12 @@
 module MoveDiscussionsHelper
-  def destinations_for(discussion: nil, user: nil)
-    source_group = discussion.group
-    # can't move the discussion unless the user belongs to the group it's currently in
-    return [] unless user.adminable_groups.include? source_group
-    user.groups.uniq - [source_group]
+
+  def destination_ids_for(discussion, user, visibility)
+    method = case visibility
+      when :private  then :private_discussions_only?
+      when :public   then :public_discussions_only? 
+    end
+
+    @destination_groups.select(&method).map(&:id).join(' ')
   end
 
 end

--- a/app/services/move_discussion_service.rb
+++ b/app/services/move_discussion_service.rb
@@ -24,11 +24,12 @@ class MoveDiscussionService
   end
 
   def move!
-    if discussion.public? && destination_group.private_discussions_only?
-      discussion.private = true
+    if valid?
+      discussion.private = true  if destination_group.private_discussions_only?
+      discussion.private = false if destination_group.public_discussions_only?
+      discussion.group = destination_group
+      discussion.save!
     end
-    discussion.group = destination_group if valid?
-    discussion.save!
   end
 end
 

--- a/app/views/discussions/_options.html.haml
+++ b/app/views/discussions/_options.html.haml
@@ -14,15 +14,19 @@
     .modal-header
       %button.close{"data-dismiss" => "modal"}×
       %h3= t :move_discussion_where
-    - destination_groups=  destinations_for(discussion: discussion, user: current_user)
-    - hidden_destination_group_ids = destination_groups.select{|g| g.is_hidden_from_public?}.map(&:id)
-    - private_int = @discussion.private ? 1 : 0
-    = form_tag move_discussion_path(discussion), method: :post, data: {hidden_group_ids: hidden_destination_group_ids.join(' '), private_discussion: @discussion.private }, class: 'move-discussion-form' do
+    = form_tag move_discussion_path(discussion), method: :post, 
+      data: { public_group_ids: destination_ids_for(discussion, current_user, :public),
+              hidden_group_ids: destination_ids_for(discussion, current_user, :private),
+              private_discussion: @discussion.private ? 1 : 0 }, 
+      class: 'move-discussion-form' do
       .modal-body
-        = select_tag :destination_group_id, options_for_select(destination_groups.sort{|a,b| a.full_name <=> b.full_name}.map{|g| [g.full_name, g.id]})
-      .warn-move-will-make-private{style: "display: none"}
+        = select_tag :destination_group_id, options_for_select(@destination_groups.map{|g| [g.full_name, g.id]})
+      .warn-move.warn-move-will-make-private{style: "display: none"}
         %i.fa.fa-lock
         = t(:move_discussion_to_hidden_group)
+      .warn-move.warn-move-will-make-public{style: "display: none"}
+        %i.fa.fa-unlock
+        = t(:move_discussion_to_public_group)
       .modal-footer
         = submit_tag t(:move_discussion), class: "btn btn-info", id: 'move-discussion-submit', :data => { :disable_with => t(:'move_discussion') }
         = link_to "Cancel", "#", "data-dismiss" => "modal", class: "btn"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -509,6 +509,7 @@ en:
   edit_discussion: "Edit discussion"
   move_discussion: "Move discussion"
   move_discussion_to_hidden_group: "This discussion is currently public. Moving it to this hidden group will make it private."
+  move_discussion_to_public_group: "This discussion is currently private. Moving it to this public group will make it public."
   move_discussion_where: "Where would you like to move this discussion to?"
   delete_discussion: "Delete discussion"
   confirm_delete_discussion: "Are you sure you want to permanently delete this discussion?"

--- a/spec/controllers/discussions_controller_spec.rb
+++ b/spec/controllers/discussions_controller_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 describe DiscussionsController do
   let(:app_controller) { controller }
   let(:user) { FactoryGirl.create(:user) }
+  let(:other_user) { FactoryGirl.create(:user) }
   let(:motion) { mock_model(Motion).as_null_object }
   let(:group) { create :group }
   let(:discussion) { stub_model(Discussion,
@@ -67,6 +68,62 @@ describe DiscussionsController do
         delete :destroy, id: discussion.key
         flash[:success].should =~ /Discussion successfully deleted/
       end
+    end
+
+    describe "moving a discussion" do
+
+      context "from a public group to a private group" do 
+        it "makes the discussion private" do 
+          g = FactoryGirl.create :group, discussion_privacy_options: 'private_only'
+          d = FactoryGirl.create :discussion, private: false
+          Group.stub(:find).with(g.key).and_return(g)
+          Discussion.stub_chain(:published, :find_by_key!).with(d.key).and_return(d)
+          
+          d.group.stub(:admins).and_return([user])
+          g.stub(:members).and_return([user])
+
+          post :move, id: d.key, destination_group_id: g.key
+
+          expect(d.group).to eq g
+          expect(d.private).to be_true
+        end
+      end
+
+      context "from a private group to a public group" do
+        it "makes the discussion public" do 
+          g = FactoryGirl.create :group, discussion_privacy_options: 'public_only'
+          d = FactoryGirl.create :discussion, private: true
+          Group.stub(:find).with(g.key).and_return(g)
+          Discussion.stub_chain(:published, :find_by_key!).with(d.key).and_return(d)
+          
+          d.group.stub(:admins).and_return([user])
+          g.stub(:members).and_return([user])
+
+          post :move, id: d.key, destination_group_id: g.key
+
+          expect(d.group).to eq g
+          expect(d.private).to be_false
+        end
+      end
+
+      context "to a group with a different user as admin" do 
+        it "successfully moves the discussion" do 
+          g1 = FactoryGirl.create :group
+          g2 = FactoryGirl.create :group
+          d = FactoryGirl.create :discussion, group: g1
+          Group.stub(:find).with(g2.key).and_return(g2)
+          Discussion.stub_chain(:published, :find_by_key!).with(d.key).and_return(d)
+          
+          g1.stub(:admins).and_return([user])
+          g2.stub(:admins).and_return([other_user])
+          g2.stub(:members).and_return([user])
+
+          post :move, id: d.key, destination_group_id: g2.key
+
+          expect(d.reload.group).to eq g2
+        end
+      end
+
     end
 
     describe "creating a new proposal" do

--- a/spec/services/move_discussion_service_spec.rb
+++ b/spec/services/move_discussion_service_spec.rb
@@ -73,6 +73,8 @@ describe MoveDiscussionService do
       @mover.should_receive(:valid?).and_return(true)
       discussion.stub(:group=){ discussion.stub(:group).and_return destination_group}
       discussion.stub(:public?).and_return(true)
+      discussion.stub(:private=) { discussion.stub(:private).and_return false }
+      destination_group.stub(:public_discussions_only?).and_return(true)
       destination_group.stub(:private_discussions_only?).and_return(false)
     end
 


### PR DESCRIPTION
Fix for #1579 
- Allow private discussion to be moved to public group
- Display confirmation message for private to public move
