### PR TITLE
Pixel image in "missed yesterday" email to mark summary as read

### DIFF
--- a/app/controllers/users/email_preferences_controller.rb
+++ b/app/controllers/users/email_preferences_controller.rb
@@ -33,8 +33,16 @@ class Users::EmailPreferencesController < BaseController
       end
     end
 
-    flash[:notice] = I18n.t "email.missed_yesterday.marked_as_read_success"
-    redirect_to dashboard_or_root_path
+    respond_to do |format|
+      format.html {
+        flash[:notice] = I18n.t "email.missed_yesterday.marked_as_read_success"
+        redirect_to dashboard_or_root_path
+      }
+      format.gif {
+        send_file Rails.root.join('app','assets','images', 'empty.gif'),
+                  type: 'image/gif', disposition: 'inline'
+      }
+    end
   end
 
   private

--- a/app/helpers/email_helper.rb
+++ b/app/helpers/email_helper.rb
@@ -22,9 +22,10 @@ module EmailHelper
     @markdown_email_parser ||= Redcarpet::Markdown.new(EmailMarkdownRenderer, autolink: true)
   end
 
-  def mark_summary_as_read_url_for(user)
+  def mark_summary_as_read_url_for(user, format: nil)
     mark_summary_email_as_read_url(unsubscribe_token: user.unsubscribe_token,
                                    time_start: @time_start.utc.to_i,
-                                   time_finish: @time_finish.utc.to_i)
+                                   time_finish: @time_finish.utc.to_i,
+                                   format: format)
   end
 end

--- a/app/views/user_mailer/missed_yesterday.html.haml
+++ b/app/views/user_mailer/missed_yesterday.html.haml
@@ -19,4 +19,5 @@
       = t(:'email.missed_yesterday.thanks_for_reading')
       %br
       =link_to(t('email.missed_yesterday.mark_as_read'), mark_summary_as_read_url_for(@user))
+      %img{src: mark_summary_as_read_url_for(@user, format: 'gif'), alt: '', width: 1, height: 1}
     =render 'unsubscribe_link'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1019,7 +1019,7 @@ en:
       subject: "Loomio - Summary of the last 24 hours"
     missed_yesterday:
       subject: "Yesterday on Loomio"
-      mark_as_read: Mark as read
+      mark_as_read: Mark as read (if images are disabled)
       thanks_for_reading: Thanks for reading, have a great day!
       click_here_to_mark_all_as_read_html: |
         Here's the stuff that happened yesterday on Loomio.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -813,7 +813,7 @@ es:
       subject: "Loomio - Resumen de las últimas 24 horas"
     missed_yesterday:
       subject: "Ayer en Loomio"
-      mark_as_read: Marcar como leído
+      mark_as_read: Marcar como leído (si imágenes deshabilitadas)
       thanks_for_reading: Gracias por leer, ¡que tengas un buen día!
       click_here_to_mark_all_as_read_html: |
         Esto es lo que pasó ayer en Loomio.

--- a/features/mark_summary_email_as_read.feature
+++ b/features/mark_summary_email_as_read.feature
@@ -6,3 +6,8 @@ Feature: Mark summary email as read
     Given I am a logged out user with an unread discussion
     When I mark the email as read
     Then the discussion should be marked as read when the email was generated
+
+  Scenario: Reading the summary email with images enabled marks it as read
+    Given I am a logged out user with an unread discussion
+    When I read the summary email with images enabled
+    Then the discussion should be marked as read when the email was generated

--- a/features/step_definitions/mark_summary_email_as_read_steps.rb
+++ b/features/step_definitions/mark_summary_email_as_read_steps.rb
@@ -33,6 +33,15 @@ When(/^I mark the email as read$/) do
   )
 end
 
+When(/^I read the summary email with images enabled$/) do
+  visit mark_summary_email_as_read_path(
+    time_start: @time_start.utc.to_i,
+    time_finish: 30.minutes.ago.utc.to_i,
+    unsubscribe_token: @user.unsubscribe_token,
+    format: 'gif'
+  )
+end
+
 Then(/^the discussion should be marked as read when the email was generated$/) do
   @motion.reload
   @discussion.reload


### PR DESCRIPTION
Required as part of this issue:

https://github.com/loomio/loomio/issues/1565

It sends invisible single pixel image in "missed yesterday" email to mark summary as read automatically for people who have images enabled.
