### PR TITLE
Add keyboard shortcuts to header; Add group dropdown search capability

### DIFF
--- a/app/assets/javascripts/main.js.coffee
+++ b/app/assets/javascripts/main.js.coffee
@@ -1,6 +1,22 @@
 window.Application ||= {}
 
+# keyboard shortcuts
 $ ->
+  $(document).on 'keydown', (event) ->
+    if document.activeElement.tagName not in ['INPUT', 'TEXTAREA', 'SELECT']
+      switch event.which
+        when 71 # G for groups search dropdown
+          $('#groups>a').click()
+          $('#groups').find('.group-dropdown-search').focus()
+          event.preventDefault()
+        when 78 # N for notifications dropdown
+          $('#notifications-container>a').click()
+        when 83 # S for search box
+          $('#search_form_query').focus()
+          event.preventDefault()
+        when 85 # U for user dropdown
+          $("#user>a").click()
+
   $(".dismiss-help-notice").click (event)->
     $.post($(this).attr("href"))
     $('.help-notice').modal('hide')

--- a/app/assets/javascripts/notifications.js.coffee
+++ b/app/assets/javascripts/notifications.js.coffee
@@ -16,5 +16,23 @@ $ ->
     event.stopPropagation()  if (event.metaKey || event.ctrlKey)
 
 $ ->
-  $("#group-dropdown-items").load('/notifications/groups_tree_dropdown')
+  $("#group-dropdown-items").load('/notifications/groups_tree_dropdown', ->
+    if $(@).find('.group-item').length > 10
+      $(@).siblings('.group-dropdown-search').show()
+  )
 
+$ ->
+  $('#groups').on 'click', '.group-dropdown-search', (event) ->
+    event.preventDefault()
+    event.stopPropagation()
+
+  $('#groups').on 'keyup', '.group-dropdown-search', (event) ->
+    groups  = $('#group-dropdown-items').find('.group-link-name')
+    val     = $(@).val().toLowerCase()
+    visible = groups.filter ->
+      @.innerHTML.toLowerCase().indexOf(val) >= 0
+    hidden  = groups.not(visible)
+
+    visible.closest('.group-item').show()
+    hidden.closest('.group-item').hide()
+    $(@).siblings('.no-groups-found').toggle(visible.length == 0)

--- a/app/assets/stylesheets/unstructured/_header.css.scss
+++ b/app/assets/stylesheets/unstructured/_header.css.scss
@@ -183,6 +183,19 @@
     .dropdown-menu {
       padding-bottom: 0;
     }
+    .group-dropdown-search {
+      display: none;
+      width: 100%;
+      padding: 1em;
+      margin: 0;
+      box-sizing: border-box;
+      position: relative;
+      bottom: 5px;
+    }
+    .no-groups-found {
+      display: none;
+      padding: 5px 15px;
+    }
   }
 
   /* group dropdown items */

--- a/app/views/application/_groups_dropdown.html.haml
+++ b/app/views/application/_groups_dropdown.html.haml
@@ -3,6 +3,9 @@
     %i.fa.fa-group
     %span= t :groups
   %ul.dropdown-menu
+    = text_field :search, :groups, class: 'group-dropdown-search', placeholder: t(:search_for_group)
+    .no-groups-found 
+      = t(:no_groups_found)
     #group-dropdown-items
     - if current_user.show_start_group_button?
       %li.group-item.group-links

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -220,6 +220,8 @@ en:
   start_new_group_hint: "To start making decisions"
   find_a_group: "Find a group"
   find_a_group_hint: "To explore public groups"
+  search_for_group: "Search for a group..."
+  no_groups_found: "No groups found by that name!"
   no_group_header: "Welcome to Loomio Beta"
   empty_notifications: "You do not have any notifications yet."
   see_all_notifications: "See all notifications"


### PR DESCRIPTION
A couple simple keyboard shortcuts for the navigation bar; 

Shortcuts are
- 'n' for opening the notifications dropdown
- 'g' for opening the groups dropdown
- 's' for focusing the search box
- 'u' for opening the user dropdown (profile, sign out, etc.)
  (open to more suggestions)

also adds a search box to the groups  dropdown if the number of groups is > 15 (which is about height where it starts scrolling.)

Screenshots!
![screenshot from 2014-07-30 10 02 51](https://cloud.githubusercontent.com/assets/750477/3750078/46b84a94-17f2-11e4-9624-31a2190cfb96.png)
![screenshot from 2014-07-30 10 03 00](https://cloud.githubusercontent.com/assets/750477/3750077/46b7c538-17f2-11e4-9754-67cb5284ae84.png)

Todo:
- Make search groups input case-insensitive
- Write a test for the keyboard shortcuts (it's harder than it should be to simulate keyboard input in Cucumber)

Take a peek! @robguthrie @rdbartlett @joshuavial 
