### PR TITLE
Sort discussions on group#show by activity, instead of comments

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -86,7 +86,7 @@ class GroupsController < GroupBaseController
     @discussions = GroupDiscussionsViewer.for(group: @group, user: current_user).
                                           joined_to_current_motion.
                                           preload(:current_motion, {:group => :parent}).
-                                          order('motions.closing_at ASC, last_comment_at DESC').
+                                          order('motions.closing_at ASC, last_activity_at DESC').
                                           page(params[:page]).per(20)
 
     @closed_motions = Queries::VisibleMotions.new(user: current_user, groups: @group).order('closed_at desc')


### PR DESCRIPTION
Fix for #1563 
