### PR TITLE
de-jargon the invitation error

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -36,7 +36,7 @@ en:
   devise:
     invitations:
       send_instructions: 'An invite has been sent to %{email}.'
-      invitation_token_invalid: 'The invitation token provided is not valid!'
+      invitation_token_invalid: 'This invitation is no longer valid!'
       updated: 'Account created.'
       no_invitations_remaining: "No invitations remaining"
     mailer:


### PR DESCRIPTION
based on this feedback from translator:
![image](https://cloud.githubusercontent.com/assets/2665886/3871081/a16682aa-20ec-11e4-9b79-58ac899c28fa.png)

Basically the word _token_ needs removing. There might be some work needed to provide some help / next step info for the user
