### PR TITLE
Fix members display on group page

### DIFF
--- a/app/views/groups/_members.html.haml
+++ b/app/views/groups/_members.html.haml
@@ -3,7 +3,7 @@
     %h4
       = link_to group_memberships_path(group) do
         = t :members
-        = "(#{ group.memberships_count })"
+        = "(#{ group.members.count })"
 
     %ul#users-list.clearfix
       - group.members.first(15).each do |user|


### PR DESCRIPTION
Teeny-tiny fix to group page members count - wasn't changing when users were deactivated
