### PR TITLE
Fix validation for discussion form

### DIFF
--- a/app/controllers/discussions_controller.rb
+++ b/app/controllers/discussions_controller.rb
@@ -40,8 +40,8 @@ class DiscussionsController < GroupBaseController
       flash[:success] = t("success.discussion_created")
       redirect_to @discussion
     else
-      render action: :new
       flash[:error] = t("error.discussion_not_created")
+      render action: :new
     end
   end
 

--- a/app/views/discussions/_form.html.haml
+++ b/app/views/discussions/_form.html.haml
@@ -4,7 +4,7 @@
       .control-group
         - if params[:group_id].blank?
           %p= t "discussion_form.new.who"
-          = f.collection_select :group_id, current_user.groups_discussions_can_be_started_in, :id, :full_name, {include_blank: true}
+          = f.input :group_id, as: :select, collection: current_user.groups_discussions_can_be_started_in, label_method: :full_name, label: false
         - else
           = f.input :group_id, :as => :hidden
       = f.input :title, autofocus: true, input_html: {class: 'js-warn-before-navigating-away'}, label: false

--- a/features/create_discussion.feature
+++ b/features/create_discussion.feature
@@ -22,3 +22,11 @@ Feature: User creates discussion
     And I select the group from the groups dropdown
     And I fill in the discussion details and submit the form
     Then a discussion should be created
+
+  @javascript
+  Scenario: Failing to input valid discussion values outputs an error
+    When I visit the dashboard
+    And I choose to create a discussion
+    And I fill in the discussion details and submit the form
+    Then a discussion should not be created
+    And I should see a discussion not created error

--- a/features/step_definitions/create_discussion_steps.rb
+++ b/features/step_definitions/create_discussion_steps.rb
@@ -24,6 +24,10 @@ Then /^a discussion should be created$/ do
   Discussion.where(:title => @discussion_title).should exist
 end
 
+Then /^a discussion should not be created$/ do 
+  Discussion.where(:title => @discussion_title).should_not exist
+end
+
 Given /^"(.*?)" has chosen to be emailed about new discussions and decisions for the group$/ do |arg1|
   @notified_user = User.find_by_name arg1
   @notified_user.memberships.where(:group_id => @group.id).update_all(:subscribed_to_notification_emails => true)
@@ -70,6 +74,10 @@ end
 Then /^the discussion description should render markdown$/ do
   page.find('.description-body').should have_content('this markdown')
   page.find('.description-body').should_not have_content('_this markdown_')
+end
+
+Then /^I should see a discussion not created error$/ do
+  find('.main-container').should have_css('.alert.alert-error')
 end
 
 Then /^my global markdown preference should now be 'enabled'$/ do


### PR DESCRIPTION
Currently, when you try to create a discussion without selecting a group, you get an unhelpful page reload, with no visible errors around what happened.

Two fixes:
- Allow a flash message to show up by setting it before the page is rendered (right now, it's set afterwards, which unhelpfully renders out the flash message one pageload too late. :) )
- Use simple_form's `f.input as: :select` instead of `f.collection_select`; the former has baked-in validation error message goodness.
