### PR TITLE
Order destination groups by parent group, indent subgroups

### DIFF
--- a/app/controllers/discussions_controller.rb
+++ b/app/controllers/discussions_controller.rb
@@ -89,7 +89,7 @@ class DiscussionsController < GroupBaseController
     end
 
     if can?(:move, @discussion)
-      @destination_groups = current_user_or_visitor.groups.order(:name).uniq.reject { |g| g.id == @group.id }
+      @destination_groups = current_user_or_visitor.groups.order(:full_name).uniq.reject { |g| g.id == @group.id }
     end
 
     @discussion_reader = DiscussionReader.for(user: current_user_or_visitor, discussion: @discussion)

--- a/app/helpers/discussions_helper.rb
+++ b/app/helpers/discussions_helper.rb
@@ -45,6 +45,10 @@ module DiscussionsHelper
     end
   end
 
+  def destination_options(destinations)
+    destinations.map{ |g| ["#{"&nbsp;" * 4 if g.is_subgroup?}#{g.name}".html_safe, g.id] }
+  end
+
   def xml_item(event)
     case event.kind.to_sym
     when :new_comment then event.eventable

--- a/app/views/discussions/_options.html.haml
+++ b/app/views/discussions/_options.html.haml
@@ -20,7 +20,7 @@
               private_discussion: @discussion.private ? 1 : 0 }, 
       class: 'move-discussion-form' do
       .modal-body
-        = select_tag :destination_group_id, options_for_select(@destination_groups.map{|g| [g.full_name, g.id]})
+        = select_tag :destination_group_id, options_for_select(destination_options(@destination_groups))
       .warn-move.warn-move-will-make-private{style: "display: none"}
         %i.fa.fa-lock
         = t(:move_discussion_to_hidden_group)


### PR DESCRIPTION
This sorts the destination groups by their parent group, indenting subgroups.

![image](https://cloud.githubusercontent.com/assets/750477/4180887/6e0ad1b4-3707-11e4-9589-cd71f56bc97f.png)

For #1657 
