### PR TITLE
facebook meta locales (step 1)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ branches:
     - 'production'
     - /^[0-9]+\.[0-9]+$/
 rvm:
-  - 2.1.2
+  - 2.1.3
 before_script:
   - "cp config/database.yml.$DB config/database.yml"
   - "bundle exec rake db:create RAILS_ENV=test"

--- a/app/views/application/_social_metadata.html.haml
+++ b/app/views/application/_social_metadata.html.haml
@@ -1,11 +1,14 @@
-- title ||= "Loomio | Collaborative Decision-Making"
-- description ||= "Loomio is an easy to use online tool for group decision-making. It allows dispersed groups to reach decisions quickly and take constructive action."
-- twitter_creator ||= "@LoomioProject"
+- title ||= t(:'meta_tags.default_title')
+- description ||= t(:'meta_tags.default_description')
+- twitter_creator ||= "@Loomio"
+
 %meta{ name: 'description', content: description }
+
 %meta{ name: 'twitter:card', content: 'summary'}
 %meta{ name: 'twitter:creator', content: twitter_creator }
 %meta{ name: 'twitter:title', content: title }
 %meta{ name: 'twitter:description', content: description }
+
 %meta{ property: 'og:title', content: title }
 %meta{ property: 'og:description', content: description }
 %meta{ property: 'og:type', content: 'website' }
@@ -15,6 +18,10 @@
 %meta{ property: 'og:image:width', content: '1200' }
 %meta{ property: 'og:image:height', content: '1200' }
 %meta{ property: 'og:url', content: request.original_url }
-%meta{property:'fb:app_id', content:ENV['FB_APP_ID_META']}
+%meta{ property: 'fb:app_id', content:ENV['FB_APP_ID_META']}
+
+%meta{property:'og:locale', content: current_locale}
+- detectable_locales.each do |locale|
+  %meta{property:'og:locale:alternate', content: locale}
 
 %link{href: 'https://plus.google.com/116342080294548871960/', rel: 'publisher'}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1141,6 +1141,15 @@ en:
       intro: "Please click this verification link to finalise your request:"
       ignore: "If you did not request to join Loomio please ignore this email."
 
+
+  #
+  # META TAGS
+  #
+
+  meta_tags:
+    default_title: "Loomio | Collaborative Decision-Making"
+    default_description: Loomio is an easy to use online tool for group decision-making. It allows dispersed groups to reach decisions quickly and take constructive action.
+
   #
   # COMMON WORDS
   #


### PR DESCRIPTION
the default social meta data needs translating

**steps:**
1) extract translation so community can translate
2) tune app so FB scrapes and displays locales correctly

step 2 looks like it might be fidely, want to focus on doing that once we have some foreign strings to play with.

---

**notes for future**
- fb may attach param `fb_locale` when scraping
- fb might expect _downcase underscored_ locales instead of _mixed-caps hyphen_ locales  (e.g. `pt_br` over `pt-BR`). We might need to reconsider our opinion about our default (currently we bend to the hyphen because that's the format of browser request headers)

**resources:**
- https://developers.facebook.com/docs/opengraph/guides/internationalization  
- http://stackoverflow.com/questions/7614603/facebook-meta-tags-scraped-with-locale-not-working#_=_
- https://www.facebook.com/translations/FacebookLocales.xml
