### PR TITLE
fix blockquote style

### DIFF
--- a/app/assets/stylesheets/unstructured/_discussions.css.scss
+++ b/app/assets/stylesheets/unstructured/_discussions.css.scss
@@ -419,7 +419,7 @@ body.discussions.show {
 
       .activity-item-header{
         blockquote p {
-          font-size: inherit;
+          font-size: 14px;
           font-weight: inherit;
         }
         blockquote, pre {


### PR DESCRIPTION
Users reported problems with markdown blockquotes being out of control large.

investigated and found the style was `font-size: inherit`  
and that it was inheriting `font-size: 17.5px;` from .. not sure. 

---

for anyone who cares to investigate: 

Only place in code base I find that were
- loomio/lineman/vendor/bower_components/bootstrap/dist/css/bootstrap.css:
- loomio/lineman/vendor/bower_components/sass-bootstrap/dist/css/bootstrap.css:

Other place that there might be a lead to was Font-awesome... 
