### PR TITLE
Facebook locale 2

### DIFF
--- a/app/helpers/locales_helper.rb
+++ b/app/helpers/locales_helper.rb
@@ -105,7 +105,11 @@ module LocalesHelper
 
   # 2 of 2 places untrusted user input can enter system
   def params_selected_locale
-    filter_locales(params[:locale], all_locale_strings).first
+    locale = params[:locale] || params[:fb_locale]
+    return nil if locale.nil?
+
+    fixed_params_locale = locale.gsub('_', '-')
+    filter_locales(fixed_params_locale, all_locale_strings).first
   end
 
   def user_selected_locale

--- a/app/views/application/_social_metadata.html.haml
+++ b/app/views/application/_social_metadata.html.haml
@@ -21,7 +21,8 @@
 %meta{ property: 'fb:app_id', content:ENV['FB_APP_ID_META']}
 
 %meta{property:'og:locale', content: current_locale}
-- detectable_locales.each do |locale|
+-# detectable_locales.each do |locale|
+- [:es, :fr, :be_BY, :en_US, :en_GB ].each do |locale|
   %meta{property:'og:locale:alternate', content: locale}
 
 %link{href: 'https://plus.google.com/116342080294548871960/', rel: 'publisher'}

--- a/app/views/application/_social_metadata.html.haml
+++ b/app/views/application/_social_metadata.html.haml
@@ -22,7 +22,8 @@
 
 %meta{property:'og:locale', content: current_locale}
 -# detectable_locales.each do |locale|
-- [:es, :fr, :be_BY, :en_US, :en_GB ].each do |locale|
+-# temporarary test locales : 
+- [:es, :'es_ES', :be_BY, :en_US, :en_GB, :'zh_TW' ].each do |locale|
   %meta{property:'og:locale:alternate', content: locale}
 
 %link{href: 'https://plus.google.com/116342080294548871960/', rel: 'publisher'}

--- a/config/locales/fallback.es-ES.yml
+++ b/config/locales/fallback.es-ES.yml
@@ -1,0 +1,3 @@
+es-ES:
+  google: "Google"
+  # non-empty translations ensures :be is an 'available_locale', allowing fallback to :'be-BY'

--- a/db/migrate/20140708053114_generate_email_api_keys_for_users.rb
+++ b/db/migrate/20140708053114_generate_email_api_keys_for_users.rb
@@ -1,4 +1,10 @@
 class GenerateEmailAPIKeysForUsers < ActiveRecord::Migration
+  class User < ActiveRecord::Base
+    def name
+      self[:name]
+    end
+  end
+
   def up
     progress_bar = ProgressBar.create(format: "(\e[32m%c/%C\e[0m) %a |%B| \e[31m%e\e[0m ",
                                       progress_mark: "\e[32m/\e[0m",

--- a/lib/loomio_i18n.rb
+++ b/lib/loomio_i18n.rb
@@ -3,7 +3,7 @@ module Loomio
 
     SELECTABLE_LOCALES = %i( en an be-BY bg-BG ca cs zh-TW da de eo es el fr id it he hu ja ko ml nl-NL pt-BR ro sr sr-RS sk sv vi tr uk )
 
-    DETECTABLE_LOCALES = SELECTABLE_LOCALES + %i( be pt zh zh-HK )
+    DETECTABLE_LOCALES = SELECTABLE_LOCALES + %i( be pt zh zh-HK es-ES)
 
     FALLBACKS = { :an      => :es,
                   :be      => :'be-BY',
@@ -11,7 +11,8 @@ module Loomio
                   :'pt-PT' => :'pt-BR',
                   :pt      => :'pt-BR',
                   :zh      => :'zh-TW',
-                  :'zh-HK' => :'zh-TW'
+                  :'zh-HK' => :'zh-TW',
+                  :'es-ES' => :es
                  }
 
     # for locales which are only serving as redirects, make sure to add to  :


### PR DESCRIPTION
see Part 1 here https://github.com/loomio/loomio/pull/1703

looking for a good way to test this in a light-weight way. FB uses strange locales (like `el_GR` for greek, when everyone else uses `el`, they also use only underscore).
