### PR TITLE
add Right-to-Left support

### DIFF
--- a/app/assets/stylesheets/unstructured/_main.css.scss
+++ b/app/assets/stylesheets/unstructured/_main.css.scss
@@ -435,3 +435,7 @@ form{
 }
 
 .tooltip.bottom .tooltip-arrow{ top: 0 !important; }
+
+[dir='RTL'] { text-align: right; }
+[dir='LTR'] { text-align: left; }
+.text-left[dir='RTL'] { text-align: left; }

--- a/app/controllers/discussions_controller.rb
+++ b/app/controllers/discussions_controller.rb
@@ -13,7 +13,7 @@ class DiscussionsController < GroupBaseController
   end
 
   def new
-    @discussion = Discussion.new
+    @discussion = Discussion.new user: current_user
     @discussion.uses_markdown = current_user.uses_markdown
     @group = Group.find_by_id params[:group_id]
     @discussion.group = @group

--- a/app/helpers/locales_helper.rb
+++ b/app/helpers/locales_helper.rb
@@ -42,6 +42,12 @@ module LocalesHelper
     user.update_attribute(:detected_locale, detected_locale)
   end
 
+  def text_direction(object)
+    locale = object.try(:locale).try(:to_sym)
+
+    Loomio::I18n::RTL_LOCALES.include?(locale) ? 'RTL' : 'LTR'
+  end
+
   # View helper methods for language selector dropdown
 
   def linked_language_options

--- a/app/views/comments/_comment.html.haml
+++ b/app/views/comments/_comment.html.haml
@@ -18,7 +18,7 @@
               = link_to [:edit, comment] do
                 .edit-icon.edit-icon-small.edit-comment.js-tooltip{title: t(:'edit_comment.edit_comment')}
                   %i.fa.fa-pencil
-        .activity-item-header
+        .activity-item-header{dir: text_direction(comment)}
           ~ add_mention_links(render_rich_text(comment.body.to_s.force_encoding("UTF-8"), comment.uses_markdown?)).html_safe
           .translation-spacer.translated
           .activity-item-translation.translated

--- a/app/views/discussions/_add_comment.html.haml
+++ b/app/views/discussions/_add_comment.html.haml
@@ -4,7 +4,7 @@
     = render 'avatar', user: current_user_or_visitor
     #comment-input{ data: {group: @group.id, autocomplete_path: members_autocomplete_group_path(@group) } }
       .form-container
-        = text_area_tag 'comment', "", id: 'new-comment', class: 'js-warn-before-navigating-away', placeholder: t(:comment_form_placeholder)
+        = text_area_tag 'comment', "", id: 'new-comment', class: 'js-warn-before-navigating-away', placeholder: t(:comment_form_placeholder), dir: text_direction(current_user_or_visitor)
         #attachment-container
 
       = hidden_field_tag 'uses_markdown', @uses_markdown, {id: 'global-uses-markdown'}

--- a/app/views/discussions/_discussion_context.html.haml
+++ b/app/views/discussions/_discussion_context.html.haml
@@ -1,7 +1,7 @@
 .row
   .col-sm-8
     .description-container
-      .description-body
+      .description-body{dir: text_direction(@discussion)}
         .long-description
           = render_rich_text(@discussion.description, @discussion.uses_markdown)
         .translation-spacer.translated

--- a/app/views/discussions/_form.html.haml
+++ b/app/views/discussions/_form.html.haml
@@ -7,8 +7,8 @@
           = f.collection_select :group_id, current_user.groups_discussions_can_be_started_in, :id, :full_name, {include_blank: true}, class: 'form-control'
         - else
           = f.input :group_id, :as => :hidden
-      = f.input :title, autofocus: true, input_html: {class: 'js-warn-before-navigating-away'}
-      = f.input :description, input_html: {class: 'js-warn-before-navigating-away'}
+      = f.input :title, autofocus: true, input_html: {class: 'js-warn-before-navigating-away', dir: text_direction(discussion)}
+      = f.input :description, input_html: {class: 'js-warn-before-navigating-away', dir: text_direction(discussion)}
       .dropdown#discussion-markdown-dropdown.global-markdown-setting
         %a.dropdown-toggle{href:'#discussion-markdown-dropdown', id:'discussion-markdown-dropdown-link', 'data-toggle'=> 'dropdown'}
           = markdown_img(discussion.uses_markdown)

--- a/app/views/discussions/_title.html.haml
+++ b/app/views/discussions/_title.html.haml
@@ -1,7 +1,7 @@
 .row.discussion-header-container
   .col-xs-12
     .discussion-title-container
-      %h2#discussion-title
+      %h2#discussion-title.text-left{dir: text_direction(discussion)}
         - if can?(:edit, discussion) || can?(:move, discussion) || can?(:destroy, discussion)
           =render "discussions/options", discussion: discussion
         = discussion.title

--- a/features/create_discussion.feature
+++ b/features/create_discussion.feature
@@ -22,3 +22,12 @@ Feature: User creates discussion
     And I select the group from the groups dropdown
     And I fill in the discussion details and submit the form
     Then a discussion should be created
+
+  @javascript
+  Scenario: Hebrew user starting a discussion
+    Given my selected locale is "he"
+    When I visit the group page
+    And I choose to create a discussion
+    Then the new discussion form should be right-to-left
+    When I fill in the discussion details and submit the form
+    Then the discussion should be displayed right-to-left

--- a/features/discussions/comment_create.feature
+++ b/features/discussions/comment_create.feature
@@ -2,20 +2,20 @@ Feature: Post a comment in a discussion
   To allow users to share their opinions
   A user must be able to post comments in a discussion
 
-  @javascript
-  Scenario: User posts comment
+  Background:
     Given I am logged in
     And I am a member of a group
     And there is a discussion in the group
+
+  @javascript
+  Scenario: User posts comment
     When I visit the discussion page
     And I write and submit a comment
     Then a comment should be added to the discussion
+    And the comment should be displayed left-to-right
 
   @javascript
   Scenario: Discussion activity clears when user posts comment
-    Given I am logged in
-    And I am a member of a group
-    And there is a discussion in the group
     When I visit the discussion page
     And I write and submit a comment
     And I visit the group page
@@ -23,10 +23,7 @@ Feature: Post a comment in a discussion
 
   @javascript
   Scenario: User enables markdown and posts a comment
-    Given I am logged in
-    And I am a member of a group
-    And there is a discussion in the group
-    And I don't prefer markdown
+    Given I don't prefer markdown
     When I visit the discussion page
     #And I enable comment markdown
     And I write and submit a comment
@@ -52,10 +49,14 @@ Feature: Post a comment in a discussion
     ##And comment markdown should now be off by default
 
   Scenario: Comments have permalinks
-    Given I am logged in
-    And I am a member of a group
-    And there is a discussion in the group
-    And the discussion has a comment
+    Given the discussion has a comment
     When I visit the discussion page
     Then there should be an anchor for the comment
     And I should see a permalink to the anchor for that comment
+
+  Scenario: Hebrew user post RTL formatted comments
+    Given my selected locale is "he"
+    When I visit the discussion page
+    And I write and submit a comment
+    Then the comment should be displayed right-to-left
+

--- a/features/step_definitions/comment_create_steps.rb
+++ b/features/step_definitions/comment_create_steps.rb
@@ -70,3 +70,17 @@ end
 Then /^the comment should include appropriate new lines$/ do
   page.should have_css(".activity-item-header p")
 end
+
+Given(/^my selected locale is "(.*?)"$/) do |arg1|
+  @user.update_attribute(:selected_locale, arg1)
+end
+
+Then(/^the comment should be displayed right\-to\-left$/) do
+  page.should have_css(".activity-item-header[dir='RTL']")
+end
+
+Then(/^the comment should be displayed left\-to\-right$/) do
+  page.should have_css(".activity-item-header[dir='LTR']")
+end
+
+

--- a/features/step_definitions/create_discussion_steps.rb
+++ b/features/step_definitions/create_discussion_steps.rb
@@ -75,3 +75,13 @@ end
 Then /^my global markdown preference should now be 'enabled'$/ do
   step 'comment markdown should now be on by default'
 end
+
+Then(/^the new discussion form should be right\-to\-left$/) do
+  page.should have_css("#discussion_title[dir='RTL']")
+  page.should have_css("#discussion_description[dir='RTL']")
+end
+
+Then(/^the discussion should be displayed right\-to\-left$/) do
+  page.should have_css(".description-body[dir='RTL']")
+end
+

--- a/lib/loomio_i18n.rb
+++ b/lib/loomio_i18n.rb
@@ -1,7 +1,7 @@
 module Loomio
   module I18n
 
-    SELECTABLE_LOCALES = %i( en be-BY bg-BG ca cs zh-TW da de eo es el fr id it hu ja ko ml nl-NL pt-BR ro sr sr-RS sv vi tr uk )
+    SELECTABLE_LOCALES = %i( en be-BY bg-BG ca cs zh-TW da de eo es el fr id it he hu ja ko ml nl-NL pt-BR ro sr sr-RS sv vi tr uk )
 
     DETECTABLE_LOCALES = SELECTABLE_LOCALES + %i( be pt zh zh-HK )
 
@@ -18,9 +18,10 @@ module Loomio
     #  ii) FALLBACKS
     # iii) a dummy yaml e.g. config/locales/fallback.zh-HK.yml
 
+    RTL_LOCALES = %i( ar he fa-IR ml ur ur-PK )
 
     # only for display purposes, please don't depend on this in the system
-    TEST_LOCALES = %i( ar an cmn hr fi gl he ga-IE km mk mi fa-IR pl pt-PT ru sl te ur ur-PK )
+    TEST_LOCALES = %i( ar an cmn hr fi gl ga-IE km mk mi fa-IR pl pt-PT ru sl te ur ur-PK )
 
     #
   end


### PR DESCRIPTION
so the languages that need RTL (right to left) that I currently know of are : 
- Hebrew 
- Arabic
- Persian/ Farsi
- Malayalam ? 

Not all of these languages are traslated but I think the easiest thing to do to get RTL working for them would be to add these to the list of selectable languages
