### PR TITLE
make loomio X work

### DIFF
--- a/app/assets/stylesheets/unstructured/_header.scss
+++ b/app/assets/stylesheets/unstructured/_header.scss
@@ -8,12 +8,8 @@
   width: 93px;
   margin: 9px 0 0 10px;
   height: 28px;
-  background: image-url("navbar-logo.png") 0 0 no-repeat;
+  background: 0 0 no-repeat;
 }
-.app-logo.beta{
-  background: image-url("navbar-logo-beta.jpg") 0 0 no-repeat;
-}
-
 input.group-dropdown-search {
   padding: 5px;
   width: 100%;

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,7 @@
 class ApplicationController < ActionController::Base
   include LocalesHelper
   include CurrentUserHelper
+  include ApplicationHelper
   include ReadableUnguessableUrlsHelper
   include ProtectedFromForgery
 
@@ -81,7 +82,7 @@ class ApplicationController < ActionController::Base
   end
 
   def invalid_return_urls
-    [nil, root_url, new_user_password_url]
+    [nil, root_url, new_user_password_url, profile_url]
   end
 
   def user_time_zone(&block)

--- a/app/controllers/marketing_controller.rb
+++ b/app/controllers/marketing_controller.rb
@@ -3,7 +3,11 @@ class MarketingController < ApplicationController
     if user_signed_in?
       redirect_to dashboard_path
     else
-      render layout: false
+      if show_loomio_org_marketing
+        render layout: false
+      else
+        redirect_to new_user_session_path
+      end
     end
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,3 @@
-#encoding: UTF-8
 module ApplicationHelper
 
   def lineman_vendorjs_path
@@ -127,22 +126,6 @@ module ApplicationHelper
     Redcarpet::Render::SmartyPants.render(output).html_safe
   end
 
-  def show_contribution_icon?
-    current_user && !current_user.belongs_to_manual_subscription_group?
-  end
-
-  def can_ask_for_contribution?(group)
-    !group.has_manual_subscription? || !group.is_paying?
-  end
-
-  def hide_beta_logo?
-    current_user_or_visitor.belongs_to_manual_subscription_group?
-  end
-
-  def hide_crowdfunding_banner?
-    hide_beta_logo? || session[:hide_banner] == true
-  end
-
   def visitor?
     !user_signed_in?
   end
@@ -153,10 +136,6 @@ module ApplicationHelper
         yield
       end
     end
-  end
-
-  def navbar_contribute
-    ENV["NAVBAR_CONTRIBUTE"] or "show"
   end
 
   def toggle_unread_path
@@ -203,5 +182,29 @@ module ApplicationHelper
 
   def render_help_container
     ' help-container' if controller_name == 'help'
+  end
+
+  def show_loomio_org_marketing
+    ENV['SHOW_LOOMIO_ORG_MARKETING']
+  end
+
+  def site_hostname
+    ENV['CANONICAL_HOST'] || request.host
+  end
+
+  def logo_path
+    if ENV['APP_LOGO_PATH']
+      ENV['APP_LOGO_PATH']
+    else
+      if hide_beta_logo?
+        image_url("navbar-logo.png")
+      else
+        image_url("navbar-logo-beta.jpg")
+      end
+    end
+  end
+
+  def hide_beta_logo?
+    current_user_or_visitor.belongs_to_manual_subscription_group?
   end
 end

--- a/app/views/application/_footer.html.haml
+++ b/app/views/application/_footer.html.haml
@@ -1,10 +1,15 @@
-%footer.footer
-  .col-sm-6
-    - unless current_user
-      %select#select-locale
-        = options_for_select linked_language_options, selected_language_option
+- if show_loomio_org_marketing
+  %footer.footer
+    .col-sm-6
+      - unless current_user
+        %select#select-locale
+          = options_for_select linked_language_options, selected_language_option
 
-    = link_to t(:translate, default: "help translate Loomio!"), 'https://www.loomio.org/d/hB1Oijwv/overview-of-the-translation-process-for-translators'
+      = link_to t(:translate, default: "help translate Loomio!"), 'https://www.loomio.org/d/hB1Oijwv/overview-of-the-translation-process-for-translators'
 
-  .col-sm-6.footer-links
-    = render "footer_links", target: 'blank'
+    .col-sm-6.footer-links
+      = render "footer_links", target: 'blank'
+- else
+  %footer.footer
+    .col-xs-12
+      = t :"footer.independent_install_html", hostname: ENV['CANONICAL_HOST'] || request.host

--- a/app/views/application/_header.html.haml
+++ b/app/views/application/_header.html.haml
@@ -1,7 +1,3 @@
-- if hide_beta_logo?
-  - logo_class = 'app-logo'
-- else
-  - logo_class = 'app-logo beta'
 
 %nav.navbar.navbar-default.navbar-fixed-top
   .container
@@ -13,7 +9,8 @@
           %span.icon-bar
           %span.icon-bar
           %span.icon-bar
-        %a.navbar-brand{class: logo_class, href: dashboard_or_root_path, title: t(:"organisation.name")}
+
+        %a.navbar-brand.app-logo{ href: dashboard_or_root_path, title: t(:"organisation.name"), style: "background-image: url(#{logo_path})" }
 
         %ul.nav.navbar-nav
           %li#inbox-container
@@ -53,7 +50,7 @@
           = render 'user_dropdown'
 
       - else
-        %a.navbar-brand{class: logo_class, href: dashboard_or_root_path, title: t(:"organisation.name")}
+        %a.navbar-brand.app-logo{href: dashboard_or_root_path, title: t(:"organisation.name")}
         %nav
           %ul.nav.navbar-nav.navbar-right.pull-right
             - unless controller_name == "group_requests"

--- a/app/views/devise/registrations/_persona_form.html.haml
+++ b/app/views/devise/registrations/_persona_form.html.haml
@@ -3,6 +3,6 @@
   =f.input :name
   =f.input :email
 
-  .terms-of-service-text=t(:terms_of_service_html, button_text: t(:"devise.registrations.sign_up"), link_path: terms_of_service_path)
+  .terms-of-service-text=t(:terms_of_service_html, button_text: t(:"devise.registrations.sign_up"), link_path: terms_of_service_path) if show_loomio_org_marketing
   -sign_up = t(:"devise.registrations.sign_up")
   =f.submit sign_up, class: "btn btn-info btn-lg", :data => {:disable_with => sign_up}

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -26,4 +26,4 @@
               = render 'devise/shared/omniauth_buttons'
               %h3= t :or_fill_in_this_form
               = render "form"
-          .terms= t(:terms_of_service_html, button_text: t(:'devise.registrations.sign_up'), link_path: terms_of_service_path)
+          .terms= t(:terms_of_service_html, button_text: t(:'devise.registrations.sign_up'), link_path: terms_of_service_path) if show_loomio_org_marketing

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -22,4 +22,4 @@
                 = t :or
             = render "form"
           .terms
-            =t(:terms_of_service_html, button_text: t(:'devise.sessions.sign_in'), link_path: terms_of_service_path)
+            =t(:terms_of_service_html, button_text: t(:'devise.sessions.sign_in'), link_path: terms_of_service_path) if show_loomio_org_marketing

--- a/app/views/thread_mailer/_footer.html.haml
+++ b/app/views/thread_mailer/_footer.html.haml
@@ -6,7 +6,7 @@
 %p{style: 'font-size:small;-webkit-text-size-adjust:none;color:#666;'}
   &mdash;
   %br
-  = t(:'email.thread_mailer.reply_or_view_online_html', url: link)
+  = t(:'email.thread_mailer.reply_or_view_online_html', url: link, hostname: ENV['CANONICAL_HOST'])
 
   %br
   - if @following

--- a/app/views/thread_mailer/_footer.text.haml
+++ b/app/views/thread_mailer/_footer.text.haml
@@ -1,6 +1,6 @@
 \
 \--
-= t :"email.thread_mailer.footer_text"
+= t :"email.thread_mailer.footer_text", hostname: ENV['CANONICAL_HOST']
 = link
 \
 \

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -215,6 +215,7 @@ en:
     pricing: 'Pricing'
     public_groups: 'Public groups'
     terms: 'Terms'
+    independent_install_html: '%{hostname} is running an independent copy of Loomio: <a href="http://github.com/loomio/loomio">find out more</a>.'
 
   inbox:
     clear: 'Clear'
@@ -1157,15 +1158,13 @@ en:
       headline: "%{author}'s proposal in %{group} is closing soon:"
       summary: "Summary"
     thread_mailer:
-      footer_text: "Reply to this email directly or view it on Loomio:"
-      #footer_html: "Reply to this email directly or <a href='%{app_link}'>view it on Loomio</a>. Change your <a href='%{preferences_link}'>email preferences</a>."
-      reply_or_view_online_html: "Reply to this email directly or <a href='%{url}'>view it on Loomio</a>."
+      footer_text: "Reply to this email directly or view it on %{hostname}:"
+      reply_or_view_online_html: "Reply to this email directly or <a href='%{url}'>view it on %{hostname}</a>."
       unfollow_discussion_html: "<a href='%{unfollow_url}'>Unfollow</a> to stop emails about this discussion."
       unfollow_discussion_text: "Visit the following link to stop emails about this discussion: %{unfollow_url}"
       follow_discussion_html: "<a href='%{follow_url}'>Follow</a> to receive emails about this discussion."
       follow_discussion_text: "Visit the following link to receive emails about this discussion: %{follow_url}"
-      
-      change_email_preferences_html: "Change your <a href='%{email_preferences_url}'>email preferences</a> to unsubscribe from Loomio emails."
+      change_email_preferences_html: "Change your <a href='%{email_preferences_url}'>email preferences</a> to unsubscribe from these emails."
       change_preferences: "Change your email preferences:"
       new_motion: "%{who} proposed:"
       motion_closing_soon: "Proposal closing in 24 hours:"

--- a/features/contact_form.feature
+++ b/features/contact_form.feature
@@ -3,7 +3,7 @@ Feature: Person contacts Loomio using contact form
 Scenario: Guest contacts Loomio using contact form
 When I visit the contact page
 And I fill in and submit the contact form
-Then I should be redirected to the home page
+Then I should be redirected to the sign in page
 And I should see a thank you flash message
 And an email should be sent to @incoming.intercom.io
 And the message should be saved to the database

--- a/features/step_definitions/beta_logo_steps.rb
+++ b/features/step_definitions/beta_logo_steps.rb
@@ -3,11 +3,6 @@ When(/^I am a member a manual subcription group$/) do
   @subscription_group.add_member! @user
 end
 
-Then(/^I should not see the beta logo$/) do
-  visit group_path(@subscription_group)
-  page.should_not have_css('.loomio-beta-logo')
-end
-
 When(/^I am not a member of a manual subcription group$/) do
   @group = FactoryGirl.create(:group)
   @group.add_member! @user
@@ -15,5 +10,20 @@ end
 
 Then(/^I should see the beta logo$/) do
   visit group_path(@group)
-  page.should have_css('.app-logo.beta')
+  expect(page.body).to_not match(/navbar-logo\.png/)
 end
+
+Then(/^I should not see the beta logo$/) do
+  visit group_path(@subscription_group)
+  expect(page.body).to_not match(/navbar-logo-beta\.jpg/)
+end
+
+Given(/^my system admin defined us a custom logo$/) do
+  ENV['APP_LOGO_PATH'] ='www.image_store.com/custom_logo.png'
+end
+
+Then(/^I should see our custom logo instead of any loomio logo$/) do
+  visit group_path(@group)
+  expect(page.body).to match(/www\.image_store\.com\/custom_logo\.png/)
+end
+

--- a/features/step_definitions/contact_form.steps.rb
+++ b/features/step_definitions/contact_form.steps.rb
@@ -13,6 +13,10 @@ Then(/^I should be redirected to the home page$/) do
   page.should have_css("body.marketing.index")
 end
 
+Then(/^I should be redirected to the sign in page$/) do
+  page.should have_css("body.pages.sessions.new")
+end
+
 Then(/^I should see a thank you flash message$/) do
   page.should have_content("Thanks! Someone from our team will get back to you shortly!")
 end

--- a/features/step_definitions/web_steps.rb
+++ b/features/step_definitions/web_steps.rb
@@ -34,7 +34,7 @@ Then /^debugger$/ do
   debugger
 end
 
-When(/^[I\s]+debug$/) do
+When(/^[I\s]?debug$/) do
   binding.pry
 end
 

--- a/features/users/beta_logo.feature
+++ b/features/users/beta_logo.feature
@@ -1,15 +1,18 @@
-Feature: No beta logo for manual subscription users
-  As a user
-  So I can feel like I'm getting value from a professional tool
-  I want to see the non-beta logo in-app
+Feature: App logo is set appropriately in banner 
 
   Background:
     Given I am logged in
 
-  Scenario: Manual Subscription user doesn't see beta logo
-    When I am a member a manual subcription group
+  Scenario: Manual Subscription user doesn't see beta logo on loomio.org
+    And I am a member a manual subcription group
     Then I should not see the beta logo
 
-  Scenario: All other users see beta logo
-    When I am not a member of a manual subcription group
+  Scenario: non-subscription users see beta logo on loomio.org
+    And I am not a member of a manual subcription group
     Then I should see the beta logo
+
+  Scenario: private installation of loomio see there own logo
+    And I am not a member of a manual subcription group
+    And my system admin defined us a custom logo
+    Then I should see our custom logo instead of any loomio logo
+


### PR DESCRIPTION
@rob how's this?

here's what I did

- redirect / to /sign_in rather than marketing index
- change all references from 'Loomio' to hostname
- new footer:
  "{{hostname}} is running an independent copy of Loomio - [find out more](http://github.com/loomio/loomio)"
- new in-app logo
