### PR TITLE
add gitter badge to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Build Status](https://travis-ci.org/loomio/loomio.png?branch=master)](https://travis-ci.org/loomio/loomio) 
 [![Code Climate](https://codeclimate.com/github/loomio/loomio.png)](https://codeclimate.com/github/loomio/loomio) 
 [![Dependency Status](https://gemnasium.com/loomio/loomio.png)](https://gemnasium.com/loomio/loomio) 
+[![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/loomio/loomio?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 
 Loomio is a collaborative decision-making tool that makes it easy for anyone to participate in decisions which affect them. If you'd like to find out more, check out [Loomio.org](https://www.loomio.org).
 


### PR DESCRIPTION
add's a badge that looks like this
[![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/loomio/loomio)
to the front page. 
I'm interested in running this as an experiment for a fixed period of time with @gdpelican  