### PR TITLE
add simple translation stats store

### DIFF
--- a/lib/tasks/translation_stats.yaml
+++ b/lib/tasks/translation_stats.yaml
@@ -1,0 +1,144 @@
+ar:
+  main: 48
+  frontpage: 100
+an:
+  main: 99
+  frontpage: 100
+be_BY:
+  main: 98
+  frontpage: 100
+bg_BG:
+  main: 44
+  frontpage: 18
+ca:
+  main: 83
+  frontpage: 81
+cmn:
+  main: 31
+  frontpage: 0
+zh_TW:
+  main: 100
+  frontpage: 100
+hr:
+  main: 50
+  frontpage: 100
+cs:
+  main: 84
+  frontpage: 100
+da:
+  main: 99
+  frontpage: 100
+nl_NL:
+  main: 99
+  frontpage: 100
+eo:
+  main: 97
+  frontpage: 100
+fi:
+  main: 7
+  frontpage: 0
+fr:
+  main: 98
+  frontpage: 100
+gl:
+  main: 28
+  frontpage: 6
+de:
+  main: 99
+  frontpage: 100
+el:
+  main: 99
+  frontpage: 100
+he:
+  main: 71
+  frontpage: 100
+hu:
+  main: 99
+  frontpage: 100
+id:
+  main: 57
+  frontpage: 51
+ga_IE:
+  main: 48
+  frontpage: 37
+it:
+  main: 98
+  frontpage: 100
+it_CH:
+  main: 0
+  frontpage: 0
+ja:
+  main: 68
+  frontpage: 62
+km:
+  main: 52
+  frontpage: 0
+ko:
+  main: 61
+  frontpage: 97
+lv:
+  main: 0
+  frontpage: 0
+mk:
+  main: 58
+  frontpage: 100
+ml:
+  main: 56
+  frontpage: 0
+mi:
+  main: 0
+  frontpage: 2
+fa_IR:
+  main: 13
+  frontpage: 100
+pl:
+  main: 13
+  frontpage: 100
+pt_BR:
+  main: 100
+  frontpage: 100
+pt_PT:
+  main: 10
+  frontpage: 25
+ro:
+  main: 99
+  frontpage: 100
+ru:
+  main: 54
+  frontpage: 100
+sr:
+  main: 100
+  frontpage: 100
+sr_RS:
+  main: 100
+  frontpage: 100
+sk:
+  main: 100
+  frontpage: 100
+sl:
+  main: 21
+  frontpage: 100
+es:
+  main: 99
+  frontpage: 100
+sv:
+  main: 65
+  frontpage: 97
+te:
+  main: 28
+  frontpage: 18
+tr:
+  main: 100
+  frontpage: 100
+uk:
+  main: 64
+  frontpage: 83
+ur:
+  main: 0
+  frontpage: 0
+ur_PK:
+  main: 0
+  frontpage: 0
+vi:
+  main: 46
+  frontpage: 0


### PR DESCRIPTION
@robguthrie in my node script I've added a function which stores the current percentage translated of each locale.

I'm interested in storing this in the app so that : 

- I can easily see which locales were in TEST but should now be LIVE
- in the future we can show users how complete translations are.

where should this file live. I don't think `config/locales` is a good choice, since rails loads the files in there and adds them to the list of translations. Having said that I could make the top levels of this yaml `en.translation_stats`. Would certainly make pulling these numbers into the app easier.
