### PR TITLE
small stylefix for nested bullet-point markdown lists

### DIFF
--- a/app/assets/stylesheets/unstructured/_discussions.css.scss
+++ b/app/assets/stylesheets/unstructured/_discussions.css.scss
@@ -442,6 +442,12 @@ body.discussions.show {
             position: relative;
             top: -12px;
             margin-bottom: -12px;
+          }
+          ul {
+            clear: left;
+            position: relative;
+            top: -12px;
+            margin-bottom: -12px;
         }}
         ol, p, ul {
           color: $text-black;


### PR DESCRIPTION
there's a problem with the styling on markdown. 
![](http://i.imgur.com/nKT3aLX.png)

I've extended what looks like a patch-job.
this needs testing in browser. I don't have time to update ruby atm :(