### PR TITLE
Fix path calculation for private_pub.yml in private_pub.ru

### DIFF
--- a/lineman/app/templates/group_form.haml
+++ b/lineman/app/templates/group_form.haml
@@ -72,5 +72,5 @@
           %input#group-members-can-vote{type: 'checkbox', ng_model: 'group.membersCanVote'}
           %span{translate: 'group_form.permissions.members_can_vote'}
 
-    %button.btn.btn-primary{type: 'submit', translate: 'group_form.new_group_submit', ng_show: 'group.isNew()'}
-    %button.btn.btn-primary{type: 'submit', translate: 'group_form.edit_group_submit', ng_hide: 'group.isNew()'}
+    %button.btn.btn-primary{type: 'submit', translate: 'group_form.new_group_submit', ng_show: 'group.isNew()', ng_disabled: 'isDisabled'}
+    %button.btn.btn-primary{type: 'submit', translate: 'group_form.edit_group_submit', ng_hide: 'group.isNew()', ng_disabled: 'isDisabled'}

--- a/private_pub.ru
+++ b/private_pub.ru
@@ -6,5 +6,6 @@ require "private_pub"
 
 Faye::WebSocket.load_adapter('thin')
 
-PrivatePub.load_config(File.expand_path("private_pub.yml", __FILE__), ENV["RAILS_ENV"] || "development")
+base = File.join(File.dirname(__FILE__), "config")
+PrivatePub.load_config(File.expand_path("private_pub.yml", base), ENV["RAILS_ENV"] || "development")
 run PrivatePub.faye_app


### PR DESCRIPTION
Fix path calculation for ``config/private_pub.yml`` in ``private_pub.ru``.
Fixes the following error while attempting to run
``rackup private_pub.ru -s thin -E production``:

    /home/dev/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/bundler/gems/private_pub-875b3de1711b/lib/private_pub.rb:23:in `read': Not a directory @ rb_sysopen - /home/dev/git/loomio/private_pub.ru/private_pub.yml (Errno::ENOTDIR)
            from /home/dev/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/bundler/gems/private_pub-875b3de1711b/lib/private_pub.rb:23:in `load_config'
            from /home/dev/git/loomio/private_pub.ru:9:in `block in <main>'
            from /home/dev/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/rack-1.5.2/lib/rack/builder.rb:55:in `instance_eval'
            from /home/dev/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/rack-1.5.2/lib/rack/builder.rb:55:in `initialize'
            from /home/dev/git/loomio/private_pub.ru:in `new'
            from /home/dev/git/loomio/private_pub.ru:in `<main>'
            from /home/dev/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/rack-1.5.2/lib/rack/builder.rb:49:in `eval'
            from /home/dev/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/rack-1.5.2/lib/rack/builder.rb:49:in `new_from_string'
            from /home/dev/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/rack-1.5.2/lib/rack/builder.rb:40:in `parse_file'
            from /home/dev/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/rack-1.5.2/lib/rack/server.rb:277:in `build_app_and_options_from_config'
            from /home/dev/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/rack-1.5.2/lib/rack/server.rb:199:in `app'
            from /home/dev/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/rack-1.5.2/lib/rack/server.rb:314:in `wrapped_app'
            from /home/dev/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/rack-1.5.2/lib/rack/server.rb:250:in `start'
            from /home/dev/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/rack-1.5.2/lib/rack/server.rb:141:in `start'
            from /home/dev/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/rack-1.5.2/bin/rackup:4:in `<top (required)>'
            from /home/dev/.rbenv/versions/2.2.0/bin/rackup:23:in `load'
            from /home/dev/.rbenv/versions/2.2.0/bin/rackup:23:in `<main>'