### PR TITLE
Make the database initialisable from `schema.rb` alone

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,7 @@ rvm:
   - 2.2.0
 before_script:
   - "cp config/database.yml.$DB config/database.yml"
-  - "bundle exec rake db:create RAILS_ENV=test"
-  - "bundle exec rake db:migrate RAILS_ENV=test"
-  #- "bundle exec rake db:schema:load RAILS_ENV=test"
-  - "bundle exec rake db:seed RAILS_ENV=test"
+  - "bundle exec rake db:setup RAILS_ENV=test"
   - "sh -e /etc/init.d/xvfb start"
 script: "bundle exec rake travis"
 addons:

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,0 +1,7 @@
+connection = ActiveRecord::Base.connection()
+connection.execute <<SQL
+	ALTER TABLE votes
+	ADD CONSTRAINT vote_age_per_user_per_motion
+	UNIQUE USING INDEX vote_age_per_user_per_motion
+	DEFERRABLE INITIALLY IMMEDIATE
+SQL

--- a/spec/models/vote_spec.rb
+++ b/spec/models/vote_spec.rb
@@ -10,7 +10,7 @@ describe Vote do
     let(:vote) { Vote.create(user: user, motion: motion, position: "no") }
     subject { vote }
 
-    its(:age) { should == 0 }
+    its(:age) { is_expected.to eq 0 }
 
     context 'user changes their position' do
       let(:vote2) { Vote.create(user: user, motion: motion, position: "yes") }
@@ -20,15 +20,39 @@ describe Vote do
       end
 
       subject { vote2 }
-      its(:age) { should == 0 }
+      its(:age) { is_expected.to eq 0 }
 
       it "should age the first vote" do
         vote.reload
-        vote.age.should == 1
+        expect(vote.age).to eq 1
       end
 
       it 'the second vote should associate the first as the previous' do
-        vote2.previous_vote_id.should == vote.id
+        expect(vote2.previous_vote_id).to eq vote.id
+      end
+
+      context 'user changes their position again' do
+        let(:vote3) { Vote.create(user: user, motion: motion, position: "no") }
+        before do
+          vote3
+        end
+
+        subject { vote3 }
+        its(:age) { is_expected.to eq 0 }
+
+        it "should age the first vote" do
+          vote.reload
+          expect(vote.age).to eq  2
+        end
+
+        it "should age the second vote" do
+          vote2.reload
+          expect(vote2.age).to eq  1
+        end
+
+        it 'the second vote should associate the first as the previous' do
+          expect(vote3.previous_vote_id).to eq vote2.id
+        end
       end
     end
   end
@@ -43,7 +67,7 @@ describe Vote do
     vote = Vote.new(position: "yes", statement: "This is what I think about the motion")
     vote.motion = motion
     vote.user = user
-    vote.should be_valid
+    expect(vote).to be_valid
   end
 
   it 'cannot have a statement over 250 chars' do
@@ -51,7 +75,7 @@ describe Vote do
     vote.motion = create(:motion, discussion: discussion)
     vote.user = user
     vote.statement = "a"*251
-    vote.should_not be_valid
+    expect(vote).to_not be_valid
   end
 
   it 'updates motion last_vote_at on create' do
@@ -60,7 +84,7 @@ describe Vote do
     vote.user = user
     vote.save!
     motion.reload
-    motion.last_vote_at.to_s.should == vote.created_at.to_s
+    expect(motion.last_vote_at.to_s).to eq vote.created_at.to_s
   end
 
   describe 'other_group_members' do
@@ -71,11 +95,11 @@ describe Vote do
     end
 
     it 'returns members in the group' do
-      @vote.other_group_members.should include @user1
+      expect(@vote.other_group_members).to include @user1
     end
 
     it 'does not return the voter' do
-      @vote.other_group_members.should_not include user
+      expect(@vote.other_group_members).to_not include user
     end
   end
 
@@ -92,7 +116,7 @@ describe Vote do
       vote2.user = user
       vote2.save!
 
-      vote2.previous_vote.id.should == vote.id
+      expect(vote2.previous_vote.id).to eq vote.id
     end
   end
 end


### PR DESCRIPTION
This is a continuation of #1870.

With these changes, it will be possible to setup a functioning database solely from schema.rb without running a single migration, which is the best practice for Active Record.

This PR:
* Adds a SQL statement to `db/seeds.rb` to ensure that the `vote_age_per_user_per_motion` constraint is deferrable. This would normally happen as part of the relevant migration but not when using `rake db:schema:load`.
* Adds specs to ensure the original scenario from #1870 works.
* Reverts a recent work-around to .travis.yml as it's no longer necessary.

Possible follow-ups:

* Delete old migrations so that we don't rely on them for bootstrapping of the database. Not necessarily a good idea given the sheer user base of Loomio and the non-zero likelihood of someone wanting to update a 2011 instance. :)