### PR TITLE
Modify mailer when added to group to include group full name in subject.

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -54,7 +54,7 @@ class UserMailer < BaseMailer
       mail to: user.email,
            from: from_user_via_loomio(inviter),
            reply_to: inviter.name_and_email,
-           subject: t("email.user_added_to_a_group.subject", which_group: group.name, who: inviter.name)
+           subject: t("email.user_added_to_a_group.subject", which_group: group.full_name, who: inviter.name)
     end
   end
 end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -32,4 +32,18 @@ describe UserMailer do
       @mail.body.encoded.should match("http://localhost:3000/g/#{@group.key}")
     end
   end
+
+  context 'sending email on being added to group' do
+    before :each do
+      @user = create(:user)
+      @inviter = create(:user)
+      @group = build(:group, full_name: "Group full name")
+      @mail = UserMailer.added_to_group(user: @user, inviter: @inviter, group: @group)
+    end
+
+    it 'renders the subject' do
+      expect(@mail.subject).to eq "#{@inviter.name} has added you to #{@group.full_name}"
+    end
+  end
+
 end


### PR DESCRIPTION
Add test to ensure that group.full_name is in the subject of an email when user is added to a group.  Change mailer to pass test.

Fixes issue #1865 