### PR TITLE
update invitation+added_to_group emails to use group.full_name fixes#1865

### DIFF
--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -42,7 +42,7 @@ class Invitation < ActiveRecord::Base
   def invitable_name
     case invitable_type
     when 'Group'
-      invitable.name
+      invitable.full_name
     when 'Discussion'
       invitable.title
     end

--- a/app/views/user_mailer/added_to_group.html.haml
+++ b/app/views/user_mailer/added_to_group.html.haml
@@ -3,6 +3,6 @@
   %head
     = stylesheet_link_tag 'email'
   %body
-    %p= t("email.user_added_to_a_group.content", which_group: @group.name, who: @inviter.name)
+    %p= t("email.user_added_to_a_group.content", which_group: @group.full_name, who: @inviter.name)
     %p= @message
     %p= link_to group_url(@group), group_url(@group, @utm_hash)

--- a/app/views/user_mailer/added_to_group.text.haml
+++ b/app/views/user_mailer/added_to_group.text.haml
@@ -1,4 +1,4 @@
-= t("email.user_added_to_a_group.content", which_group: @group.name, who: @inviter.name)
+= t("email.user_added_to_a_group.content", which_group: @group.full_name, who: @inviter.name)
 \
 = @message
 \

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -44,6 +44,10 @@ describe UserMailer do
     it 'renders the subject' do
       expect(@mail.subject).to eq "#{@inviter.name} has added you to #{@group.full_name}"
     end
+
+    it 'uses group.full_name in the email body' do
+      expect(@mail.body.encoded).to  include @group.full_name
+    end
   end
 
 end


### PR DESCRIPTION
![](http://i.imgur.com/ARS4jXY.png)

we've QA'd this as well @HSalmon and I 