### PR TITLE
replace should == in tests

### DIFF
--- a/features/step_definitions/accept_invitation_to_start_group_steps.rb
+++ b/features/step_definitions/accept_invitation_to_start_group_steps.rb
@@ -57,7 +57,7 @@ end
 
 Then /^I should become the admin of the group$/ do
   @user ||= User.find_by_email(@admin_email)
-  @user.is_group_admin?(@group).should == true
+  expect(@user.is_group_admin?(@group)).to be true
 end
 
 Then /^the group request should be marked as accepted$/ do

--- a/features/step_definitions/contact_form.steps.rb
+++ b/features/step_definitions/contact_form.steps.rb
@@ -33,8 +33,8 @@ Given(/^I am a current user$/) do
 end
 
 Then(/^I should see my name and email pre\-filled$/) do
-  find_field('Your name').value.should eq "Bob"
-  find_field('Your email address').value.should eq "bob@log.com"
+  expect(find_field('Your name').value).to eq  "Bob"
+  expect(find_field('Your email address').value).to eq  "bob@log.com"
 end
 
 Then(/^the message should be saved to the database with my user id$/) do

--- a/features/step_definitions/create_proposal_steps.rb
+++ b/features/step_definitions/create_proposal_steps.rb
@@ -32,7 +32,7 @@ Then /^I should see the proposal details$/ do
 end
 
 Then(/^the time zone should match my time zone setting$/) do
-  find('#motion_close_at_time_zone option[selected]').value.should == @user.time_zone_city
+  expect(find('#motion_close_at_time_zone option[selected]').value).to eq @user.time_zone_city
 end
 
 Given(/^"(.*?)" is the author of the proposal$/) do |arg1|

--- a/features/step_definitions/create_subgroup_steps.rb
+++ b/features/step_definitions/create_subgroup_steps.rb
@@ -10,7 +10,7 @@ end
 
 Then(/^a totally open subgroup should be created$/) do
   group = Group.find_by_name('subgroup')
-  group.description.should == 'description'
+  expect(group.description).to eq 'description'
   group.should be_is_visible_to_public
   group.should be_public_discussions_only
 end
@@ -26,7 +26,7 @@ end
 
 Then(/^a locked down subgroup should be created$/) do
   group = Group.find_by_name('subgroup')
-  group.description.should == 'description'
+  expect(group.description).to eq 'description'
   group.should_not be_is_visible_to_public
   group.should be_private_discussions_only
   group.should_not be_is_visible_to_parent_members
@@ -34,7 +34,7 @@ end
 
 Then(/^a visible to parent members subgroup should be created$/) do
   group = Group.find_by_name('subgroup')
-  group.description.should == 'description'
+  expect(group.description).to eq 'description'
   group.should be_is_visible_to_parent_members
   group.should be_parent_members_can_see_discussions
 end

--- a/features/step_definitions/discussion_activity_steps.rb
+++ b/features/step_definitions/discussion_activity_steps.rb
@@ -12,5 +12,5 @@ Given(/^I edit a discussion description twice in quick succession$/) do
 end
 
 Then(/^I should only see one activity item in the discussion activity feed$/) do
-  page.all(".discussion-icon").count.should == 3
+  expect(page.all(".discussion-icon").count).to eq 3
 end

--- a/features/step_definitions/discussion_steps.rb
+++ b/features/step_definitions/discussion_steps.rb
@@ -20,13 +20,13 @@ end
 
 Then /^I should see a discussion xml feed$/ do                                                                                                                            
   response = Hash.from_xml page.body
-  response['feed']['title'].should eq @discussion.title
-  response['feed']['subtitle'].should eq @discussion.description
+  expect(response['feed']['title']).to eq  @discussion.title
+  expect(response['feed']['subtitle']).to eq  @discussion.description
 end
 
 Then /^the xml feed should have the comment$/ do 
   response = Hash.from_xml page.body
   response['feed']['entry']['title'].should match /#{@comment.author.name}/
   response['feed']['entry']['author']['uri'].should match /#{@comment.author.key}/
-  response['feed']['entry']['content'].should eq @comment.body
+  expect(response['feed']['entry']['content']).to eq  @comment.body
 end

--- a/features/step_definitions/edit_group_settings_steps.rb
+++ b/features/step_definitions/edit_group_settings_steps.rb
@@ -106,8 +106,8 @@ end
 
 Then(/^the group name and description should be changed$/) do
   @group.reload
-  @group.name.should == 'changed'
-  @group.description.should == 'changed'
+  expect(@group.name).to eq 'changed'
+  expect(@group.description).to eq 'changed'
 end
 
 

--- a/features/step_definitions/edit_invitations_step.rb
+++ b/features/step_definitions/edit_invitations_step.rb
@@ -51,7 +51,7 @@ When(/^I cancel the pending invitation$/) do
 end
 
 Then(/^there should be no more pending invitations$/) do
-  @group.pending_invitations.count.should == 0
+  expect(@group.pending_invitations.count).to eq 0
 end
 
 Then(/^the flash notice should confirm the cancellation$/) do

--- a/features/step_definitions/edit_membership_steps.rb
+++ b/features/step_definitions/edit_membership_steps.rb
@@ -12,7 +12,7 @@ end
 
 Then(/^I should see the memberships index$/) do
   page.should have_css('body.memberships.index')
-  current_path.should == group_memberships_path(@group)
+  expect(current_path).to eq group_memberships_path(@group)
 end
 
 Given(/^there is another group member$/) do

--- a/features/step_definitions/email_steps.rb
+++ b/features/step_definitions/email_steps.rb
@@ -50,19 +50,19 @@ end
 #
 
 Then /^(?:I|they|"([^"]*?)") should receive (an|no|\d+) emails?$/ do |address, amount|
-  unread_emails_for(address).size.should == parse_email_count(amount)
+  expect(unread_emails_for(address).size).to eq parse_email_count(amount)
 end
 
 Then /^(?:I|they|"([^"]*?)") should have (an|no|\d+) emails?$/ do |address, amount|
-  mailbox_for(address).size.should == parse_email_count(amount)
+  expect(mailbox_for(address).size).to eq parse_email_count(amount)
 end
 
 Then /^(?:I|they|"([^"]*?)") should receive (an|no|\d+) emails? with subject "([^"]*?)"$/ do |address, amount, subject|
-  unread_emails_for(address).select { |m| m.subject =~ Regexp.new(Regexp.escape(subject)) }.size.should == parse_email_count(amount)
+  expect(unread_emails_for(address).select { |m| m.subject =~ Regexp.new(Regexp.escape(subject)) }.size).to eq parse_email_count(amount)
 end
 
 Then /^(?:I|they|"([^"]*?)") should receive (an|no|\d+) emails? with subject \/([^"]*?)\/$/ do |address, amount, subject|
-  unread_emails_for(address).select { |m| m.subject =~ Regexp.new(subject) }.size.should == parse_email_count(amount)
+  expect(unread_emails_for(address).select { |m| m.subject =~ Regexp.new(subject) }.size).to eq parse_email_count(amount)
 end
 
 Then /^(?:I|they|"([^"]*?)") should receive an email with the following body:$/ do |address, expected_body|
@@ -143,19 +143,19 @@ end
 #
 
 Then /^(?:I|they) should see (an|no|\d+) attachments? with the email$/ do |amount|
-  current_email_attachments.size.should == parse_email_count(amount)
+  expect(current_email_attachments.size).to eq parse_email_count(amount)
 end
 
 Then /^there should be (an|no|\d+) attachments? named "([^"]*?)"$/ do |amount, filename|
-  current_email_attachments.select { |a| a.filename == filename }.size.should == parse_email_count(amount)
+  expect(current_email_attachments.select { |a| a.filename == filename }.size).to eq parse_email_count(amount)
 end
 
 Then /^attachment (\d+) should be named "([^"]*?)"$/ do |index, filename|
-  current_email_attachments[(index.to_i - 1)].filename.should == filename
+  expect(current_email_attachments[(index.to_i - 1)].filename).to eq filename
 end
 
 Then /^there should be (an|no|\d+) attachments? of type "([^"]*?)"$/ do |amount, content_type|
-  current_email_attachments.select { |a| a.content_type.include?(content_type) }.size.should == parse_email_count(amount)
+  expect(current_email_attachments.select { |a| a.content_type.include?(content_type) }.size).to eq parse_email_count(amount)
 end
 
 Then /^attachment (\d+) should be of type "([^"]*?)"$/ do |index, content_type|

--- a/features/step_definitions/following_threads_steps.rb
+++ b/features/step_definitions/following_threads_steps.rb
@@ -105,7 +105,7 @@ end
 
 Then(/^I should get an email about the new discussion$/) do
   ActionMailer::Base.deliveries.last.to.should include @user.email
-  ActionMailer::Base.deliveries.last.subject.should == @discussion.title
+  expect(ActionMailer::Base.deliveries.last.subject).to eq @discussion.title
 end
 
 Then(/^I should not get an email about the new discussion$/) do
@@ -123,11 +123,11 @@ Given(/^there are no emails waiting for me$/) do
 end
 
 Then(/^I should be following new discussions by default$/) do
-  @group.membership_for(@user).following_by_default.should == true
+  expect(@group.membership_for(@user).following_by_default).to be true
 end
 
 Then(/^I should not be following discussions by default$/) do
-  @group.membership_for(@user).following_by_default.should == false
+  expect(@group.membership_for(@user).following_by_default).to be false
 end
 
 Given(/^I get mentioned in a discussion$/) do
@@ -163,7 +163,7 @@ Given(/^I click 'Following' on the discussion page$/) do
 end
 
 Then(/^I should get a mentioned notification$/) do
-  @user.notifications.last.event.kind.should == 'user_mentioned'
+  expect(@user.notifications.last.event.kind).to eq 'user_mentioned'
 end
 
 Given(/^there is a discussion I am not following$/) do

--- a/features/step_definitions/group_privacy_steps.rb
+++ b/features/step_definitions/group_privacy_steps.rb
@@ -261,7 +261,7 @@ end
 
 Then(/^the group should be set to private$/) do
   @group.reload
-  @group.privacy.should == 'private'
+  expect(@group.privacy).to eq 'private'
 end
 
 Given(/^a private group exists$/) do

--- a/features/step_definitions/group_request_migration_steps.rb
+++ b/features/step_definitions/group_request_migration_steps.rb
@@ -18,10 +18,10 @@ end
 
 Then(/^there should be an invitation to start that group$/) do
   @invitation = Invitation.find_by_token(@group_request.token)
-  @invitation.intent.should == 'start_group'
-  @invitation.recipient_email.should == @group_request.admin_email
-  @invitation.token.should == @group_request.token
-  @invitation.invitable.should == @group_request.group
+  expect(@invitation.intent).to eq 'start_group'
+  expect(@invitation.recipient_email).to eq @group_request.admin_email
+  expect(@invitation.token).to eq @group_request.token
+  expect(@invitation.invitable).to eq @group_request.group
 end
 
 When(/^I visit a GroupRequest\#start new group$/) do
@@ -42,5 +42,5 @@ When(/^I visit a GroupRequest\#start new group$/) do
 end
 
 Then(/^I should be redirected to invitations with the same token$/) do
-  current_path.should == invitation_path(@invitation)
+  expect(current_path).to eq invitation_path(@invitation)
 end

--- a/features/step_definitions/group_setup_steps.rb
+++ b/features/step_definitions/group_setup_steps.rb
@@ -32,7 +32,7 @@ Given(/^I am an admin of a group that has not completed setup$/) do
 end
 
 Then(/^I should be redirected to the group setup$/) do
-  current_path.should == setup_group_path(@group)
+  expect(current_path).to eq setup_group_path(@group)
 end
 
 Given(/^I am an admin of a parent group that has not completed setup$/) do
@@ -59,7 +59,7 @@ Then(/^I should have received the Welcome to Loomio email$/) do
   address = @user.email
   subject = "Welcome to Loomio"
   amount = 1
-  unread_emails_for(address).select { |m| m.subject =~ Regexp.new(subject) }.size.should == parse_email_count(amount)
+  expect(unread_emails_for(address).select { |m| m.subject =~ Regexp.new(subject) }.size).to eq parse_email_count(amount)
 end
 
 Then(/^I should see the subgroup page$/) do

--- a/features/step_definitions/inbox_steps.rb
+++ b/features/step_definitions/inbox_steps.rb
@@ -106,5 +106,5 @@ end
 
 Then(/^all the discussions in the group should be marked as read$/) do
   sleep(1)
-  Queries::VisibleDiscussions.new(user: @user, groups: [@group]).unread.size.should == 0
+  expect(Queries::VisibleDiscussions.new(user: @user, groups: [@group]).unread.size).to eq 0
 end

--- a/features/step_definitions/invitation_to_join_group_steps.rb
+++ b/features/step_definitions/invitation_to_join_group_steps.rb
@@ -22,13 +22,13 @@ end
 
 Then(/^bill and jane should both have invitations to join$/) do
   emails = ActionMailer::Base.deliveries.map(&:to).flatten.sort
-  emails.should == %w[bill@example.org jane@example.org]
+  expect(emails).to eq %w[bill@example.org jane@example.org]
 end
 
 Then(/^"(.*?)" should get an invitation to join the group$/) do |arg1|
   last_email = ActionMailer::Base.deliveries.last
-  last_email.to.should == [arg1]
-  last_email.reply_to.should == [@group_admin.email]
+  expect(last_email.to).to eq [arg1]
+  expect(last_email.reply_to).to eq [@group_admin.email]
 end
 
 Given(/^there is a user called "(.*?)" with email "(.*?)"$/) do |arg1, arg2|
@@ -229,7 +229,7 @@ end
 
 Then(/^"(.*?)" should receive a notification that they have been added$/) do |arg1|
   user = User.find_by_name(arg1)
-  Notification.where(user_id: user.id).last.event.kind.should == 'user_added_to_group'
+  expect(Notification.where(user_id: user.id).last.event.kind).to eq 'user_added_to_group'
 end
 
 When(/^I enter "(.*?)" in the invitations field$/) do |arg1|
@@ -238,7 +238,7 @@ end
 
 Then(/^"(.*?)" should be invited to join the subgroup$/) do |arg1|
   last_email = ActionMailer::Base.deliveries.last
-  last_email.to.should == [arg1]
+  expect(last_email.to).to eq [arg1]
   last_email.subject.should =~ /invited you to join/
 end
 
@@ -265,7 +265,7 @@ end
 
 Then (/^"(.*?)" should get an invitation to join the discussion$/) do |arg1|
   last_email = ActionMailer::Base.deliveries.last
-  last_email.to.should == [arg1]
+  expect(last_email.to).to eq [arg1]
 end
 
 Given(/^I am invited to join a discussion$/) do

--- a/features/step_definitions/leave_group_steps.rb
+++ b/features/step_definitions/leave_group_steps.rb
@@ -14,7 +14,7 @@ end
 And(/^I am the only coordinator of a group$/) do
   @group = FactoryGirl.create :group
   @user = @group.admins.first
-  @group.admins.count.should == 1
+  expect(@group.admins.count).to eq 1
 end
 
 Then(/^I should see that I can't leave the group$/) do

--- a/features/step_definitions/mark_summary_email_as_read_steps.rb
+++ b/features/step_definitions/mark_summary_email_as_read_steps.rb
@@ -20,9 +20,9 @@ Given(/^I am a logged out user with an unread discussion$/) do
   @motion.reload
   @discussion.reload
 
-  DiscussionReader.for(user: @user, discussion: @discussion).unread_comments_count.should == 2
-  MotionReader.for(user: @user, motion: @motion).unread_votes_count.should == 1
-  MotionReader.for(user: @user, motion: @motion).unread_activity_count.should == 2
+  expect(DiscussionReader.for(user: @user, discussion: @discussion).unread_comments_count).to eq 2
+  expect(MotionReader.for(user: @user, motion: @motion).unread_votes_count).to eq 1
+  expect(MotionReader.for(user: @user, motion: @motion).unread_activity_count).to eq 2
 end
 
 When(/^I mark the email as read$/) do
@@ -46,11 +46,11 @@ Then(/^the discussion should be marked as read when the email was generated$/) d
   @motion.reload
   @discussion.reload
 
-  DiscussionReader.for(user: @user, discussion: @discussion).
-                   unread_comments_count.should == 1
+  expect(DiscussionReader.for(user: @user, discussion: @discussion).
+                   unread_comments_count).to eq 1
 
-  MotionReader.for(user: @user, motion: @motion).unread_votes_count.should == 1
-  MotionReader.for(user: @user, motion: @motion).unread_activity_count.should == 1
+  expect(MotionReader.for(user: @user, motion: @motion).unread_votes_count).to eq 1
+  expect(MotionReader.for(user: @user, motion: @motion).unread_activity_count).to eq 1
 end
 
 

--- a/features/step_definitions/mention_user_steps.rb
+++ b/features/step_definitions/mention_user_steps.rb
@@ -67,11 +67,11 @@ Given /^harry wants to be emailed when mentioned$/ do
 end
 
 Then /^the user should be notified that they were mentioned$/ do
-  Event.where(:kind => "user_mentioned").count.should == 1
+  expect(Event.where(:kind => "user_mentioned").count).to eq 1
 end
 
 Then /^the user should not be notified that they were mentioned$/ do
-  Event.where(:kind => "user_mentioned").count.should == 0
+  expect(Event.where(:kind => "user_mentioned").count).to eq 0
 end
 
 Given /^I wait (\d+) seconds?$/ do |sec|

--- a/features/step_definitions/migrations/make_subgroups_of_secret_groups_secret_steps.rb
+++ b/features/step_definitions/migrations/make_subgroups_of_secret_groups_secret_steps.rb
@@ -11,5 +11,5 @@ end
 
 Then(/^the public subgroup should be secret$/) do
   @sub_group.reload
-  @sub_group.privacy.should == 'secret'
+  expect(@sub_group.privacy).to eq 'secret'
 end

--- a/features/step_definitions/omniauth_steps.rb
+++ b/features/step_definitions/omniauth_steps.rb
@@ -23,7 +23,7 @@ end
 
 Then(/^my omniauth_identity should be linked to my account$/) do
   @omniauth_identity = OmniauthIdentity.find_by_email('bill@example.com')
-  @omniauth_identity.user.should == User.find_by_email('bill@example.com')
+  expect(@omniauth_identity.user).to eq User.find_by_email('bill@example.com')
   page.get_rack_session.should_not have_key :omniauth_identity_id
 end
 

--- a/features/step_definitions/start_new_group_steps.rb
+++ b/features/step_definitions/start_new_group_steps.rb
@@ -88,6 +88,6 @@ end
 
 Then(/^the example content should be created$/) do
   @group = Group.where(name: @group_name).first
-  @group.discussions.first.title.should == I18n.t('example_discussion.title')
-  @group.motions.first.name.should == I18n.t('example_motion.name')
+  expect(@group.discussions.first.title).to eq I18n.t('example_discussion.title')
+  expect(@group.motions.first.name).to eq I18n.t('example_motion.name')
 end

--- a/features/step_definitions/time_zone_to_city_steps.rb
+++ b/features/step_definitions/time_zone_to_city_steps.rb
@@ -3,5 +3,5 @@ When(/^I convert "(.*?)"$/) do |iana_string|
 end
 
 Then(/^the city is "(.*?)"$/) do |city|
-  @city.should == city
+  expect(@city).to eq city
 end

--- a/spec/controllers/email_actions_controller_spec.rb
+++ b/spec/controllers/email_actions_controller_spec.rb
@@ -31,7 +31,7 @@ describe EmailActionsController do
 
     it 'marks the discussion as read at event created_at' do
       get :mark_discussion_as_read, discussion_id: @discussion.id, event_id: @event.id, unsubscribe_token: @user.unsubscribe_token
-      DiscussionReader.for(discussion: @discussion, user: @user).unread_comments_count.should == 0
+      expect(DiscussionReader.for(discussion: @discussion, user: @user).unread_comments_count).to eq 0
     end
   end
 

--- a/spec/controllers/groups_controller_spec.rb
+++ b/spec/controllers/groups_controller_spec.rb
@@ -43,7 +43,7 @@ describe GroupsController do
 
     it "create subgroup" do
       post :create, :group => {parent_id: group.id, name: 'subgroup', is_visible_to_public: false}
-      assigns(:group).parent.should eq(group)
+      expect(assigns(:group).parent).to eq (group)
       assigns(:group).admins.should include(user)
       response.should redirect_to(group_url(assigns(:group)))
     end
@@ -54,7 +54,7 @@ describe GroupsController do
       it "update" do
         expected_new_path = group_path(group).gsub(group.full_name.parameterize, 'new-name')
         post :update, id: group.key, group: { name: "New name!" }
-        flash[:notice].should == "Group was successfully updated."
+        expect(flash[:notice]).to eq "Group was successfully updated."
         response.should redirect_to expected_new_path
       end
 

--- a/spec/controllers/invitations_controller_spec.rb
+++ b/spec/controllers/invitations_controller_spec.rb
@@ -52,7 +52,7 @@ describe InvitationsController do
       end
 
       it "sets session attribute of the invitation token" do
-        session[:invitation_token].should == "AaBC1256"
+        expect(session[:invitation_token]).to eq "AaBC1256"
       end
 
       it "redirects to sign up" do

--- a/spec/controllers/translations_controller_spec.rb
+++ b/spec/controllers/translations_controller_spec.rb
@@ -42,8 +42,8 @@ describe TranslationsController do
 
     it "does not translate when passed a bogus model" do
       post :create, model: :bogus, id: comment.id, format: :js
-      response.body.strip.should eq ""
-      response.status.should eq 400
+      expect(response.body.strip).to eq  ""
+      expect(response.status).to eq  400
     end
   end
 end

--- a/spec/extras/accept_invitation_spec.rb
+++ b/spec/extras/accept_invitation_spec.rb
@@ -10,7 +10,7 @@ describe AcceptInvitation do
     end
 
     it 'sets accepted_by to the user' do
-      invitation.accepted_by.should == user
+      expect(invitation.accepted_by).to eq user
     end
 
     it 'sets accepted_at' do
@@ -34,7 +34,7 @@ describe AcceptInvitation do
     end
 
     it 'notifies the invitor of acceptance' do
-      Event.last.kind.should == 'invitation_accepted'
+      expect(Event.last.kind).to eq 'invitation_accepted'
     end
   end
 end

--- a/spec/extras/discussion_item_spec.rb
+++ b/spec/extras/discussion_item_spec.rb
@@ -8,8 +8,8 @@ describe DiscussionItem do
       it "delagates to a NewDiscussion discussion item" do
         event.stub(:kind).and_return("new_discussion")
         event.stub(:eventable).and_return(double(:Discussion))
-        DiscussionItem.new(event).
-          item.class.should == DiscussionItems::NewDiscussion
+        expect(DiscussionItem.new(event).
+          item.class).to eq DiscussionItems::NewDiscussion
       end
     end
 
@@ -17,8 +17,8 @@ describe DiscussionItem do
       it "delagates to a NewMotion discussion item" do
         event.stub(:kind).and_return("new_motion")
         event.stub(:eventable).and_return(double(:Motion))
-        DiscussionItem.new(event).
-          item.class.should == DiscussionItems::NewMotion
+        expect(DiscussionItem.new(event).
+          item.class).to eq DiscussionItems::NewMotion
       end
     end
 
@@ -26,8 +26,8 @@ describe DiscussionItem do
       it "delagates to a NewVote discussion item" do
         event.stub(:kind).and_return("new_vote")
         event.stub(:eventable).and_return(double(:Vote))
-        DiscussionItem.new(event).
-          item.class.should == DiscussionItems::NewVote
+        expect(DiscussionItem.new(event).
+          item.class).to eq DiscussionItems::NewVote
       end
     end
 
@@ -35,8 +35,8 @@ describe DiscussionItem do
       it "delagates to a MotionClosed discussion item" do
         event.stub(:kind).and_return("motion_closed")
         event.stub(:eventable).and_return(double(:Motion))
-        DiscussionItem.new(event).
-          item.class.should == DiscussionItems::MotionClosed
+        expect(DiscussionItem.new(event).
+          item.class).to eq DiscussionItems::MotionClosed
       end
     end
 
@@ -44,8 +44,8 @@ describe DiscussionItem do
       it "delagates to a MotionCloseDateEdited discussion item" do
         event.stub(:kind).and_return("motion_close_date_edited")
         event.stub(:eventable).and_return(double(:Motion))
-        DiscussionItem.new(event).
-          item.class.should == DiscussionItems::MotionCloseDateEdited
+        expect(DiscussionItem.new(event).
+          item.class).to eq DiscussionItems::MotionCloseDateEdited
       end
     end
 
@@ -53,8 +53,8 @@ describe DiscussionItem do
       it "delagates to a DiscussionTitleEdited discussion item" do
         event.stub(:kind).and_return("discussion_title_edited")
         event.stub(:eventable).and_return(double(:Motion))
-        DiscussionItem.new(event).
-          item.class.should == DiscussionItems::DiscussionTitleEdited
+        expect(DiscussionItem.new(event).
+          item.class).to eq DiscussionItems::DiscussionTitleEdited
       end
     end
 
@@ -62,8 +62,8 @@ describe DiscussionItem do
       it "delagates to a DiscussionDescriptionEdited discussion item" do
         event.stub(:kind).and_return("discussion_description_edited")
         event.stub(:eventable).and_return(double(:Motion))
-        DiscussionItem.new(event).
-          item.class.should == DiscussionItems::DiscussionDescriptionEdited
+        expect(DiscussionItem.new(event).
+          item.class).to eq DiscussionItems::DiscussionDescriptionEdited
       end
     end
 

--- a/spec/extras/discussion_items/discussion_description_edited_spec.rb
+++ b/spec/extras/discussion_items/discussion_description_edited_spec.rb
@@ -10,20 +10,20 @@ describe DiscussionItems::DiscussionDescriptionEdited do
   it "#actor returns the user who edited the description" do
     actor = double(:actor)
     item.stub_chain(:event, :user).and_return(actor)
-    item.actor.should == item.event.user
+    expect(item.actor).to eq item.event.user
   end
 
   it "#header returns a string" do
-    item.header.should == I18n.t('discussion_items.discussion_description_edited')
+    expect(item.header).to eq I18n.t('discussion_items.discussion_description_edited')
   end
 
   it "#group returns the discussion's group" do
     item.stub_chain(:discussion, :group).and_return("goob")
-    item.group.should == item.discussion.group
+    expect(item.group).to eq item.discussion.group
   end
 
   it "#time returns the time the discription's title was edited" do
     item.stub_chain(:event, :created_at).and_return("blah")
-    item.time.should == item.event.created_at
+    expect(item.time).to eq item.event.created_at
   end
 end

--- a/spec/extras/discussion_items/discussion_title_edited_spec.rb
+++ b/spec/extras/discussion_items/discussion_title_edited_spec.rb
@@ -8,26 +8,26 @@ describe DiscussionItems::DiscussionTitleEdited do
   it "#actor returns the user who edited the title" do
     actor = double(:actor)
     item.stub_chain(:event, :user).and_return(actor)
-    item.actor.should == item.event.user
+    expect(item.actor).to eq item.event.user
   end
 
   it "#header returns a string" do
-    item.header.should == I18n.t('discussion_items.discussion_title_edited') + ": "
+    expect(item.header).to eq I18n.t('discussion_items.discussion_title_edited') + ": "
   end
 
   it "#group returns the discussion's group" do
     item.stub_chain(:discussion, :group).and_return("goob")
-    item.group.should == item.discussion.group
+    expect(item.group).to eq item.discussion.group
   end
 
   it "#body returns the discussion's new title with a space at front" do
     item.stub_chain(:event, :created_at).and_return("blah")
     item.stub_chain(:discussion, :version_at, :title).and_return("goob")
-    item.body.should == " #{item.discussion.version_at.title}"
+    expect(item.body).to eq " #{item.discussion.version_at.title}"
   end
 
   it "#time returns the time the discription's title was edited" do
     item.stub_chain(:event, :created_at).and_return("blah")
-    item.time.should == item.event.created_at
+    expect(item.time).to eq item.event.created_at
   end
 end

--- a/spec/extras/discussion_items/motion_close_date_edited_spec.rb
+++ b/spec/extras/discussion_items/motion_close_date_edited_spec.rb
@@ -8,20 +8,20 @@ describe DiscussionItems::MotionCloseDateEdited do
   it "#actor returns the user who edited the close date" do
     actor = double(:actor)
     item.stub_chain(:event, :user).and_return(actor)
-    item.actor.should == item.event.user
+    expect(item.actor).to eq item.event.user
   end
 
   it "#header returns a string" do
-    item.header.should == I18n.t('discussion_items.motion_close_date_edited')
+    expect(item.header).to eq I18n.t('discussion_items.motion_close_date_edited')
   end
 
   it "#group returns the discussion's group" do
     item.stub_chain(:motion, :group).and_return("goob")
-    item.group.should == item.motion.group
+    expect(item.group).to eq item.motion.group
   end
 
   it "#time returns the time the close date was edited" do
     item.stub_chain(:event, :created_at).and_return("blah")
-    item.time.should == item.event.created_at
+    expect(item.time).to eq item.event.created_at
   end
 end

--- a/spec/extras/discussion_items/motion_closed_by_user.spec.rb
+++ b/spec/extras/discussion_items/motion_closed_by_user.spec.rb
@@ -10,26 +10,26 @@ describe DiscussionItems::MotionClosedByUser do
 
     it "#actor returns the user who created a discussion" do
       actor = double(:actor)
-      item.actor.should == item.event.user
+      expect(item.actor).to eq item.event.user
     end
 
     it "#header returns a string" do
-      item.header.should == I18n.t('discussion_items.motion_closed.by_user') + ": "
+      expect(item.header).to eq I18n.t('discussion_items.motion_closed.by_user') + ": "
     end
   end
 
   it "#group returns the discussion's group" do
     item.stub_chain(:motion, :group).and_return("goob")
-    item.group.should == item.motion.group
+    expect(item.group).to eq item.motion.group
   end
 
   it "#body returns the motion's name with a space at front" do
     item.stub_chain(:motion, :name).and_return("goob")
-    item.body.should == " #{item.motion.name}"
+    expect(item.body).to eq " #{item.motion.name}"
   end
 
   it "#time returns the time the motion was closed" do
     item.stub_chain(:event, :created_at).and_return("blah")
-    item.time.should == item.event.created_at
+    expect(item.time).to eq item.event.created_at
   end
 end

--- a/spec/extras/discussion_items/motion_closed_by_user_spec.rb
+++ b/spec/extras/discussion_items/motion_closed_by_user_spec.rb
@@ -12,7 +12,7 @@ describe NotificationItems::MotionClosedByUser do
 
   context "user closed motion" do
     it "#action_text returns a string" do
-      item.action_text.should == I18n.t('notifications.motion_closed.by_user')
+      expect(item.action_text).to eq I18n.t('notifications.motion_closed.by_user')
     end
   end
 end

--- a/spec/extras/discussion_items/motion_closed_spec.rb
+++ b/spec/extras/discussion_items/motion_closed_spec.rb
@@ -9,26 +9,26 @@ describe DiscussionItems::MotionClosed do
     before { item.stub_chain(:event, :user).and_return(nil) }
 
     it "#actor returns an empty string" do
-      item.actor.should == ""
+      expect(item.actor).to eq ""
     end
 
     it "#header returns a string" do
-      item.header.should == I18n.t('discussion_items.motion_closed.by_expiry') + ": "
+      expect(item.header).to eq I18n.t('discussion_items.motion_closed.by_expiry') + ": "
     end
   end
 
   it "#group returns the discussion's group" do
     item.stub_chain(:motion, :group).and_return("goob")
-    item.group.should == item.motion.group
+    expect(item.group).to eq item.motion.group
   end
 
   it "#body returns the motion's name with a space at front" do
     item.stub_chain(:motion, :name).and_return("goob")
-    item.body.should == " #{item.motion.name}"
+    expect(item.body).to eq " #{item.motion.name}"
   end
 
   it "#time returns the time the motion was closed" do
     item.stub_chain(:event, :created_at).and_return("blah")
-    item.time.should == item.event.created_at
+    expect(item.time).to eq item.event.created_at
   end
 end

--- a/spec/extras/discussion_items/new_discussion_spec.rb
+++ b/spec/extras/discussion_items/new_discussion_spec.rb
@@ -8,26 +8,26 @@ describe DiscussionItems::NewDiscussion do
   it "#actor returns the user who created a discussion" do
     actor = double(:actor)
     item.stub_chain(:discussion, :author).and_return(actor)
-    item.actor.should == item.discussion.author
+    expect(item.actor).to eq item.discussion.author
   end
 
   it "#header returns a string" do
-    item.header.should == I18n.t('discussion_items.new_discussion') + ": "
+    expect(item.header).to eq I18n.t('discussion_items.new_discussion') + ": "
   end
 
   it "#group returns the discussion's group" do
     item.stub_chain(:discussion, :group).and_return("goob")
-    item.group.should == item.discussion.group
+    expect(item.group).to eq item.discussion.group
   end
 
   it "#body returns the discussion's title with a space at front" do
     item.stub_chain(:event, :created_at).and_return("blah")
     item.stub_chain(:discussion, :version_at, :title).and_return("goob")
-    item.body.should == " #{item.discussion.version_at.title}"
+    expect(item.body).to eq " #{item.discussion.version_at.title}"
   end
 
   it "#time returns the time the discussion was created at" do
     item.stub_chain(:discussion, :created_at).and_return("blah")
-    item.time.should == item.discussion.created_at
+    expect(item.time).to eq item.discussion.created_at
   end
 end

--- a/spec/extras/discussion_items/new_motion_spec.rb
+++ b/spec/extras/discussion_items/new_motion_spec.rb
@@ -7,25 +7,25 @@ describe DiscussionItems::NewMotion do
   it "#actor returns the user who created a motion" do
     actor = double(:actor)
     item.stub_chain(:motion, :author).and_return(actor)
-    item.actor.should == item.motion.author
+    expect(item.actor).to eq item.motion.author
   end
 
   it "#header returns a string" do
-    item.header.should == I18n.t('discussion_items.new_motion') + ": "
+    expect(item.header).to eq I18n.t('discussion_items.new_motion') + ": "
   end
 
   it "#group returns the motion's group" do
     item.stub_chain(:motion, :group).and_return("goob")
-    item.group.should == item.motion.group
+    expect(item.group).to eq item.motion.group
   end
 
   it "#body returns the motion's name with a space at front" do
     item.stub_chain(:motion, :name).and_return("goob")
-    item.body.should == " #{item.motion.name}"
+    expect(item.body).to eq " #{item.motion.name}"
   end
 
   it "#time returns the time the motion was created at" do
     item.stub_chain(:motion, :created_at).and_return("blah")
-    item.time.should == item.motion.created_at
+    expect(item.time).to eq item.motion.created_at
   end
 end

--- a/spec/extras/discussion_items/new_vote_spec.rb
+++ b/spec/extras/discussion_items/new_vote_spec.rb
@@ -7,26 +7,26 @@ describe DiscussionItems::NewVote do
   it "#actor returns the user who voted" do
     actor = double(:actor)
     item.stub_chain(:vote, :user).and_return(actor)
-    item.actor.should == item.vote.user
+    expect(item.actor).to eq item.vote.user
   end
 
   it "#header returns a string"
 
   it "#group returns the motion's group" do
     item.stub_chain(:vote, :discussion, :group).and_return("goob")
-    item.group.should == item.vote.discussion.group
+    expect(item.group).to eq item.vote.discussion.group
   end
 
   context "user has given a statement" do
     before { item.stub_chain(:vote, :statement).and_return(double("It's furry!")) }
 
     it "#body returns the users statement with a space at front" do
-      item.body.should == " #{item.vote.statement}"
+      expect(item.body).to eq " #{item.vote.statement}"
     end
   end
 
   it "#time returns the time the motion was created at" do
     item.stub_chain(:vote, :created_at).and_return("blah")
-    item.time.should == item.vote.created_at
+    expect(item.time).to eq item.vote.created_at
   end
 end

--- a/spec/extras/notification_item_spec.rb
+++ b/spec/extras/notification_item_spec.rb
@@ -5,80 +5,80 @@ describe NotificationItem do
     context "notification is for a new discussion" do
       it "returns a NewDiscussion notification item" do
         notification.stub(:event_kind).and_return("new_discussion")
-        NotificationItem.new(notification).
-          item.class.should == NotificationItems::NewDiscussion
+        expect(NotificationItem.new(notification).
+          item.class).to eq NotificationItems::NewDiscussion
       end
     end
 
     context "notification is for a new motion" do
       it "returns a NewMotion notification item" do
         notification.stub(:event_kind).and_return("new_motion")
-        NotificationItem.new(notification).
-          item.class.should == NotificationItems::NewMotion
+        expect(NotificationItem.new(notification).
+          item.class).to eq NotificationItems::NewMotion
       end
     end
 
     context "notification is for closed motion" do
       it "returns a MotionClosed notification item" do
         notification.stub(:event_kind).and_return("motion_closed")
-        NotificationItem.new(notification).
-          item.class.should == NotificationItems::MotionClosed
+        expect(NotificationItem.new(notification).
+          item.class).to eq NotificationItems::MotionClosed
       end
     end
 
     context "notification is for a adding a new comment" do
       it "returns NewComment notification item" do
         notification.stub(:event_kind).and_return("new_comment")
-        NotificationItem.new(notification).
-          item.class.should == NotificationItems::NewComment
+        expect(NotificationItem.new(notification).
+          item.class).to eq NotificationItems::NewComment
       end
     end
 
     context "notification is for a comment like" do
       it "returns a CommentLiked notification item" do
         notification.stub(:event_kind).and_return("comment_liked")
-        NotificationItem.new(notification).
-          item.class.should == NotificationItems::CommentLiked
+        expect(NotificationItem.new(notification).
+          item.class).to eq NotificationItems::CommentLiked
       end
     end
 
     context "notification is for a membership request" do
       it "returns a MembershipRequested notification item" do
         notification.stub(:event_kind).and_return("membership_requested")
-        NotificationItem.new(notification).
-          item.class.should == NotificationItems::MembershipRequested
+        expect(NotificationItem.new(notification).
+          item.class).to eq NotificationItems::MembershipRequested
       end
     end
 
     context "notification is for a adding a user to a group" do
       it "returns UserAddedToGroup notification item" do
         notification.stub(:event_kind).and_return("user_added_to_group")
-        NotificationItem.new(notification).
-        item.class.should == NotificationItems::UserAddedToGroup
+        expect(NotificationItem.new(notification).
+        item.class).to eq NotificationItems::UserAddedToGroup
       end
     end
 
     context "notification is for mentioning a user" do
       it "returns MentionedUser notification item" do
         notification.stub(:event_kind).and_return("user_mentioned")
-        item = NotificationItem.new(notification).
-          item.class.should == NotificationItems::UserMentioned
+        expect(item = NotificationItem.new(notification).
+          item.class).to eq NotificationItems::UserMentioned
       end
     end
 
     context "notification is for a motion closing soon" do
       it "returns MotionClosingSoon notification item" do
         notification.stub(:event_kind).and_return("motion_closing_soon")
-        NotificationItem.new(notification).
-          item.class.should == NotificationItems::MotionClosingSoon
+        expect(NotificationItem.new(notification).
+          item.class).to eq NotificationItems::MotionClosingSoon
       end
     end
 
     context "notification is for a new vote" do
       it "returns NewVote notification item" do
         notification.stub(:event_kind).and_return("new_vote")
-        NotificationItem.new(notification).
-          item.class.should == NotificationItems::NewVote
+        expect(NotificationItem.new(notification).
+          item.class).to eq NotificationItems::NewVote
       end
     end
   end

--- a/spec/extras/notification_items/comment_liked_spec.rb
+++ b/spec/extras/notification_items/comment_liked_spec.rb
@@ -8,26 +8,26 @@ describe NotificationItems::CommentLiked do
   it "#actor returns the user who liked the comment" do
     liker = double(:user)
     eventable.stub(user: liker)
-    item.actor.should == notification.eventable.user
+    expect(item.actor).to eq notification.eventable.user
   end
 
   it "#action_text returns a string" do
-    item.action_text.should == I18n.t('notifications.comment_liked')
+    expect(item.action_text).to eq I18n.t('notifications.comment_liked')
   end
 
   it "#title returns the discussion title" do
     eventable.stub(discussion_title: "hello")
-    item.title.should == notification.eventable.discussion_title
+    expect(item.title).to eq notification.eventable.discussion_title
   end
 
   it "#group_full_name returns the discussion's group name including a parent if there is one" do
     eventable.stub(group_full_name: "goob")
-    item.group_full_name.should == notification.eventable.group_full_name
+    expect(item.group_full_name).to eq notification.eventable.group_full_name
   end
 
   it "#link returns a path to the comment" do
     item.stub_chain(:url_helpers, :discussion_path).and_return("/discussions/1/")
     eventable.stub(comment_id: "123", discussion: double(:discussion))
-    item.link.should == "/discussions/1/#comment-123"
+    expect(item.link).to eq "/discussions/1/#comment-123"
   end
 end

--- a/spec/extras/notification_items/comment_replied_to_spec.rb
+++ b/spec/extras/notification_items/comment_replied_to_spec.rb
@@ -7,27 +7,27 @@ describe NotificationItems::CommentRepliedTo do
   it "#actor returns the user who posted the comment" do
     poster = double(:user)
     notification.stub_chain(:eventable, :user).and_return(poster)
-    item.actor.should == notification.eventable.user
+    expect(item.actor).to eq notification.eventable.user
   end
 
   it "#action_text returns a string" do
-    item.action_text.should == I18n.t('notifications.comment_replied_to')
+    expect(item.action_text).to eq I18n.t('notifications.comment_replied_to')
   end
 
   it "#title returns the discussion title" do
     notification.stub_chain(:eventable, :discussion_title).and_return("hello")
-    item.title.should == notification.eventable.discussion_title
+    expect(item.title).to eq notification.eventable.discussion_title
   end
 
   it "#group_full_name returns the discussion's group name including a parent if there is one" do
     notification.stub_chain(:eventable, :group_full_name).and_return("goob")
-    item.group_full_name.should == notification.eventable.group_full_name
+    expect(item.group_full_name).to eq notification.eventable.group_full_name
   end
 
   it "#link returns a path to the discussion" do
     item.stub_chain(:url_helpers, :discussion_path).and_return("/discussions/1")
     notification.stub_chain(:eventable, :comment_id).and_return(1)
     notification.stub_chain(:eventable, :discussion).and_return(stub:(:discussion))
-    item.link.should == "/discussions/1#comment-1"
+    expect(item.link).to eq "/discussions/1#comment-1"
   end
 end

--- a/spec/extras/notification_items/membership_requested_spec.rb
+++ b/spec/extras/notification_items/membership_requested_spec.rb
@@ -26,26 +26,26 @@ describe NotificationItems::MembershipRequested do
     action_text = "blah"
     I18n.should_receive(:t).with('notifications.membership_requested').
       and_return(action_text)
-    item.action_text.should == action_text
+    expect(item.action_text).to eq action_text
   end
 
   it "#title returns the groups name" do
-    item.title.should == notification.eventable.group_name
+    expect(item.title).to eq notification.eventable.group_name
   end
 
   it "#group_full_name returns the group name including a parent group if there is one" do
-    item.group_full_name.should == notification.eventable.group_name
+    expect(item.group_full_name).to eq notification.eventable.group_name
   end
 
   it "#link returns a path to the membersip requests for the requested group" do
     item.should_receive(:group_membership_requests_path).with(group).and_return("/groups/1/membership_requests")
-    item.link.should eq("/groups/1/membership_requests")
+    expect(item.link).to eq ("/groups/1/membership_requests")
   end
 
   describe "#actor" do
     it "returns the user who requested membership" do
       requestor = double(:user)
-      item.actor.should == notification.eventable.requestor
+      expect(item.actor).to eq notification.eventable.requestor
     end
 
     context "if membership was requested by a visitor to the site" do
@@ -58,9 +58,9 @@ describe NotificationItems::MembershipRequested do
       end
 
       it "returns a visitor with a name and email" do
-        item.actor.class.should eq(LoggedOutUser)
-        item.actor.name.should eq(@name)
-        item.actor.email.should eq(@email)
+        expect(item.actor.class).to eq (LoggedOutUser)
+        expect(item.actor.name).to eq (@name)
+        expect(item.actor.email).to eq (@email)
       end
     end
   end

--- a/spec/extras/notification_items/motion_closed_spec.rb
+++ b/spec/extras/notification_items/motion_closed_spec.rb
@@ -14,28 +14,28 @@ describe NotificationItems::MotionClosed do
     before { notification.stub_chain(:event, :user).and_return(nil) }
 
     it "#action_text returns a string" do
-      item.action_text.should == I18n.t('notifications.motion_closed.by_expiry') + ": "
+      expect(item.action_text).to eq I18n.t('notifications.motion_closed.by_expiry') + ": "
     end
 
     it "#avatar returns the motion author" do
       notification.stub_chain(:eventable, :author).and_return("Peter")
-      item.avatar.should == notification.eventable.author
+      expect(item.avatar).to eq notification.eventable.author
     end
   end
 
   it "#title returns the motion name" do
     notification.stub_chain(:eventable, :name).and_return("hello")
-    item.title.should == notification.eventable.name
+    expect(item.title).to eq notification.eventable.name
   end
 
   it "#group_full_name returns the discussion's group name including a parent if there is one" do
     notification.stub_chain(:eventable, :group_full_name).and_return("goob")
-    item.group_full_name.should == notification.eventable.group_full_name
+    expect(item.group_full_name).to eq notification.eventable.group_full_name
   end
 
   it "#link returns a path to the motion" do
     item.stub_chain(:url_helpers, :motion_path).and_return("/motions/1")
     notification.stub(:eventable).and_return(double(:motion))
-    item.link.should == "/motions/1"
+    expect(item.link).to eq "/motions/1"
   end
 end

--- a/spec/extras/notification_items/motion_closing_soon_spec.rb
+++ b/spec/extras/notification_items/motion_closing_soon_spec.rb
@@ -5,31 +5,31 @@ describe NotificationItems::MotionClosingSoon do
   let(:item) { NotificationItems::MotionClosingSoon.new(notification) }
 
   it "#actor returns nil" do
-    item.actor.should == nil
+    expect(item.actor).to eq nil
   end
 
   it "#action_text returns a string" do
-    item.action_text.should == I18n.t('notifications.motion_closing_soon') + ": "
+    expect(item.action_text).to eq I18n.t('notifications.motion_closing_soon') + ": "
   end
 
   it "#title returns the motion name" do
     notification.stub_chain(:eventable, :name).and_return("hello")
-    item.title.should == notification.eventable.name
+    expect(item.title).to eq notification.eventable.name
   end
 
   it "#group_full_name returns the discussion's group name including a parent if there is one" do
     notification.stub_chain(:eventable, :group_full_name).and_return("goob")
-    item.group_full_name.should == notification.eventable.group_full_name
+    expect(item.group_full_name).to eq notification.eventable.group_full_name
   end
 
   it "#link returns a path to the motion" do
     item.stub_chain(:url_helpers, :motion_path).and_return("/motions/1")
     notification.stub(:eventable).and_return(double(:motion))
-    item.link.should == "/motions/1"
+    expect(item.link).to eq "/motions/1"
   end
 
   it "#avatar returns the correct user for the notification avatar" do
     notification.stub_chain(:eventable, :author).and_return("Peter")
-    item.avatar.should == notification.eventable.author
+    expect(item.avatar).to eq notification.eventable.author
   end
 end

--- a/spec/extras/notification_items/new_comment_spec.rb
+++ b/spec/extras/notification_items/new_comment_spec.rb
@@ -7,26 +7,26 @@ describe NotificationItems::NewComment do
   it "#actor returns the user who posted the new comment" do
     poster = double(:user)
     notification.stub_chain(:eventable, :user).and_return(poster)
-    item.actor.should == notification.eventable.user
+    expect(item.actor).to eq notification.eventable.user
   end
 
   it "#action_text returns a string" do
-    item.action_text.should == I18n.t('notifications.new_comment')
+    expect(item.action_text).to eq I18n.t('notifications.new_comment')
   end
 
   it "#title returns the discussion title" do
     notification.stub_chain(:eventable, :discussion_title).and_return("hello")
-    item.title.should == notification.eventable.discussion_title
+    expect(item.title).to eq notification.eventable.discussion_title
   end
 
   it "#group_full_name returns the discussion's group name including a parent if there is one" do
     notification.stub_chain(:eventable, :group_full_name).and_return("goob")
-    item.group_full_name.should == notification.eventable.group_full_name
+    expect(item.group_full_name).to eq notification.eventable.group_full_name
   end
 
   it "#link returns a path to the discussion" do
     item.stub_chain(:url_helpers, :discussion_path).and_return("/discussions/1")
     notification.stub_chain(:eventable, :discussion).and_return(stub:(:discussion))
-    item.link.should == "/discussions/1"
+    expect(item.link).to eq "/discussions/1"
   end
 end

--- a/spec/extras/notification_items/new_discussion_spec.rb
+++ b/spec/extras/notification_items/new_discussion_spec.rb
@@ -7,26 +7,26 @@ describe NotificationItems::NewDiscussion do
   it "#actor returns the user who created a discussion" do
     actor = double(:actor)
     notification.stub_chain(:eventable, :author).and_return(actor)
-    item.actor.should == notification.eventable.author
+    expect(item.actor).to eq notification.eventable.author
   end
 
   it "#action_text returns a string" do
-    item.action_text.should == I18n.t('notifications.new_discussion')
+    expect(item.action_text).to eq I18n.t('notifications.new_discussion')
   end
 
   it "#title returns the motion name" do
     notification.stub_chain(:eventable, :title).and_return("hello")
-    item.title.should == notification.eventable.title
+    expect(item.title).to eq notification.eventable.title
   end
 
   it "#group_full_name returns the discussion's group name including a parent if there is one" do
     notification.stub_chain(:eventable, :group_full_name).and_return("goob")
-    item.group_full_name.should == notification.eventable.group_full_name
+    expect(item.group_full_name).to eq notification.eventable.group_full_name
   end
 
   it "#link returns a path to the motion's discussion" do
     item.stub_chain(:url_helpers, :discussion_path).and_return("/discussions/1")
     notification.stub_chain(:eventable).and_return(double(:discussion))
-    item.link.should == "/discussions/1"
+    expect(item.link).to eq "/discussions/1"
   end
 end

--- a/spec/extras/notification_items/new_motion_spec.rb
+++ b/spec/extras/notification_items/new_motion_spec.rb
@@ -7,26 +7,26 @@ describe NotificationItems::NewMotion do
   it "#actor returns the user who created a motion" do
     actor = double(:actor)
     notification.stub_chain(:eventable, :author).and_return(actor)
-    item.actor.should == notification.eventable.author
+    expect(item.actor).to eq notification.eventable.author
   end
 
   it "#action_text returns a string" do
-    item.action_text.should == I18n.t('notifications.new_motion') + ": "
+    expect(item.action_text).to eq I18n.t('notifications.new_motion') + ": "
   end
 
   it "#title returns the motion name" do
     notification.stub_chain(:eventable, :name).and_return("hello")
-    item.title.should == notification.eventable.name
+    expect(item.title).to eq notification.eventable.name
   end
 
   it "#group_full_name returns the discussion's group name including a parent if there is one" do
     notification.stub_chain(:eventable, :group_full_name).and_return("goob")
-    item.group_full_name.should == notification.eventable.group_full_name
+    expect(item.group_full_name).to eq notification.eventable.group_full_name
   end
 
   it "#link returns a path to the motion's discussion" do
     item.stub_chain(:url_helpers, :discussion_path).and_return("/discussions/1")
     notification.stub_chain(:eventable, :discussion).and_return(double(:discussion))
-    item.link.should == "/discussions/1"
+    expect(item.link).to eq "/discussions/1"
   end
 end

--- a/spec/extras/notification_items/user_added_to_group_spec.rb
+++ b/spec/extras/notification_items/user_added_to_group_spec.rb
@@ -7,26 +7,26 @@ describe NotificationItems::UserAddedToGroup do
   it "#actor returns the user who invited or approved the new user into the group" do
     notification.stub_chain(:event, :user).and_return double
     notification.stub_chain(:eventable, :user).and_return double
-    item.actor.should == notification.event.user
+    expect(item.actor).to eq notification.event.user
   end
 
   it "#action_text returns a string" do
-    item.action_text.should == I18n.t('notifications.user_added_to_group')
+    expect(item.action_text).to eq I18n.t('notifications.user_added_to_group')
   end
 
   it "#title returns the groups name" do
     notification.stub_chain(:eventable, :group_full_name).and_return("hello")
-    item.title.should == notification.eventable.group_full_name
+    expect(item.title).to eq notification.eventable.group_full_name
   end
 
   it "#group_full_name returns the group name including a parent group if there is one" do
     notification.stub_chain(:eventable, :group_full_name).and_return("goob")
-    item.group_full_name.should == notification.eventable.group_full_name
+    expect(item.group_full_name).to eq notification.eventable.group_full_name
   end
 
   it "#link returns a path to the group" do
     item.stub_chain(:url_helpers, :group_path).and_return("/groups/1/")
     notification.stub_chain(:eventable, :group).and_return(double(:group))
-    item.link.should == "/groups/1/"
+    expect(item.link).to eq "/groups/1/"
   end
 end

--- a/spec/extras/notification_items/user_mentioned_spec.rb
+++ b/spec/extras/notification_items/user_mentioned_spec.rb
@@ -8,26 +8,26 @@ describe NotificationItems::UserMentioned do
   it "#actor returns the user who mentioned someone" do
     mentioner = double(:user)
     eventable.stub(:user => mentioner)
-    item.actor.should == notification.eventable.user
+    expect(item.actor).to eq notification.eventable.user
   end
 
   it "#action_text returns a string" do
-    item.action_text.should == I18n.t('notifications.user_mentioned')
+    expect(item.action_text).to eq I18n.t('notifications.user_mentioned')
   end
 
   it "#title returns the discussion title" do
     eventable.stub(:discussion_title => "hello")
-    item.title.should == notification.eventable.discussion_title
+    expect(item.title).to eq notification.eventable.discussion_title
   end
 
   it "#group_full_name returns the discussion's group name including a parent if there is one" do
     eventable.stub(:group_full_name => "goob")
-    item.group_full_name.should == notification.eventable.group_full_name
+    expect(item.group_full_name).to eq notification.eventable.group_full_name
   end
 
   it "#link returns a path to the comment" do
     item.stub_chain(:url_helpers, :discussion_path).and_return("/discussions/1/")
     eventable.stub(:id => "123", :discussion => double(:discussion))
-    item.link.should == "/discussions/1/#comment-123"
+    expect(item.link).to eq "/discussions/1/#comment-123"
   end
 end

--- a/spec/extras/tree_spec.rb
+++ b/spec/extras/tree_spec.rb
@@ -6,9 +6,9 @@ describe Tree do
       parent, value, children = double(:parent), double(:value), double(:children)
       root = Tree.new(parent: parent, value: value,
                                 children: children)
-      root.parent.should == parent
-      root.value.should == value
-      root.children.should == children
+      expect(root.parent).to eq parent
+      expect(root.value).to eq value
+      expect(root.children).to eq children
     end
   end
 
@@ -21,10 +21,10 @@ describe Tree do
       children[0].children = [grandchild]
       root.children = children
       enumerator = root.each
-      enumerator.next.should == root
-      enumerator.next.should == children[0]
-      enumerator.next.should == grandchild
-      enumerator.next.should == children[1]
+      expect(enumerator.next).to eq root
+      expect(enumerator.next).to eq children[0]
+      expect(enumerator.next).to eq grandchild
+      expect(enumerator.next).to eq children[1]
     end
   end
 

--- a/spec/forms/inbox_preferences_form_spec.rb
+++ b/spec/forms/inbox_preferences_form_spec.rb
@@ -21,7 +21,7 @@ describe InboxPreferencesForm do
       end
 
       it 'returns empty array if user has no memberships' do
-        subject.should == []
+        expect(subject).to eq []
       end
 
       it 'returns membership selected to appear in inbox' do
@@ -34,7 +34,7 @@ describe InboxPreferencesForm do
         blue_group = FactoryGirl.create(:group)
         m1 = create_membership_with_position(user, red_group, 1)
         m0 = create_membership_with_position(user, blue_group, 0)
-        subject.should == [m0.group, m1.group]
+        expect(subject).to eq [m0.group, m1.group]
       end
     end
   end
@@ -46,15 +46,15 @@ describe InboxPreferencesForm do
       m1 = create_membership_with_position(user, red_group, 5)
       m0 = create_membership_with_position(user, blue_group, 6)
       subject.submit({groups: [m0.group_id, m1.group_id]})
-      m0.reload.inbox_position.should == 0
-      m1.reload.inbox_position.should == 1
+      expect(m0.reload.inbox_position).to eq 0
+      expect(m1.reload.inbox_position).to eq 1
     end
 
     it 'removes groups you dont want to see' do
       red_group = FactoryGirl.create(:group)
       m0 = create_membership_with_position(user, red_group, 6)
       subject.submit({groups: []})
-      m0.reload.inbox_position.should == nil
+      expect(m0.reload.inbox_position).to eq nil
     end
   end
 

--- a/spec/forms/subscription_form_spec.rb
+++ b/spec/forms/subscription_form_spec.rb
@@ -23,21 +23,21 @@ describe SubscriptionForm do
     context "when preset_amount == 'custom'" do
       it "returns custom_amount" do
         form = SubscriptionForm.new('preset_amount' => 'custom', 'custom_amount' => '23')
-        form.amount.should eq('23')
+        expect(form.amount).to eq ('23')
       end
     end
 
     context "when preset_amount is blank" do
       it "returns custom_amount" do
         form = SubscriptionForm.new('preset_amount' => '', 'custom_amount' => '23')
-        form.amount.should eq('23')
+        expect(form.amount).to eq ('23')
       end
     end
 
     context "when both preset_amount and custom_amount have numeric values" do
       it "returns preset_amount" do
         form = SubscriptionForm.new('preset_amount' => '52', 'custom_amount' => '23')
-        form.amount.should eq('52')
+        expect(form.amount).to eq ('52')
       end
     end
   end
@@ -46,9 +46,9 @@ describe SubscriptionForm do
     it "always returns amount with two decimal places" do
       form = SubscriptionForm.new
       form.stub amount: '2.5'
-      form.amount_with_cents.should eq('2.50')
+      expect(form.amount_with_cents).to eq ('2.50')
       form.stub amount: '12'
-      form.amount_with_cents.should eq('12.00')
+      expect(form.amount_with_cents).to eq ('12.00')
     end
   end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -11,7 +11,7 @@ describe ApplicationHelper do
     context 'when time is same day' do
       it 'displays hours, minutes and meridian' do
         Timecop.freeze("2013-01-02 12:00:00 UTC") do
-          subject.should == ' 4:55 pm'
+          expect(subject).to eq ' 4:55 pm'
         end
       end
     end
@@ -19,7 +19,7 @@ describe ApplicationHelper do
     context 'when it is not the same day' do
       it 'displays date only' do
         Timecop.freeze("2013-01-01 12:00:00 UTC") do
-          subject.should == ' 2 Jan'
+          expect(subject).to eq ' 2 Jan'
         end
       end
     end
@@ -27,7 +27,7 @@ describe ApplicationHelper do
     context 'when it is not the same year' do
       it 'displays date and year' do
         Timecop.freeze("2014-01-01 12:00:00 UTC") do
-          subject.should == '2/1/13'
+          expect(subject).to eq '2/1/13'
         end
       end
     end
@@ -35,10 +35,10 @@ describe ApplicationHelper do
 
   describe "display_title" do
     it "shows Loomio name" do
-      helper.display_title(double(:size => 0)).should == "Loomio"
+      expect(helper.display_title(double(:size => 0))).to eq "Loomio"
     end
     it "shows notifications in paranthensis (if any)" do
-      helper.display_title(double(:size => 2)).should == "(2) Loomio"
+      expect(helper.display_title(double(:size => 2))).to eq "(2) Loomio"
     end
   end
   describe "set_title" do
@@ -77,7 +77,7 @@ describe ApplicationHelper do
       helper.analytics_scope do
         executed = true
       end    
-      executed.should eq true
+      expect(executed).to eq  true
     end
 
     it "executes block in staging" do
@@ -86,7 +86,7 @@ describe ApplicationHelper do
       helper.analytics_scope do
         executed = true
       end    
-      executed.should eq true
+      expect(executed).to eq  true
     end
 
     it "does not execute block in other environments" do
@@ -95,7 +95,7 @@ describe ApplicationHelper do
       helper.analytics_scope do
         executed = true
       end    
-      executed.should eq false
+      expect(executed).to eq  false
     end
 
     it "does not execute block in the searches controller" do
@@ -105,7 +105,7 @@ describe ApplicationHelper do
       helper.analytics_scope do
         executed = true
       end    
-      executed.should eq false
+      expect(executed).to eq  false
     end
   end
 end

--- a/spec/helpers/email_helper_spec.rb
+++ b/spec/helpers/email_helper_spec.rb
@@ -9,7 +9,7 @@ describe EmailHelper do
     it "gives correct format" do
       output = helper.reply_to_address(discussion: discussion,
                                           user: user)
-      output.should == "d=d1&u=1&k=abc123@replyhostname.com"
+      expect(output).to eq "d=d1&u=1&k=abc123@replyhostname.com"
     end
   end
 end

--- a/spec/helpers/locales_helper_spec.rb
+++ b/spec/helpers/locales_helper_spec.rb
@@ -10,7 +10,7 @@ describe LocalesHelper do
     end
 
     it 'gives the correct language preference' do
-      helper.send(:browser_accepted_locales).should == [:'pt-BR', :'pt', :'en-US', :'en', :'es']
+      expect(helper.send(:browser_accepted_locales)).to eq [:'pt-BR', :'pt', :'en-US', :'en', :'es']
     end
   end
 end

--- a/spec/helpers/motion_helper_spec.rb
+++ b/spec/helpers/motion_helper_spec.rb
@@ -12,13 +12,13 @@ describe MotionsHelper do
     context "motion closed" do
       before { @motion.stub(:voting?).and_return(false) }
       it "returns false" do
-        display_vote_buttons?(@motion, @user).should == false
+        expect(display_vote_buttons?(@motion, @user)).to be false
       end
     end
     context "user has voted" do
       before { @motion.stub(:user_has_voted?).and_return(true) }
       it "returns false" do
-        display_vote_buttons?(@motion, @user).should == false
+        expect(display_vote_buttons?(@motion, @user)).to be false
       end
     end
   end

--- a/spec/mailers/group_mailer_spec.rb
+++ b/spec/mailers/group_mailer_spec.rb
@@ -24,21 +24,20 @@ describe GroupMailer do
     end
 
     it 'renders the subject' do
-      @mail.subject.should ==
-        "#{@membership_request.name} has requested to join #{@group.full_name}"
+      expect(@mail.subject).to eq "#{@membership_request.name} has requested to join #{@group.full_name}"
     end
 
     it "sends email to group admins" do
-      @mail.to.should == [@admin.email]
+      expect(@mail.to).to eq [@admin.email]
     end
 
     context "requestor is an existing loomio user" do
       it 'renders the sender email' do
-        @mail.from.should == ['notifications@loomio.org']
+        expect(@mail.from).to eq ['notifications@loomio.org']
       end
 
       it 'assigns correct reply_to' do
-        @mail.reply_to.should == [@membership_request.email]
+        expect(@mail.reply_to).to eq [@membership_request.email]
       end
 
       it 'assigns confirmation_url for email body' do

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -3,11 +3,11 @@ require "rails_helper"
 describe UserMailer do
   shared_examples_for 'email_meta' do
     it 'renders the receiver email' do
-      @mail.to.should == [@user.email]
+      expect(@mail.to).to eq [@user.email]
     end
 
     it 'renders the sender email' do
-      @mail.from.should == ['notifications@loomio.org']
+      expect(@mail.from).to eq ['notifications@loomio.org']
     end
   end
 
@@ -21,11 +21,11 @@ describe UserMailer do
     it_behaves_like 'email_meta'
 
     it 'assigns correct reply_to' do
-      @mail.reply_to.should == [@group.admin_email]
+      expect(@mail.reply_to).to eq [@group.admin_email]
     end
 
     it 'renders the subject' do
-      @mail.subject.should == "[Loomio: #{@group.full_name}] Membership approved"
+      expect(@mail.subject).to eq "[Loomio: #{@group.full_name}] Membership approved"
     end
 
     it 'assigns confirmation_url for email body' do

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -51,11 +51,11 @@ describe Comment do
     end
 
     it "increases like count" do
-      comment.comment_votes.count.should == 1
+      expect(comment.comment_votes.count).to eq 1
     end
 
     it "returns a CommentVote object" do
-      @like.class.name.should == "CommentVote"
+      expect(@like.class.name).to eq "CommentVote"
     end
 
     context "liked again by the same user" do
@@ -64,7 +64,7 @@ describe Comment do
       end
 
       it "does not increase like count" do
-        comment.comment_votes.count.should == 1
+        expect(comment.comment_votes.count).to eq 1
       end
     end
   end
@@ -76,7 +76,7 @@ describe Comment do
     end
 
     it "decreases like count" do
-      comment.comment_votes.count.should == 0
+      expect(comment.comment_votes.count).to eq 0
     end
 
     context "unliked again by the same user" do
@@ -85,7 +85,7 @@ describe Comment do
       end
 
       it "does not decrease like count" do
-        comment.comment_votes.count.should == 0
+        expect(comment.comment_votes.count).to eq 0
       end
     end
   end

--- a/spec/models/concerns/avatar_initials_spec.rb
+++ b/spec/models/concerns/avatar_initials_spec.rb
@@ -23,30 +23,30 @@ describe AvatarInitials do
     it "sets avatar_initials to 'DU' if deactivated_at is true (a date is present)" do
       user.deactivated_at = "20/12/2002"
       user.set_avatar_initials
-      user.avatar_initials.should == "DU"
+      expect(user.avatar_initials).to eq "DU"
     end
 
     it "sets avatar_initials to the first two characters in all caps of the email if the user's name is email" do
       user.set_avatar_initials
-      user.avatar_initials.should == "RG"
+      expect(user.avatar_initials).to eq "RG"
     end
 
     it "returns the first three initials of the stored name" do
       user.name = "Bob bobby sinclair deebop"
       user.set_avatar_initials
-      user.avatar_initials.should == "BBS"
+      expect(user.avatar_initials).to eq "BBS"
     end
 
     it "returns the first two characters of their email if they have no name" do
       user.name = nil
       user.set_avatar_initials
-      user.avatar_initials.should == "RO"
+      expect(user.avatar_initials).to eq "RO"
     end
 
     it "works for strange characters" do
       user.name = "D'Angelo (Loco)"
       user.set_avatar_initials
-      user.avatar_initials.should == "D("
+      expect(user.avatar_initials).to eq "D("
     end
   end
 end

--- a/spec/models/discussion_spec.rb
+++ b/spec/models/discussion_spec.rb
@@ -67,7 +67,7 @@ describe Discussion do
     before { @user = create(:user) }
     it "returns user's discussions that match the query string" do
       discussion = create :discussion, title: "jam toast", author: @user
-      @user.discussions.search("jam").should == [discussion]
+      expect(@user.discussions.search("jam")).to eq [discussion]
     end
     it "does not return discussions that don't belong to the user" do
       discussion = create :discussion, title: "sandwich crumbs"
@@ -79,7 +79,7 @@ describe Discussion do
     it "returns the time the discussion was created at if no previous version exists" do
       Timecop.freeze do
         discussion = create :discussion
-        discussion.last_versioned_at.iso8601.should == discussion.created_at.iso8601
+        expect(discussion.last_versioned_at.iso8601).to eq discussion.created_at.iso8601
       end
     end
     it "returns the time the previous version was created at" do
@@ -87,7 +87,7 @@ describe Discussion do
       discussion.stub :has_previous_versions? => true
       discussion.stub_chain(:previous_version, :version, :created_at)
                 .and_return 12345
-      discussion.last_versioned_at.should == 12345
+      expect(discussion.last_versioned_at).to eq 12345
     end
   end
 
@@ -118,7 +118,7 @@ describe Discussion do
     end
 
     it "returns a count of motions" do
-      @discussion.reload.motions_count.should == 1
+      expect(@discussion.reload.motions_count).to eq 1
     end
 
     it "updates correctly after creating a motion" do
@@ -211,9 +211,9 @@ describe Discussion do
       @discussion = create :discussion
     end
     it "increases the total_views by 1" do
-      @discussion.total_views.should == 0
+      expect(@discussion.total_views).to eq 0
       @discussion.viewed!
-      @discussion.total_views.should == 1
+      expect(@discussion.total_views).to eq 1
     end
   end
 

--- a/spec/models/events/comment_replied_to_spec.rb
+++ b/spec/models/events/comment_replied_to_spec.rb
@@ -20,7 +20,7 @@ describe Events::CommentRepliedTo do
     end
 
     it 'returns an event' do
-      Events::CommentRepliedTo.publish!(comment).should == event
+      expect(Events::CommentRepliedTo.publish!(comment)).to eq event
     end
   end
 end

--- a/spec/models/events/invitation_accepted_spec.rb
+++ b/spec/models/events/invitation_accepted_spec.rb
@@ -14,7 +14,7 @@ describe Events::InvitationAccepted do
     end
 
     it 'returns an event' do
-      Events::InvitationAccepted.publish!(membership).should == event
+      expect(Events::InvitationAccepted.publish!(membership)).to eq event
     end
   end
 end

--- a/spec/models/events/membership_request_approved_spec.rb
+++ b/spec/models/events/membership_request_approved_spec.rb
@@ -22,7 +22,7 @@ describe Events::MembershipRequestApproved do
     end
 
     it 'returns an event' do
-      Events::MembershipRequestApproved.publish!(membership, approver).should == event
+      expect(Events::MembershipRequestApproved.publish!(membership, approver)).to eq event
     end
   end
 

--- a/spec/models/events/membership_requested_spec.rb
+++ b/spec/models/events/membership_requested_spec.rb
@@ -20,7 +20,7 @@ describe Events::MembershipRequested do
     end
 
     it 'returns an event' do
-      Events::MembershipRequested.publish!(membership_request).should == event
+      expect(Events::MembershipRequested.publish!(membership_request)).to eq event
     end
   end
 

--- a/spec/models/events/motion_closed_by_user_spec.rb
+++ b/spec/models/events/motion_closed_by_user_spec.rb
@@ -17,7 +17,7 @@ describe Events::MotionClosedByUser do
     end
 
     it 'returns an event' do
-      Events::MotionClosedByUser.publish!(motion, closer).should == event
+      expect(Events::MotionClosedByUser.publish!(motion, closer)).to eq event
     end
   end
 end

--- a/spec/models/events/new_comment_spec.rb
+++ b/spec/models/events/new_comment_spec.rb
@@ -18,7 +18,7 @@ describe Events::NewComment do
     end
 
     it 'returns an event' do
-      Events::NewComment.publish!(comment).should == event
+      expect(Events::NewComment.publish!(comment)).to eq event
     end
 
     it 'does not publish a comment replied to event if there is no parent' do

--- a/spec/models/events/user_added_to_group_spec.rb
+++ b/spec/models/events/user_added_to_group_spec.rb
@@ -16,7 +16,7 @@ describe Events::UserAddedToGroup do
     end
 
     it 'returns an event' do
-      Events::UserAddedToGroup.publish!(membership, inviter).should == event
+      expect(Events::UserAddedToGroup.publish!(membership, inviter)).to eq event
     end
   end
 

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -8,13 +8,13 @@ describe Group do
 
   context "group creator" do
     it "stores the admin as a creator" do
-      group.creator.should == group.admins.first
+      expect(group.creator).to eq group.admins.first
     end
 
     it "delegates language to the group creator" do
       @user = create :user, selected_locale: :fr
       group = create :group, creator: @user
-      group.locale.should == group.creator.locale
+      expect(group.locale).to eq group.creator.locale
     end
   end
 
@@ -29,7 +29,7 @@ describe Group do
       end
 
       it "returns a count of motions" do
-        @group.reload.motions_count.should == 1
+        expect(@group.reload.motions_count).to eq 1
       end
 
       it "updates correctly after creating a motion" do
@@ -72,7 +72,7 @@ describe Group do
 
       it "updates correctly after archiving a discussion" do
         @group.discussions.create(attributes_for(:discussion).merge({ author: @user }))
-        @group.reload.discussions_count.should == 1
+        expect(@group.reload.discussions_count).to eq 1
         expect {
           @group.discussions.first.archive!
         }.to change { @group.reload.discussions_count }.by(-1)
@@ -80,7 +80,7 @@ describe Group do
 
       it "updates correctly after deleting a discussion" do
         @group.discussions.create(attributes_for(:discussion).merge({ author: @user }))
-        @group.reload.discussions_count.should == 1
+        expect(@group.reload.discussions_count).to eq 1
         expect {
           @group.discussions.first.destroy
         }.to change { @group.reload.discussions_count }.by(-1)
@@ -123,14 +123,14 @@ describe Group do
 
     context "subgroup.full_name" do
       it "contains parent name" do
-        @subgroup.full_name.should == "#{@group.name} - #{@subgroup.name}"
+        expect(@subgroup.full_name).to eq "#{@group.name} - #{@subgroup.name}"
       end
 
       it "updates if parent_name changes" do
         @group.name = "bluebird"
         @group.save!
         @subgroup.reload
-        @subgroup.full_name.should == "#{@group.name} - #{@subgroup.name}"
+        expect(@subgroup.full_name).to eq "#{@group.name} - #{@subgroup.name}"
       end
     end
   end

--- a/spec/models/invitation_spec.rb
+++ b/spec/models/invitation_spec.rb
@@ -48,7 +48,7 @@ describe Invitation do
     end
 
     it 'sets attribute canceller' do
-      @invitation.canceller.should == @admin_user
+      expect(@invitation.canceller).to eq @admin_user
     end
 
     it 'should be cancelled' do
@@ -70,11 +70,11 @@ describe Invitation do
     end
 
     it 'specifies the recpient email' do
-      @invitation.recipient_email.should == 'jon@lemmon.com'
+      expect(@invitation.recipient_email).to eq 'jon@lemmon.com'
     end
 
     it 'specifies the group' do
-      @invitation.invitable.should == group
+      expect(@invitation.invitable).to eq group
     end
 
     it 'is to join as an admin' do
@@ -95,11 +95,11 @@ describe Invitation do
     end
 
     it 'specifies the recpient email' do
-      @invitation.recipient_email.should == 'jon@lemmon.com'
+      expect(@invitation.recipient_email).to eq 'jon@lemmon.com'
     end
 
     it 'specifies the group' do
-      @invitation.invitable.should == group
+      expect(@invitation.invitable).to eq group
     end
 
     it 'is to join as an admin' do

--- a/spec/models/invite_people_spec.rb
+++ b/spec/models/invite_people_spec.rb
@@ -4,7 +4,7 @@ describe InvitePeopleForm do
   context 'parsed_emails' do
     it 'splits recipients string into a list of valid email strings' do
       invite_people = InvitePeopleForm.new(:recipients => 'j@j.com, b@b.com, rob guthrie <r@g.com>')
-      invite_people.instance_eval{ parsed_emails } .should == ['j@j.com', 'b@b.com', 'rob guthrie <r@g.com>']
+      expect(invite_people.instance_eval{ parsed_emails } ).to eq ['j@j.com', 'b@b.com', 'rob guthrie <r@g.com>']
     end
   end
 end

--- a/spec/models/membership_request_spec.rb
+++ b/spec/models/membership_request_spec.rb
@@ -96,10 +96,10 @@ describe MembershipRequest do
       membership_request.approve!(responder)
     end
     it "sets response to approved" do
-      membership_request.response.should == 'approved'
+      expect(membership_request.response).to eq 'approved'
     end
     it "sets responder" do
-      membership_request.responder.should == responder
+      expect(membership_request.responder).to eq responder
     end
     it "sets response_at" do
       membership_request.responded_at.should_not be_blank

--- a/spec/models/membership_spec.rb
+++ b/spec/models/membership_spec.rb
@@ -29,7 +29,7 @@ describe Membership do
     membership = user.memberships.new(:group_id => group.id)
     membership.inviter = user2
     membership.save!
-    membership.inviter.should == user2
+    expect(membership.inviter).to eq user2
   end
 
   context "destroying a membership" do
@@ -70,7 +70,7 @@ describe Membership do
 
       it "removes user's open votes for the group" do
         @membership.destroy
-        @motion.votes.count.should == 0
+        expect(@motion.votes.count).to eq 0
       end
 
       it "does not remove user's open votes for other groups" do
@@ -83,7 +83,7 @@ describe Membership do
         vote.motion = motion2
         vote.save!
         @membership.destroy
-        motion2.votes.count.should == 1
+        expect(motion2.votes.count).to eq 1
       end
 
       it "does not fail if motion no longer exists" do

--- a/spec/models/motion_reader_spec.rb
+++ b/spec/models/motion_reader_spec.rb
@@ -19,11 +19,11 @@ describe MotionReader do
 
     context 'not called' do
       it "should have 1 unread vote" do
-        reader.unread_votes_count.should == 1
+        expect(reader.unread_votes_count).to eq 1
       end
 
       it "should have 2 unread activity" do
-        reader.unread_activity_count.should == 2
+        expect(reader.unread_activity_count).to eq 2
       end
     end
 
@@ -33,11 +33,11 @@ describe MotionReader do
       end
 
       it 'marks all unique votes as read' do
-        reader.unread_votes_count.should == 0
+        expect(reader.unread_votes_count).to eq 0
       end
 
       it 'marks all vote activity as read' do
-        reader.unread_activity_count.should == 0
+        expect(reader.unread_activity_count).to eq 0
       end
     end
 
@@ -47,11 +47,11 @@ describe MotionReader do
       end
 
       it 'marks all unique votes before time as read' do
-        reader.unread_votes_count.should == 1
+        expect(reader.unread_votes_count).to eq 1
       end
 
       it 'marks all vote activity before time as read' do
-        reader.unread_activity_count.should == 1
+        expect(reader.unread_activity_count).to eq 1
       end
     end
   end

--- a/spec/models/motion_spec.rb
+++ b/spec/models/motion_spec.rb
@@ -13,9 +13,9 @@ describe Motion do
       vote1 = Vote.create(motion_id: motion.id, user_id: user.id, position: "no")
       vote2 = Vote.create(motion_id: motion.id, user_id: user.id, position: "yes")
 
-      motion.votes.count.should == 2
-      motion.unique_votes.count.should == 1
-      motion.unique_votes.first.should == vote2
+      expect(motion.votes.count).to eq 2
+      expect(motion.unique_votes.count).to eq 1
+      expect(motion.unique_votes.first).to eq vote2
     end
   end
 
@@ -43,7 +43,7 @@ describe Motion do
       @vote.user = @user
       @vote.motion = @motion
       @vote.save!
-      @motion.user_has_voted?(@user).should == true
+      expect(@motion.user_has_voted?(@user)).to be true
     end
   end
 
@@ -51,7 +51,7 @@ describe Motion do
     before { @user = create(:user) }
     it "returns user's motions that match the query string" do
       motion = create(:motion, name: "jam toast", author: @user, discussion: discussion)
-      @user.motions.search("jam").should == [motion]
+      expect(@user.motions.search("jam")).to eq [motion]
     end
     it "does not return discussions that don't belong to the user" do
       motion = create(:motion, name: "sandwich crumbs", discussion: discussion)
@@ -67,7 +67,7 @@ describe Motion do
       motion.group.add_member! user
       create :vote, :motion => motion, :position => "yes", :user => user
       motion.reload
-      motion.members_not_voted_count.should == motion.group_members.count - 1
+      expect(motion.members_not_voted_count).to eq motion.group_members.count - 1
     end
 
     it "still works if the same user votes multiple times" do
@@ -75,7 +75,7 @@ describe Motion do
       motion.group.add_member! user
       vote1 = create :vote, :motion => motion, :position => "yes", :user => user
       vote2 = create :vote, :motion => motion, :position => "no", :user => user
-      motion.members_not_voted_count.should == motion.group_members.count - 1
+      expect(motion.members_not_voted_count).to eq motion.group_members.count - 1
     end
 
     context "for a closed motion" do
@@ -84,7 +84,7 @@ describe Motion do
       it "returns the number of members who did not vote" do
         motion.should be_closed
         motion.stub(:did_not_votes_count).and_return(99)
-        motion.members_not_voted_count.should == 99
+        expect(motion.members_not_voted_count).to eq 99
       end
     end
   end
@@ -119,7 +119,7 @@ describe Motion do
     it "returns the pecentage of users that have voted" do
       @motion.stub(:members_not_voted_count).and_return(10)
       @motion.stub(:group_size_when_voting).and_return(20)
-      @motion.percent_voted.should == 50
+      expect(@motion.percent_voted).to eq 50
     end
   end
 
@@ -145,10 +145,10 @@ describe Motion do
 
       context 'after updating the vote_counts' do
         it 'has counts of 1' do
-          motion.yes_votes_count.should == 1
-          motion.no_votes_count.should == 1
-          motion.abstain_votes_count.should == 1
-          motion.block_votes_count.should == 1
+          expect(motion.yes_votes_count).to eq 1
+          expect(motion.no_votes_count).to eq 1
+          expect(motion.abstain_votes_count).to eq 1
+          expect(motion.block_votes_count).to eq 1
         end
       end
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -55,14 +55,14 @@ describe User do
     user = User.new attributes_for(:user)
     user.stub(:has_gravatar? => true)
     user.save!
-    user.avatar_kind.should == "gravatar"
+    expect(user.avatar_kind).to eq "gravatar"
   end
 
   it "does not set avatar_kind if user does not have gravatar" do
     user = User.new attributes_for(:user)
     user.stub(:has_gravatar?).and_return(false)
     user.save!
-    user.avatar_kind.should == 'initials'
+    expect(user.avatar_kind).to eq 'initials'
   end
 
   it "email can have an apostrophe" do
@@ -152,7 +152,7 @@ describe User do
     end
 
     it "marks all notifications before given notification id as viewed" do
-      user.unviewed_notifications.count.should == 1
+      expect(user.unviewed_notifications.count).to eq 1
       @notif1.reload
       @notif1.viewed_at.should_not be_nil
     end
@@ -182,21 +182,21 @@ describe User do
   describe "#using_initials?" do
     it "returns true if user avatar_kind is 'initials'" do
       user.avatar_kind = "initials"
-      user.using_initials?.should == true
+      expect(user.using_initials?).to be true
     end
     it "returns false if user avatar_kind is something else" do
       user.avatar_kind = "uploaded"
-      user.using_initials?.should == false
+      expect(user.using_initials?).to be false
     end
   end
 
   describe "#has_uploaded_image?" do
     it "returns true if user has uploaded an image" do
       user.stub_chain(:uploaded_avatar, :url).and_return('/uploaded_avatars/medium/pants.png')
-      user.has_uploaded_image?.should == true
+      expect(user.has_uploaded_image?).to be true
     end
     it "returns false if user has not uploaded an image" do
-      user.has_uploaded_image?.should == false
+      expect(user.has_uploaded_image?).to be false
     end
   end
 
@@ -209,7 +209,7 @@ describe User do
     it "returns gravatar url if avatar_kind is 'gravatar'" do
       user.should_receive(:gravatar_url).and_return('www.gravatar/spike')
       user.avatar_kind = 'gravatar'
-      user.avatar_url(:small).should == 'www.gravatar/spike'
+      expect(user.avatar_url(:small)).to eq 'www.gravatar/spike'
     end
 
     context "where avatar_kind is 'uploaded'" do
@@ -220,22 +220,22 @@ describe User do
       it "returns medium url if no size is specified" do
         @uploaded_avatar.should_receive(:url).with(:medium).and_return('www.gravatar/uploaded/mike')
         user.avatar_kind = 'uploaded'
-        user.avatar_url(:medium).should == 'www.gravatar/uploaded/mike'
+        expect(user.avatar_url(:medium)).to eq 'www.gravatar/uploaded/mike'
       end
       it "returns large url if large size is specified" do
         @uploaded_avatar.should_receive(:url).with(:large).and_return('www.gravatar/uploaded/mike')
         user.avatar_kind = 'uploaded'
-        user.avatar_url(:large).should == 'www.gravatar/uploaded/mike'
+        expect(user.avatar_url(:large)).to eq 'www.gravatar/uploaded/mike'
       end
       it "returns medium url if medium size is specified" do
         @uploaded_avatar.should_receive(:url).with(:medium).and_return('www.gravatar/uploaded/mike')
         user.avatar_kind = 'uploaded'
-        user.avatar_url(:medium).should == 'www.gravatar/uploaded/mike'
+        expect(user.avatar_url(:medium)).to eq 'www.gravatar/uploaded/mike'
       end
       it "returns small url if small size is specified" do
         @uploaded_avatar.should_receive(:url).with(:small).and_return('www.gravatar/uploaded/mike')
         user.avatar_kind = 'uploaded'
-        user.avatar_url(:small).should == 'www.gravatar/uploaded/mike'
+        expect(user.avatar_url(:small)).to eq 'www.gravatar/uploaded/mike'
       end
     end
   end
@@ -278,14 +278,14 @@ describe User do
     it "returns notifications that the user has not viewed yet" do
       notification = Notification.create!(:event => mock_model(Event),
                                           :user => user)
-      user.unviewed_notifications.first.id.should == notification.id
+      expect(user.unviewed_notifications.first.id).to eq notification.id
     end
     it "does not return notifications that the user has viewed" do
       notification = Notification.new(:event => mock_model(Event),
                                       :user => user)
       notification.viewed_at = Time.now
       notification.save
-      user.unviewed_notifications.count.should == 0
+      expect(user.unviewed_notifications.count).to eq 0
     end
   end
 
@@ -323,21 +323,21 @@ describe User do
       user = User.new
       user.name = "R!chard D. Bar_tle*tt$"
       user.generate_username
-      user.username.should == "rcharddbartlett"
+      expect(user.username).to eq "rcharddbartlett"
     end
 
     it "changes non ASCII characters to their ASCII counterparts" do
       user = User.new
       user.name = "Kæsper Nørdskov _^25*/\!"
       user.generate_username
-      user.username.should == "kaespernordskov25"
+      expect(user.username).to eq "kaespernordskov25"
     end
 
     it "usernames radical should be 18 characters max" do
       user = User.new
       user.name = "Wow this is quite long as a name"
       user.generate_username
-      user.username.length.should equal(18)
+      expect(user.username.length).to eq 18
     end
   end
 
@@ -346,12 +346,12 @@ describe User do
       group.add_member!(user)
       other_user = FactoryGirl.create :user
       group.add_member!(other_user)
-      user.in_same_group_as?(other_user).should == true
+      expect(user.in_same_group_as?(other_user)).to be true
     end
     it "returns false if user and other_user do not share any groups" do
       group.add_member!(user)
       other_user = FactoryGirl.create :user
-      user.in_same_group_as?(other_user).should == false
+      expect(user.in_same_group_as?(other_user)).to be false
     end
   end
 

--- a/spec/services/discussion_service_spec.rb
+++ b/spec/services/discussion_service_spec.rb
@@ -63,8 +63,8 @@ describe 'DiscussionService' do
       end
 
       it 'returns the event created' do
-        DiscussionService.create(discussion: discussion,
-                                 actor: user).should == event
+        expect(DiscussionService.create(discussion: discussion,
+                                 actor: user)).to eq event
       end
     end
   end
@@ -108,9 +108,9 @@ describe 'DiscussionService' do
     context 'the discussion is invalid' do
       before { discussion.stub(:valid?).and_return(false) }
       it 'returns false' do
-        DiscussionService.update(discussion: discussion,
+        expect(DiscussionService.update(discussion: discussion,
                                  params: discussion_params,
-                                 actor: user).should == false
+                                 actor: user)).to be false
       end
     end
   end

--- a/spec/services/motion_service_spec.rb
+++ b/spec/services/motion_service_spec.rb
@@ -185,7 +185,7 @@ describe 'MotionService' do
       end
 
       it 'returns false' do
-        MotionService.create_outcome(motion: motion, params: {}, actor: user).should == false
+        expect(MotionService.create_outcome(motion: motion, params: {}, actor: user)).to be false
       end
 
       it 'does not create an event' do

--- a/spec/services/move_discussion_service_spec.rb
+++ b/spec/services/move_discussion_service_spec.rb
@@ -82,7 +82,7 @@ describe MoveDiscussionService do
     it "moves the discussion from source to destination" do
       discussion.should_receive(:save!)
       @mover.move!
-      discussion.group.should == destination_group
+      expect(discussion.group).to eq destination_group
     end
   end
 


### PR DESCRIPTION
I did a large regex find+replace on `.should ==` to update us to `expect(    ).to`

The motivation is so that people writing new specs have examples of good spec practice that they can confidently refer to. 

I hit specs + cuke steps,  lets see how the tests run

:poodle: 