### PR TITLE
Fix move discussion for #1647

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -154,8 +154,7 @@ class Ability
       end
     end
 
-    can [:destroy,
-         :move], Discussion do |discussion|
+    can [:destroy, :move], Discussion do |discussion|
       user_is_author_of?(discussion) or user_is_admin_of?(discussion.group_id)
     end
 

--- a/app/services/move_discussion_service.rb
+++ b/app/services/move_discussion_service.rb
@@ -10,17 +10,8 @@ class MoveDiscussionService
     @user = user
   end
 
-
-  def user_is_admin_of_source?
-    discussion.group.admins.include? user
-  end
-
-  def user_is_member_of_destination?
-    destination_group.members.include? user
-  end
-
   def valid?
-    user_is_admin_of_source? && user_is_member_of_destination?
+    user.ability.can?(:move, discussion) && destination_group.members.include?(user)
   end
 
   def move!

--- a/spec/controllers/discussions_controller_spec.rb
+++ b/spec/controllers/discussions_controller_spec.rb
@@ -51,9 +51,9 @@ describe DiscussionsController do
           d = FactoryGirl.create :discussion, private: false
           Group.stub(:find).with(g.key).and_return(g)
           Discussion.stub_chain(:published, :find_by_key!).with(d.key).and_return(d)
-          
-          d.group.stub(:admins).and_return([user])
-          g.stub(:members).and_return([user])
+
+          d.group.admins << user
+          g.members << user
 
           post :move, id: d.key, destination_group_id: g.key
 
@@ -69,8 +69,8 @@ describe DiscussionsController do
           Group.stub(:find).with(g.key).and_return(g)
           Discussion.stub_chain(:published, :find_by_key!).with(d.key).and_return(d)
           
-          d.group.stub(:admins).and_return([user])
-          g.stub(:members).and_return([user])
+          d.group.admins << user
+          g.members << user
 
           post :move, id: d.key, destination_group_id: g.key
 

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -359,6 +359,7 @@ describe "User abilities" do
     it { should_not be_able_to(:update_version, discussion) }
     it { should     be_able_to(:update_version, user_discussion) }
     it { should_not be_able_to(:move, discussion) }
+    it { should     be_able_to(:move, user_discussion) }
     it { should     be_able_to(:update, user_discussion) }
     it { should     be_able_to(:show, Discussion) }
     it { should     be_able_to(:unfollow, Discussion) }


### PR DESCRIPTION
This should fix the user being able to move discussions they're not able to.

Before, the UI would allow the author of a discussion to attempt to move a discussion, but it would fail on submit.

The logic (as I understand it should be): If a user is an admin of a group, they can move any discussion in that group to any other group they are a member of.