### PR TITLE
redirect to dashboard at controller level

### DIFF
--- a/app/controllers/marketing_controller.rb
+++ b/app/controllers/marketing_controller.rb
@@ -1,6 +1,8 @@
 class MarketingController < ApplicationController
   def index
-    if stale?(1) # bump this when we change the frontpage
+    if user_signed_in?
+      redirect_to dashboard_path
+    else
       render layout: false
     end
   end

--- a/app/views/marketing/index.html.haml
+++ b/app/views/marketing/index.html.haml
@@ -4,8 +4,6 @@
     %meta{content: "width=device-width, initial-scale=1", name: "viewport"}/
     %meta{content: "IE=Edge", "http-equiv" => "X-UA-Compatible"}/
     %title Loomio | #{t(:'frontpage.title.collaborative_decision_making')}
-    :javascript
-      if (document.cookie.indexOf("signed_in") >= 0) {window.location.replace("#{dashboard_path}");}
     <link href='//fonts.googleapis.com/css?family=Open+Sans:400,300,700,600' rel='stylesheet' type='text/css'>
     = stylesheet_link_tag  "marketing/index"
     = csrf_meta_tags


### PR DESCRIPTION
We currently do this with JS in the marketing index. It's not necessary to do that because we don't do app level caching now. Redirect based on cookies will prevent the "flash of marketing page before redirect" issue we've put up with for ages.