### PR TITLE
add transaction around membership check and creation

### DIFF
--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -373,10 +373,12 @@ class Group < ActiveRecord::Base
   end
 
   def find_or_create_membership(user, inviter)
-    membership = memberships.where(user_id: user.id).first
-    membership ||= Membership.create!(group: self,
-                                      user: user,
-                                      inviter: inviter)
+    Membership.transaction do
+      membership = memberships.where(user_id: user.id).first
+      membership ||= Membership.create!(group: self,
+                                        user: user,
+                                        inviter: inviter)
+    end
   end
 
   def user_membership_or_request_exists? user


### PR DESCRIPTION
We have a few places like this where the code is not threadsafe, but we run with threading enabled (indeed loomio.org would need a lot more resources if we did not)

The trick is, if there is a place where you are reading a value, then in another statement writing based on that result, the read and write need to be contained in a transaction so that the value does not get changed by another thread inbetween the read and the write.

In this case I think there is even a rails helper for find_or_create but I kinda remembered that being problematic when I wrote this ages ago, and this makes it super clear we are using a transaction.