### PR TITLE
Include links to feedback discussion in docs

### DIFF
--- a/app/assets/stylesheets/unstructured/_help.scss
+++ b/app/assets/stylesheets/unstructured/_help.scss
@@ -99,6 +99,8 @@
 
   .permissions-subhead { font-style: italic; }
 
+  .after-group-setup { margin-top: 40px; }
+
   .import-contacts-permission { float: right; }
 
   .deactivation {
@@ -108,7 +110,9 @@
     margin-left: 20px;
   }
 
-  #back-to-top { margin: 30px 0 0 0; }
+  #bottom-links { margin: 30px 0 0 0; }
+
+  .feedback-discussion-link { float: right; }
 }
 
 .help-container { padding: 0 40px; }

--- a/app/views/help/_comments.html.haml
+++ b/app/views/help/_comments.html.haml
@@ -31,6 +31,8 @@
       =image_tag "liked-comment.png", class: "screenshot"
   %h3.anchor#deleting-comments Deleting a comment
   %p Members can delete their own comments at any time by clicking the <strong>"X"</strong> in the right-hand corner of the comment. Group coordinators can delete any comments posted in discussions taking place in their group.
-  .row#back-to-top
-    .col-sm-12
-      %a{:href => "#contents"} ^ Back to top
+  .row#bottom-links
+    .col-sm-6
+      %a.back-to-top{:href => "#contents"} ^ Back to top
+    .col-sm-6
+      %a.feedback-discussion-link{:href => "https://www.loomio.org/d/Yl5D3EC0/new-help-documentation-we-want-your-feedback"} Think this explanation could be clearer? Give us your feedback >

--- a/app/views/help/_coordination.html.haml
+++ b/app/views/help/_coordination.html.haml
@@ -39,6 +39,8 @@
   %p People will be excited to jump in and start participating when there’s an engaging proposal on the table. A good proposal contains a plan of action for the group, so that it’s immediately obvious what it means to agree or disagree. Think about how you can identify discussions/decisions the group is currently undertaking in person or by email that would be easier if they were on Loomio. Alternatively, if your group wants to get accustomed to using the tool before using it to address real decisions, you could start a light-hearted decision to give everyone a chance to play with the tool and see the decision-making process in action.
   %h4 Encourage <a href="#mentioning">@mentioning</a>:
   %p Another simple way to encourage people to engage in a discussion is to use the @mention feature to prompt specific people; this will send them an email to tell them they’ve been mentioned in a comment.
-  .row#back-to-top
-    .col-sm-12
-      %a{:href => "#contents"} ^ Back to top
+  .row#bottom-links
+    .col-sm-6
+      %a.back-to-top{:href => "#contents"} ^ Back to top
+    .col-sm-6
+      %a.feedback-discussion-link{:href => "https://www.loomio.org/d/Yl5D3EC0/new-help-documentation-we-want-your-feedback"} Think this explanation could be clearer? Give us your feedback >

--- a/app/views/help/_dashboard.html.haml
+++ b/app/views/help/_dashboard.html.haml
@@ -2,6 +2,8 @@
   %h1 Your dashboard
   %p Your dashboard is your home page. It gives you an overview of what is happening in your groups. It is the page you see when you first log in to Loomio. Your dashboard displays content from your groups in a prioritised list. Open proposals are at the top, followed by all of the discussion threads from all of the groups you are a member of, sorted by most recent activity.
   =image_tag "dashboard-screenshot.png", class: "screenshot"
-  .row#back-to-top
-    .col-sm-12
-      %a{:href => "#contents"} ^ Back to top
+  .row#bottom-links
+    .col-sm-6
+      %a.back-to-top{:href => "#contents"} ^ Back to top
+    .col-sm-6
+      %a.feedback-discussion-link{:href => "https://www.loomio.org/d/Yl5D3EC0/new-help-documentation-we-want-your-feedback"} Think this explanation could be clearer? Give us your feedback >

--- a/app/views/help/_discussion_threads.html.haml
+++ b/app/views/help/_discussion_threads.html.haml
@@ -39,6 +39,8 @@
       =image_tag "move-discussion.png", class: "screenshot"
   %h3.anchor#deleting-discussions Deleting a discussion
   %p Only group coordinators can delete discussions. When a discussion is deleted it is removed and cannot be restored. If you are a group coordinator and you wish to delete a discussion, visit the discussion, click the cog icon and then <strong>“Delete discussion”</strong>.
-  .row#back-to-top
-    .col-sm-12
-      %a{:href => "#contents"} ^ Back to top
+  .row#bottom-links
+    .col-sm-6
+      %a.back-to-top{:href => "#contents"} ^ Back to top
+    .col-sm-6
+      %a.feedback-discussion-link{:href => "https://www.loomio.org/d/Yl5D3EC0/new-help-documentation-we-want-your-feedback"} Think this explanation could be clearer? Give us your feedback >

--- a/app/views/help/_faq.html.haml
+++ b/app/views/help/_faq.html.haml
@@ -18,6 +18,8 @@
       %p To find out what our developers are working on and what’s coming up in the development pipeline, take a look at our <a href="https://www.loomio.org/roadmap">public roadmap</a>. You can vote for the ideas you want to see prioritised, and comment with your feedback.
       %h3 What is the maximum number of members I can have in a group?
       %p Currently maximum group size is 1000 members. If you need to increase this for any reason, contact us - <a href=mailto:contact@loomio.org>contact@loomio.org</a>.
-  .row#back-to-top
-    .col-sm-12
-      %a{:href => "#contents"} ^ Back to top
+  .row#bottom-links
+    .col-sm-6
+      %a.back-to-top{:href => "#contents"} ^ Back to top
+    .col-sm-6
+      %a.feedback-discussion-link{:href => "https://www.loomio.org/d/Yl5D3EC0/new-help-documentation-we-want-your-feedback"} Have we missed something? Give us your feedback >

--- a/app/views/help/_getting_started.html.haml
+++ b/app/views/help/_getting_started.html.haml
@@ -4,7 +4,7 @@
   %h3.anchor#starting-new-group When you want to start a new Loomio group
   .row
     .col-sm-8
-      %p If you do not have a Loomio account you can start a new group from the Loomio front page by clicking the <strong>“Try out Loomio beta”</strong> button. You will be guided through the steps to start your own group.
+      %p If you do not have a Loomio account you can start a new group from the Loomio front page by clicking the <strong>“Try out Loomio beta”</strong> button. You will be guided through the steps to start your own group. As part of the group setup process, you will need to determine how you want your group to function by customising your group settings. Click <a href="#group-settings">here</a> to read more about group settings.
     .col-sm-4
       =image_tag "try-loomio-beta.png", class: "screenshot"
   %h3.anchor#invited-into-group When you are invited into a Loomio group
@@ -34,6 +34,8 @@
       %p You may also associate an existing Google, Facebook or Persona account with an existing Loomio account. Ensure you are logged out, visit the <a href="https://www.loomio.org/users/sign_in">Log in page</a> and select your preferred platform. Loomio will ask you if you want to create a new account with your existing account on your chosen platform, or link it to your existing Loomio account.
     .col-sm-5
       =image_tag "login-page.png", class: "screenshot"
-  .row#back-to-top
-    .col-sm-12
-      %a{:href => "#contents"} ^ Back to top
+  .row#bottom-links
+    .col-sm-6
+      %a.back-to-top{:href => "#contents"} ^ Back to top
+    .col-sm-6
+      %a.feedback-discussion-link{:href => "https://www.loomio.org/d/Yl5D3EC0/new-help-documentation-we-want-your-feedback"} Think this explanation could be clearer? Give us your feedback >

--- a/app/views/help/_group_settings.html.haml
+++ b/app/views/help/_group_settings.html.haml
@@ -65,6 +65,10 @@
   %p Do you want anyone in the group to be able to <a href="#starting-proposals">raise proposals</a> for the group to vote on?  When this box is selected then anyone in your group will be able to raise a proposal within a discussion. When this box is deselected only group coordinators will be able to raise proposals.
   %p.permissions-subhead Vote on proposals
   %p Do you want all members of the group to be able to <a href="#stating-positions">state their position on proposals</a>? Or would you prefer if some people could only observe?  When this box is selected then anyone in your group will be able to state their position on proposals. When it is deselected only group coordinators will be able to state their position on proposals.
-  .row#back-to-top
-    .col-sm-12
-      %a{:href => "#contents"} ^ Back to top
+  %h3.after-group-setup What next?
+  %p Upon submitting the group setup form you will be directed to your group page. From your group page you can invite people to join your group. Click <a href="#inviting-members">here</a> to read more about invitations.
+  .row#bottom-links
+    .col-sm-6
+      %a.back-to-top{:href => "#contents"} ^ Back to top
+    .col-sm-6
+      %a.feedback-discussion-link{:href => "https://www.loomio.org/d/Yl5D3EC0/new-help-documentation-we-want-your-feedback"} Think this explanation could be clearer? Give us your feedback >

--- a/app/views/help/_how_to.html.haml
+++ b/app/views/help/_how_to.html.haml
@@ -1,11 +1,11 @@
 %section#how-to
   %h1 How do I get started?
   %ul#get-started
-    %li <strong>Start a group</strong> to collaborate with people on Loomio
-    %li <strong>Invite people</strong> into your group
-    %li <strong>Start a discussion</strong> on any topic
-    %li <strong>Make a proposal</strong> to see how everyone feels about a particular course of action
-    %li <strong>Decide together:</strong> anyone can agree, abstain, disagree, or block – so you can see how everyone feels about the proposal.
+    %li <strong><a href="#starting-new-group">Start a group</a></strong> to collaborate with people on Loomio
+    %li <strong><a href="#inviting-members">Invite people</a></strong> into your group
+    %li <strong><a href="#starting-discussions">Start a discussion</a></strong> on any topic
+    %li <strong><a href="#starting-proposals">Make a proposal</a></strong> to see how everyone feels about a particular course of action
+    %li <strong><a href="#stating-positions">Decide together:</a></strong> anyone can agree, abstain, disagree, or block – so you can see how everyone feels about the proposal.
   %h2= t :"help.how_it_works"
   %p= t :"help.video_tutorial_description"
   <iframe width='356px' height='267px' src="//www.youtube.com/embed/eu6A1IQar0g" frameborder="0" allowfullscreen></iframe>

--- a/app/views/help/_inviting_members.html.haml
+++ b/app/views/help/_inviting_members.html.haml
@@ -21,6 +21,8 @@
     .col-sm-6
       =image_tag "import-contacts-link.png", class: "screenshot"
       =image_tag "import-contacts-permission.png", class: "screenshot"
-  .row#back-to-top
-    .col-sm-12
-      %a{:href => "#contents"} ^ Back to top
+  .row#bottom-links
+    .col-sm-6
+      %a.back-to-top{:href => "#contents"} ^ Back to top
+    .col-sm-6
+      %a.feedback-discussion-link{:href => "https://www.loomio.org/d/Yl5D3EC0/new-help-documentation-we-want-your-feedback"} Think this explanation could be clearer? Give us your feedback >

--- a/app/views/help/_keeping_up_to_date.html.haml
+++ b/app/views/help/_keeping_up_to_date.html.haml
@@ -32,6 +32,8 @@
       %p If you don’t want to be emailed each time a new comment appears in a discussion you are following then you can disable the email notifications by unchecking that option in your <strong><a href="#email-settings">“Email settings”</a></strong>.
     .col-sm-4
       =image_tag "filters.png", class: "screenshot"
-  .row#back-to-top
-    .col-sm-12
-      %a{:href => "#contents"} ^ Back to top
+  .row#bottom-links
+    .col-sm-6
+      %a.back-to-top{:href => "#contents"} ^ Back to top
+    .col-sm-6
+      %a.feedback-discussion-link{:href => "https://www.loomio.org/d/Yl5D3EC0/new-help-documentation-we-want-your-feedback"} Think this explanation could be clearer? Give us your feedback >

--- a/app/views/help/_leaving_group.html.haml
+++ b/app/views/help/_leaving_group.html.haml
@@ -5,6 +5,8 @@
       %p If you wish to leave your group then you must ensure that you are not the only group coordinator. If you are the sole coordinator of your group, you must either appoint another coordinator or deactivate the group. If you are not the sole coordinator of a group then you can leave the group by selecting the <strong>"Leave group"</strong> option from the <strong>"Options"</strong> menu on the group page.
     .col-sm-4
       =image_tag "leave-group.png", class: "screenshot"
-  .row#back-to-top
-    .col-sm-12
-      %a{:href => "#contents"} ^ Back to top
+  .row#bottom-links
+    .col-sm-6
+      %a.back-to-top{:href => "#contents"} ^ Back to top
+    .col-sm-6
+      %a.feedback-discussion-link{:href => "https://www.loomio.org/d/Yl5D3EC0/new-help-documentation-we-want-your-feedback"} Think this explanation could be clearer? Give us your feedback >

--- a/app/views/help/_proposals.html.haml
+++ b/app/views/help/_proposals.html.haml
@@ -65,6 +65,8 @@
       %p When a new proposal is started, any previous proposals will be reduced to a summary (showing proposal title, the decision pie and your position) in a <strong>“Previous decisions”</strong> panel beneath the <strong>“Current decision”</strong> panel.
     .col-sm-6
       =image_tag "previous-decisions.png", class: "screenshot"
-  .row#back-to-top
-    .col-sm-12
-      %a{:href => "#contents"} ^ Back to top
+  .row#bottom-links
+    .col-sm-6
+      %a.back-to-top{:href => "#contents"} ^ Back to top
+    .col-sm-6
+      %a.feedback-discussion-link{:href => "https://www.loomio.org/d/Yl5D3EC0/new-help-documentation-we-want-your-feedback"} Think this explanation could be clearer? Give us your feedback >

--- a/app/views/help/_subgroups.html.haml
+++ b/app/views/help/_subgroups.html.haml
@@ -13,6 +13,8 @@
       %p Sub-group settings are the same as <a href="#group-settings">group settings</a>, with one additional privacy option. The additional option (visible underneath <strong>“Who can find this group?”</strong> in the <strong>“Privacy”</strong> section of the new sub-group form) determines whether people in the parent group can see the sub-group. When the <strong>“People in [parent group]”</strong> option is selected then the group will be visible to members of the parent group, even if they are not members of the sub-group. When this option is deselected, only members of the sub-group will be able to find it.
     .col-sm-3
       =image_tag "edit-subgroup.png", class: "screenshot"
-  .row#back-to-top
-    .col-sm-12
-      %a{:href => "#contents"} ^ Back to top
+  .row#bottom-links
+    .col-sm-6
+      %a.back-to-top{:href => "#contents"} ^ Back to top
+    .col-sm-6
+      %a.feedback-discussion-link{:href => "https://www.loomio.org/d/Yl5D3EC0/new-help-documentation-we-want-your-feedback"} Think this explanation could be clearer? Give us your feedback >

--- a/app/views/help/_user_profile.html.haml
+++ b/app/views/help/_user_profile.html.haml
@@ -33,6 +33,8 @@
   %p If you are the only coordinator of one or more Loomio groups then you will need to either appoint another group coordinator or archive the group before you can deactivate your account.
   %h3.anchor#account-reactivation Reactivating your account
   %p Account reactivation can only be done by a member of the Loomio team. To reactivate your deactivated account, contact the Loomio team by sending an email to <a href="mailto:contact@loomio.org">contact@loomio.org</a>.
-  .row#back-to-top
-    .col-sm-12
-      %a{:href => "#contents"} ^ Back to top
+  .row#bottom-links
+    .col-sm-6
+      %a.back-to-top{:href => "#contents"} ^ Back to top
+    .col-sm-6
+      %a.feedback-discussion-link{:href => "https://www.loomio.org/d/Yl5D3EC0/new-help-documentation-we-want-your-feedback"} Think this explanation could be clearer? Give us your feedback >


### PR DESCRIPTION
+ Added links to the feedback discussion happening in the Loomio Community to the bottom of each section (see image below):

![screen shot 2015-02-21 at 12 45 17 pm](https://cloud.githubusercontent.com/assets/2882097/6311434/8a07e12a-b9c7-11e4-8069-eeb6ac038428.png)


+ Added additional information to create more of a cohesive flow between a couple of sections, e.g. "Group settings" leads into the section on invitations etc...