### PR TITLE
One item per thread in beta inbox

### DIFF
--- a/app/models/discussion_reader.rb
+++ b/app/models/discussion_reader.rb
@@ -56,6 +56,14 @@ class DiscussionReader < ActiveRecord::Base
     discussion.items_count - read_items_count
   end
 
+  def unread_activity_count
+    if last_read_at.blank?
+      discussion.salient_items_count + 1
+    else
+      discussion.salient_items_count - read_salient_items_count
+    end
+  end
+
   def has_read?(event)
     if last_read_at.present?
       self.last_read_at >= event.created_at

--- a/app/views/inbox/_discussion_line_item.html.haml
+++ b/app/views/inbox/_discussion_line_item.html.haml
@@ -4,13 +4,13 @@
       .col-xs-2.col-sm-1
         .icon.discussion-icon
           %span.activity-badge.unread-comments-count{title: t(:'tooltip.unread_comments')}
-            =@discussion_reader_cache.get_for(item).unread_comments_count
+            =@discussion_reader_cache.get_for(item).unread_activity_count
 
       .col-xs-8.col-sm-7.title
         = item.title
 
-      .col-xs-3.hidden-xs.time{title: 'Last comment at'}
-        = time_formatted_relative_to_age(item.last_comment_at || item.created_at)
+      .col-xs-3.hidden-xs.time{title: 'Last activity at'}
+        = time_formatted_relative_to_age(item.last_activity_at)
       -#.col-xs-1
         -#.unfollow-btn
           -#= link_to 'h', inbox_unfollow_path({class: item.class.to_s, id: item.id}), remote: true, method: :post, id: 'unfollow-btn'

--- a/app/views/inbox/_motion_line_item.html.haml
+++ b/app/views/inbox/_motion_line_item.html.haml
@@ -4,7 +4,8 @@
       .icon
         .activity-container
           %span.count.unread-votes-count{title: t(:'tooltip.new_votes')}
-            - count = @motion_reader_cache.get_for(item).unread_activity_count
+            - count = DiscussionReader.for(discussion: item.discussion, user: current_user).unread_activity_count
+            -#- count = @motion_reader_cache.get_for(item).unread_activity_count
             - if count != 0
               =count
         .motion-sparkline


### PR DESCRIPTION
Only show a discussion if there is no active motion also being shown...

Also.. always show the same value on each line item. In this case, the unread activity count.