### PR TITLE
fix the added_to_group email readability sense

### DIFF
--- a/app/views/user_mailer/added_to_group.html.haml
+++ b/app/views/user_mailer/added_to_group.html.haml
@@ -4,5 +4,5 @@
     = stylesheet_link_tag 'email'
   %body
     %p= t("email.user_added_to_a_group.content", which_group: @group.full_name, who: @inviter.name)
-    %p= @message
     %p= link_to group_url(@group), group_url(@group, @utm_hash)
+    %p= @message

--- a/app/views/user_mailer/added_to_group.text.haml
+++ b/app/views/user_mailer/added_to_group.text.haml
@@ -1,5 +1,5 @@
 = t("email.user_added_to_a_group.content", which_group: @group.full_name, who: @inviter.name)
 \
-= @message
-\
 = link_to group_url(@group), group_url(@group, @utm_hash)
+\
+= @message


### PR DESCRIPTION
a translator pointed out an email that didn't make sense : 

This translation:

```ruby
      content: "%{who} has added you to %{which_group} on Loomio. Click here to go to the group:"
```

was not followed by a link in the email. I've just changed the order of the email so it reads correctly