### PR TITLE
use FORCE_SSL to determine http(s) email links

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -53,7 +53,8 @@ module Loomio
     config.assets.version = '1.4'
 
     config.action_mailer.default_url_options = {
-      host: ENV['CANONICAL_HOST']
+      host:     ENV['CANONICAL_HOST'],
+      protocol: ENV['FORCE_SSL'] ? 'https' : 'http'
     }
 
     config.roadie.url_options = nil

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -33,7 +33,6 @@ Loomio::Application.configure do
   config.action_mailer.raise_delivery_errors = true
   config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
   config.action_mailer.delivery_method = :smtp
-  config.action_mailer.delivery_method = :smtp
 
   config.action_mailer.smtp_settings = { :address => "localhost", :port => 1025 }
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -21,8 +21,9 @@ Loomio::Application.configure do
 
   config.action_mailer.delivery_method = :test
   config.action_mailer.default_url_options = {
-    :host           => 'localhost',
-    :port           => 3000
+    host:    'localhost',
+    port:     3000,
+    protocol: ENV['FORCE_SSL'] ? 'https' : 'http'
   }
 
   # Use SQL instead of Active Record's schema dumper when creating the test database.

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -31,6 +31,17 @@ describe UserMailer do
     it 'assigns confirmation_url for email body' do
       @mail.body.encoded.should match("http://localhost:3000/g/#{@group.key}")
     end
+
+    it 'uses http links by default' do
+      expect(@mail.body.encoded).to match(/http:/)
+    end
+
+    it 'uses https links if action_mailer protocol is set to https' do
+      Loomio::Application.config.action_mailer.default_url_options[:protocol] = 'https'
+
+      @mail = UserMailer.group_membership_approved(@user, @group)
+      expect(@mail.body.encoded).to match(/https:/)
+    end
   end
 
   context 'sending email on being added to group' do


### PR DESCRIPTION
adds config for using https links in emails 

