### PR TITLE
provide minimum translation of markdown help

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -207,4 +207,12 @@ module ApplicationHelper
   def hide_beta_logo?
     current_user_or_visitor.belongs_to_manual_subscription_group?
   end
+
+  def markdown_help_url
+    if current_locale.to_s == 'en'
+      'https://help.github.com/articles/markdown-basics'
+    else
+      'http://translate.google.co.nz/translate?hl=' + current_locale.to_s + '&u=https://help.github.com/articles/markdown-basics/&prev=search'
+    end
+  end
 end

--- a/app/views/comments/edit.html.haml
+++ b/app/views/comments/edit.html.haml
@@ -9,4 +9,4 @@
           = check_box_tag 'comment[uses_markdown]', 1, @comment.uses_markdown
           = label_tag :uses_markdown, 'Markdown'
           = surround '(', ')' do
-            = link_to t(:'help.help'), "https://help.github.com/articles/markdown-basics/", title: t(:'common.markdown_help_tooltip'), class: 'js-tooltip-left', target: '_blank'
+            = link_to t(:'help.help'), markdown_help_url, title: t(:'common.markdown_help_tooltip'), class: 'js-tooltip-left', target: '_blank'

--- a/app/views/discussions/_add_comment.html.haml
+++ b/app/views/discussions/_add_comment.html.haml
@@ -16,7 +16,7 @@
             = check_box_tag 'uses_markdown', 1, current_user.uses_markdown
             = label_tag :uses_markdown, 'Markdown'
             = surround '(', ')' do
-              = link_to t(:'help.help'), "https://help.github.com/articles/markdown-basics/", title: t(:'common.markdown_help_tooltip'), class: 'js-tooltip-left', target: '_blank'
+              = link_to t(:'help.help'), markdown_help_url, title: t(:'common.markdown_help_tooltip'), class: 'js-tooltip-left', target: '_blank'
 
   - if user_signed_in?
     -unless browser.ie? && browser.version.to_i < 10

--- a/app/views/discussions/_form.html.haml
+++ b/app/views/discussions/_form.html.haml
@@ -17,7 +17,7 @@
         = f.check_box :uses_markdown
         = f.label :uses_markdown, 'Markdown'
         = surround '(', ')' do
-          = link_to t(:'help.help'), "https://help.github.com/articles/markdown-basics/", title: t(:'common.markdown_help_tooltip'), class: 'js-tooltip-left', target: '_blank'
+          = link_to t(:'help.help'), markdown_help_url, title: t(:'common.markdown_help_tooltip'), class: 'js-tooltip-left', target: '_blank'
 
       - if discussion.group.present? and discussion.group.beta_feature_enabled?('discussion_iframe') and can?(:update, discussion.group)
         =f.input :iframe_src


### PR DESCRIPTION
check out this!

**the problem**: we're linking all users to an english-only markdown help doc

**the solution**: uses google page translate url instead of just serving the plain url  

