### PR TITLE
restore Intercom default messenger

### DIFF
--- a/app/assets/javascripts/main.js.coffee
+++ b/app/assets/javascripts/main.js.coffee
@@ -1,9 +1,4 @@
 window.Application ||= {}
-$ ->
-  $('.intercom-proxy').on 'click', (e) ->
-    e.preventDefault()
-    $('#Intercom').trigger('click')
-
 # keyboard shortcuts
 $ ->
 

--- a/app/views/application/_header.html.haml
+++ b/app/views/application/_header.html.haml
@@ -3,7 +3,6 @@
   .container
     .navbar-header
       - if user_signed_in?
-        #Intercom
         %button.navbar-toggle{type: 'button', data: {toggle: 'collapse', target: '#navbar-collapse'}}
           %span.sr-only= t :"sr.toggle_navigation"
           %span.icon-bar

--- a/app/views/application/_user_profile_options.html.haml
+++ b/app/views/application/_user_profile_options.html.haml
@@ -11,11 +11,6 @@
     %i.fa.fa-star
     = t :"help.help"
 
-- if ENV["INTERCOM_APP_ID"].present?
-  %li
-    %a.intercom-proxy{href: "mailto:#{ENV["INTERCOM_APP_ID"]}@incoming.intercom.io"}
-      %i.fa.fa-question-circle
-      = t :"contact_page.contact_us"
 %li
   %a{href: destroy_user_session_path, 'data-method' => 'delete'}
     %i.fa.fa-sign-out

--- a/config/initializers/intercom.rb
+++ b/config/initializers/intercom.rb
@@ -107,7 +107,7 @@ if Rails.application.secrets.intercom_app_id
     #   * :custom attaches the inbox open event to an anchor with an
     #             id of #Intercom.
     #
-    # config.inbox.style = :default 
-    config.inbox.style = :custom
+    config.inbox.style = :default
+    # config.inbox.style = :custom
   end
 end


### PR DESCRIPTION
I've put the default Intercom messenger back in because it makes it easier for people to get hold of us. Sorry for the hassle before, there was something wrong with my brain.