### PR TITLE
Angular hide proposals

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -265,6 +265,8 @@ en:
     my_groups: Groups
 
   discussion:
+    proposals: 'Proposals'
+    previous_proposals: 'Previous Proposals'
     load_previous: 'Load previous thread items'
     you_like_this: 'You like this.'
     liked_by_you_and_someone: 'You and {{name}} like this.'

--- a/lineman/app/modules/discussion_page/discussion_page.haml
+++ b/lineman/app/modules/discussion_page/discussion_page.haml
@@ -35,7 +35,7 @@
 
           .thread-discussion-description{btf-markdown: 'discussion.description' }
 
-        %proposals_card{discussion: 'discussion'}
+        %proposals_card{discussion: 'discussion', ng-show: 'discussion.proposals().length > 0'}
         %thread_card{discussion: 'discussion'}
         %comment_form{discussion: 'discussion'}
 

--- a/lineman/app/modules/discussion_page/proposals_card/proposals_card.haml
+++ b/lineman/app/modules/discussion_page/proposals_card/proposals_card.haml
@@ -1,10 +1,9 @@
 .thread-proposals
-  %h3.first Proposal
-
+  %h3.first{translate: 'discussion.proposals'}
   %div{ng_repeat: 'proposal in discussion.proposals()'}
     .active-proposal{ng-if: 'isExpanded(proposal)'}
       %proposal_expanded{proposal: 'proposal'}
-      %h3{ng-show: "discussion.proposals().length > 1"} Previous proposals
+      %h3{translate: 'discussion.previous_proposals', ng-show: "discussion.proposals().length > 1"}
 
     .inactive-proposal{ng-if: '!isExpanded(proposal)', ng_click: 'selectProposal(proposal)'}
       %proposal_collapsed{proposal: 'proposal'}


### PR DESCRIPTION
Don't show a lonely 'proposals' label when no proposal exists on a discussion. Also translates that card correctly.