### PR TITLE
Fix dropdowns

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -55,6 +55,11 @@ en:
     in_reply_to: "In reply to <strong>{{name}}</strong>:"
 
   navbar:
+    user_options:
+      contact_us: 'Contact us'
+      new_thread: 'New Thread'
+      profile: 'Profile'
+      help: 'Help'
     search:
       placeholder: 'Search for groups or threads'
       loading: 'Loading results...'

--- a/lineman/app/components/navbar/navbar_controller.coffee
+++ b/lineman/app/components/navbar/navbar_controller.coffee
@@ -1,10 +1,9 @@
 angular.module('loomioApp').controller 'NavbarController', ($scope, $modal, Records, UserAuthService, DiscussionFormService) ->
-  $scope.showInbox = false
 
   $scope.openDiscussionForm = ->
     DiscussionFormService.openNewDiscussionModal()
 
-  $scope.toggleInbox = (open) -> $scope.showInbox = open
-
   $scope.currentUser = ->
     window.Loomio.currentUser
+
+  return

--- a/lineman/app/components/navbar/navbar_notifications.haml
+++ b/lineman/app/components/navbar/navbar_notifications.haml
@@ -1,7 +1,7 @@
 .lmo-navbar-item{dropdown: ''}
   %a.lmo-navbar-btn.lmo-navbar-btn__icon.dropdown-toggle{href: '#'}
     %i.fa.fa-lg.fa-fw.fa-bell
-  .lmo-navbar-dropdown.dropdown-menu.notifications-dropdown{role: 'menu'}
+  .lmo-navbar-dropdown.dropdown-menu.dropdown-menu-right.notifications-dropdown{role: 'menu'}
     .navbar-notifications
       %ul.selector-list
         %li.selector-list-header

--- a/lineman/app/components/navbar/navbar_notifications_controller.coffee
+++ b/lineman/app/components/navbar/navbar_notifications_controller.coffee
@@ -26,3 +26,4 @@ angular.module('loomioApp').controller 'NavbarNotificationsController', ($scope,
     'motion_outcome_updated',
   ]
 
+  return

--- a/lineman/app/components/navbar/navbar_user_options.haml
+++ b/lineman/app/components/navbar/navbar_user_options.haml
@@ -1,7 +1,7 @@
 %li.lmo-navbar-item{dropdown: ''}
   %a.dropdown-toggle.lmo-navbar-btn.lmo-navbar-btn__icon{href: '#'}
     %i.fa.fa-lg.fa-fw.fa-navicon
-  .lmo-navbar-dropdown.dropdown-menu.user-options-dropdown
+  .lmo-navbar-dropdown.dropdown-menu.dropdown-menu-right.user-options-dropdown
     %ul.selector-list
       %li.media.selector-list-item.visible-xs
         %a{href: '#', ng_click: 'openDiscussionForm()'}

--- a/lineman/app/components/navbar/navbar_user_options.haml
+++ b/lineman/app/components/navbar/navbar_user_options.haml
@@ -7,22 +7,19 @@
         %a{href: '#', ng_click: 'openDiscussionForm()'}
           .media-left
             %i.fa.fa-xlg.fa-plus
-          .media-body New thread
+          .media-body{translate: 'navbar.user_options.new_thread'}
       %li.selector-list-item
         %a{href: '/profile'}
           .media-left
             %user_avatar{user: "currentUser()"}
-          .media-body
-            Profile
+          .media-body{translate: 'navbar.user_options.profile'}
       %li.selector-list-item
         %a{href: '/help'}
           .media-left
             %i.fa.fa-xlg.fa-info
-          .media-body
-            Help
+          .media-body{translate: 'navbar.user_options.help'}
       %li.selector-list-item
         %a{href: '/contact'}
           .media-left
             %i.fa.fa-xlg.fa-question-circle
-          .media-body
-            Contact us
+          .media-body{translate: 'navbar.user_options.contact_us'}


### PR DESCRIPTION
Fixes angular dropdown menus on navbar

Main issue was that the new angular router requires controllers to return a value, otherwise b0rktown when trying to load controllers (since coffeescript returns the last value)
Secondary issue was missing 'dropdown-menu-right' css class