### PR TITLE
Dashboard mark as read

### DIFF
--- a/app/controllers/api/discussion_readers_controller.rb
+++ b/app/controllers/api/discussion_readers_controller.rb
@@ -5,4 +5,16 @@ class API::DiscussionReadersController < API::RestfulController
     self.resource = DiscussionReader.for(user: current_user, discussion: @discussion)
   end
 
+  def mark_as_read
+    load_resource
+    resource.viewed! (discussion_event || @discussion).created_at
+    respond_with_resource
+  end
+
+  private
+
+  def discussion_event
+    Event.where(discussion_id: @discussion.id, sequence_id: params[:sequence_id]).first
+  end
+
 end

--- a/app/controllers/api/discussions_controller.rb
+++ b/app/controllers/api/discussions_controller.rb
@@ -27,12 +27,6 @@ class API::DiscussionsController < API::RestfulController
     respond_with_discussion
   end
 
-  def mark_as_read
-    event = Event.where(discussion_id: @discussion.id, sequence_id: params[:sequence_id]).first
-    discussion_reader.viewed! (event || @discussion).created_at
-    respond_with_discussion
-  end
-
   private
 
   def respond_with_discussion
@@ -73,6 +67,7 @@ class API::DiscussionsController < API::RestfulController
 
   def inbox_threads
     GroupDiscussionsViewer.for(user: current_user, group: @group, filter: params[:filter])
+                          .not_muted
                           .where('last_activity_at > ?', params[:from_date] || 3.months.ago)
                           .joined_to_current_motion
                           .preload(:current_motion, {group: :parent})

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -1,0 +1,2 @@
+class API::UsersController < API::RestfulController
+end

--- a/app/controllers/api/votes_controller.rb
+++ b/app/controllers/api/votes_controller.rb
@@ -1,8 +1,12 @@
 class API::VotesController < API::RestfulController
 
   def my_votes
-    load_and_authorize_discussion
-    @votes = @discussion.votes.most_recent.for_user(current_user)
+    @votes = if params[:discussion_id]
+      load_and_authorize_discussion
+      @discussion.votes.for_user(current_user).most_recent
+    else
+      current_user.votes.most_recent.since(3.months.ago).most_recent
+    end
     respond_with_collection
   end
 

--- a/app/extras/group_discussions_viewer.rb
+++ b/app/extras/group_discussions_viewer.rb
@@ -2,7 +2,7 @@ class GroupDiscussionsViewer
   def self.for(group: nil, user: nil, filter: nil)
     groups = groups_displayed(group: group, user: user)
     Queries::VisibleDiscussions.new(groups: groups, user: user).tap do |discussions|
-      discussions = discussions.unread if filter == 'unread'
+      discussions = discussions.unread if filter == 'show_unread'
     end
   end
 

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -129,6 +129,10 @@ class Ability
       not user_to_deactivate.adminable_groups.published.any? { |g| g.admins.count == 1 }
     end
 
+    can :update, User do |user|
+      @user == user
+    end
+
     can :create, MembershipRequest do |request|
       group = request.group
       can?(:show, group) and group.membership_granted_upon_approval?

--- a/app/models/permitted_params.rb
+++ b/app/models/permitted_params.rb
@@ -20,7 +20,7 @@ class PermittedParams < Struct.new(:params, :user)
     [:name, :avatar_kind, :email, :password, :password_confirmation,
      :remember_me, :uploaded_avatar, :username, :uses_markdown,
      :time_zone, :selected_locale, :email_when_mentioned,
-     :email_missed_yesterday,
+     :email_missed_yesterday, :dashboard_sort, :dashboard_filter,
      :email_when_proposal_closing_soon, :email_new_discussions_and_proposals, :email_on_participation,
      {email_new_discussions_and_proposals_group_ids: []}]
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,9 @@ class User < ActiveRecord::Base
   require 'net/http'
   require 'digest/md5'
 
+  validates_inclusion_of :dashboard_sort,   in: %w[sort_by_group sort_by_date]
+  validates_inclusion_of :dashboard_filter, in: %w[show_all show_unread]
+
   AVATAR_KINDS = %w[initials uploaded gravatar]
   LARGE_IMAGE = 170
   MED_LARGE_IMAGE = 70

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,5 +1,13 @@
 class UserSerializer < ActiveModel::Serializer
   attributes :id, :name, :username, :avatar_initials, :avatar_kind, :avatar_url, :profile_url, :gravatar_md5
+  attributes :dashboard_sort, :dashboard_filter
+
+  def is_current_user?
+    object == current_user
+  end
+
+  alias :include_dashboard_sort :is_current_user?
+  alias :include_dashboard_filter :is_current_user?
 
   def gravatar_md5
     Digest::MD5.hexdigest(object.email.to_s.downcase) if object.avatar_kind == "gravatar"

--- a/app/services/discussion_reader_cache.rb
+++ b/app/services/discussion_reader_cache.rb
@@ -1,33 +1,20 @@
 class DiscussionReaderCache
-  attr_accessor :user
-  attr_accessor :readers
+  attr_accessor :user, :cache
 
   def initialize(user: nil, discussions: [])
-    @user = user
-    @readers_by_discussion_id = {}
+    return unless user && discussions
 
-    if user
-      @readers = DiscussionReader.where(user_id: user.id,
-                                        discussion_id: discussions.map(&:id)).includes(:discussion)
-    else
-      @readers = []
-    end
-
-    @readers.each do |reader|
-      @readers_by_discussion_id[reader.discussion_id] = reader
+    @user, @cache = user, {}
+    DiscussionReader.includes(:discussion)
+                    .where(user_id: user.id,
+                           discussion_id: discussions.map(&:id))
+                    .each do |reader|
+      cache[reader.discussion_id] = reader
     end
   end
 
   def get_for(discussion)
-    @readers_by_discussion_id.fetch(discussion.id) { new_reader_for(discussion) }
+    cache.fetch discussion.id, DiscussionReader.for(discussion: discussion, user: user)
   end
 
-  private
-
-  def new_reader_for(discussion)
-    DiscussionReader.new do |dr|
-      dr.discussion = discussion
-      dr.user = user
-    end
-  end
 end

--- a/app/services/user_service.rb
+++ b/app/services/user_service.rb
@@ -1,0 +1,7 @@
+class UserService
+  def self.update(user:, actor:, params:)
+    actor.ability.authorize! :update, user
+    user.update! params
+    user
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -47,9 +47,10 @@ Loomio::Application.routes.draw do
       get :inbox_by_date, on: :collection
       get :inbox_by_organization, on: :collection
       get :inbox_by_group, on: :collection
+    end
+    resources :discussion_readers, only: :update do
       patch :mark_as_read, on: :member
     end
-    resources :discussion_readers, only: :update
 
     resources :motions,     only: [:show, :index, :create, :update], path: :proposals do
       post :close, on: :member
@@ -68,6 +69,7 @@ Loomio::Application.routes.draw do
     resources :translations, only: :show
     resources :notifications, only: :index
     resources :search_results, only: :index
+
     resources :contact_messages, only: :create
     namespace :faye do
       post :subscribe
@@ -77,6 +79,7 @@ Loomio::Application.routes.draw do
       get :current
       get :unauthorized
     end
+    resources :users, only: :update
     devise_scope :user do
       resources :sessions, only: [:create, :destroy]
     end

--- a/db/migrate/20150324073159_add_dashboard_prefs.rb
+++ b/db/migrate/20150324073159_add_dashboard_prefs.rb
@@ -1,0 +1,6 @@
+class AddDashboardPrefs < ActiveRecord::Migration
+  def change
+    add_column :users, :dashboard_sort, :string, default: 'sort_by_group', null: false
+    add_column :users, :dashboard_filter, :string, default: 'show_all', null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150315210731) do
+ActiveRecord::Schema.define(version: 20150324073159) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -606,9 +606,11 @@ ActiveRecord::Schema.define(version: 20150315210731) do
     t.string   "detected_locale",                  limit: 255
     t.boolean  "email_missed_yesterday",                       default: true,       null: false
     t.string   "email_api_key",                    limit: 255
-    t.boolean  "email_when_mentioned",                         default: true,       null: false
-    t.boolean  "angular_ui_enabled",                           default: false,      null: false
-    t.boolean  "email_on_participation",                       default: true,       null: false
+    t.boolean  "email_when_mentioned",                         default: true,            null: false
+    t.boolean  "angular_ui_enabled",                           default: false,           null: false
+    t.boolean  "email_on_participation",                       default: true,            null: false
+    t.string   "dashboard_sort",                               default: "sort_by_group", null: false
+    t.string   "dashboard_filter",                             default: "show_all",      null: false
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree

--- a/lineman/app/app.coffee
+++ b/lineman/app/app.coffee
@@ -25,7 +25,7 @@ angular.module('loomioApp', ['ngNewRouter',
     snakeName = _.snakeCase(name);
     'generated/components/' + snakeName + '/' + snakeName + '.html';
 
-angular.module('loomioApp').run (Records, UserAuthService) ->
+angular.module('loomioApp').run (Records) ->
   if window? and window.Loomio?
     Records.import(window.Loomio.seedRecords)
     window.Loomio.currentUser = Records.users.find(window.Loomio.currentUserId)

--- a/lineman/app/components/dashboard_page/dashboard_page.haml
+++ b/lineman/app/components/dashboard_page/dashboard_page.haml
@@ -4,67 +4,65 @@
       .col-xs-6
         .dashboard-page-dropdown.dashboard-page-filter-dropdown{dropdown: '', on-toggle: 'dashboardPage.toggled(open)'}
           %a.dashboard-page-dropdown-toggle.dropdown-toggle{href: '#'}
-            %span{translate: "dashboard_page.filtering.all", ng-show: 'dashboardPage.filter == "all"'}>
-            %span{translate: "dashboard_page.filtering.unread", ng-show: 'dashboardPage.filter == "unread"'}>
+            %span{translate: "dashboard_page.filtering.all", ng-show: 'dashboardPage.filter() == "show_all"'}>
+            %span{translate: "dashboard_page.filtering.unread", ng-show: 'dashboardPage.filter() == "show_unread"'}>
             %i.fa.fa-chevron-down
           .dropdown-menu.dropdown-menu-with-labels.dropdown-menu-right{role: 'menu'}
             %ul.dropdown-menu-items.filtering-options
-              %li.dropdown-menu-item.filtering-option{ng-click: 'dashboardPage.setOptions({filter: "all"})'}
+              %li.dropdown-menu-item.filtering-option{ng-click: 'dashboardPage.changePreferences({dashboard_filter: "show_all"})'}
                 .dropdown-menu-item-label{translate: 'dashboard_page.filtering.all'}
                 .dashboard-description{translate: 'dashboard_page.filtering.all_description'}
-              %li.dropdown-menu-item.filtering-option{ng-click: 'dashboardPage.setOptions({filter: "unread"})'}
+              %li.dropdown-menu-item.filtering-option{ng-click: 'dashboardPage.changePreferences({dashboard_filter: "show_unread"})'}
                 .dropdown-menu-item-label{translate: 'dashboard_page.filtering.unread'}
                 .dashboard-description{translate: 'dashboard_page.filtering.unread_description'}
       .col-xs-6
         .dashboard-page-sort-dropdown.dashboard-page-dropdown.pull-right{dropdown: '', on-toggle: 'dashboardPage.toggled(open)'}
           %a.dashboard-page-dropdown-toggle.dropdown-toggle{href: '#'}
-            %span{translate: "dashboard_page.sorting.group", ng-show: 'dashboardPage.sort == "group"'}>
-            %span{translate: "dashboard_page.sorting.date", ng-show: 'dashboardPage.sort == "date"'}>
+            %span{translate: "dashboard_page.sorting.group", ng-show: 'dashboardPage.sort() == "sort_by_group"'}>
+            %span{translate: "dashboard_page.sorting.date", ng-show: 'dashboardPage.sort() == "sort_by_date"'}>
             %i.fa.fa-chevron-down
           .dropdown-menu.dropdown-menu-with-labels.dropdown-menu-right{role: 'menu'}
             %ul.dropdown-menu-items.sorting-options
-              %li.dropdown-menu-item.sorting-option{ng-click: 'dashboardPage.setOptions({sort: "group"})'}
+              %li.dropdown-menu-item.sorting-option{ng-click: 'dashboardPage.changePreferences({dashboard_sort: "sort_by_group"})'}
                 .dropdown-menu-item-label{translate: 'dashboard_page.sorting.group'}
                 .dashboard-description{translate: 'dashboard_page.sorting.group_description'}
-              %li.dropdown-menu-item.sorting-option{ng-click: 'dashboardPage.setOptions({sort: "date"})'}
+              %li.dropdown-menu-item.sorting-option{ng-click: 'dashboardPage.changePreferences({dashboard_sort: "sort_by_date"})'}
                 .dropdown-menu-item-label{translate: 'dashboard_page.sorting.date'}
                 .dashboard-description{translate: 'dashboard_page.sorting.date_description'}
     .row
       .col-xs-12
         .dashboard-page-panel
-          .dashboard-page-sort-group{ng-if: 'dashboardPage.sort == "date"'}
+          .dashboard-page-sort-group{ng-if: 'dashboardPage.sort() == "sort_by_date"'}
             .dashboard-page-threads-container{ng-if: 'dashboardPage.anyToday()'}
               .dashboard-page-date-range{translate: 'common.date_range.today'}
               .dashboard-page-threads
-                %dashboard_page_thread{discussion: 'discussion', ng-repeat: 'discussion in dashboardPage.dashboardDiscussions() | orderBy:dashboardPage.lastInboxActivity | filter:dashboardPage.unread | limitByFn:dashboardPage.loadedCount | filter:dashboardPage.today'}
+                %dashboard_page_thread{discussion: 'discussion', ng-repeat: 'discussion in dashboardPage.dashboardDiscussions() | filter:dashboardPage.today'}
             .dashboard-page-threads-container{ng-if: 'dashboardPage.anyYesterday()'}
               .dashboard-page-date-range{translate: 'common.date_range.yesterday'}
               .dashboard-page-threads
-                %dashboard_page_thread{discussion: 'discussion', ng-repeat: 'discussion in dashboardPage.dashboardDiscussions() | orderBy:dashboardPage.lastInboxActivity | filter:dashboardPage.unread | limitByFn:dashboardPage.loadedCount | filter:dashboardPage.yesterday'}
+                %dashboard_page_thread{discussion: 'discussion', ng-repeat: 'discussion in dashboardPage.dashboardDiscussions() | filter:dashboardPage.yesterday'}
             .dashboard-page-threads-container{ng-if: 'dashboardPage.anyThisWeek()'}
               .dashboard-page-date-range{translate: 'common.date_range.this_week'}
               .dashboard-page-threads
-                %dashboard_page_thread{discussion: 'discussion', ng-repeat: 'discussion in dashboardPage.dashboardDiscussions() | orderBy:dashboardPage.lastInboxActivity | filter:dashboardPage.unread | limitByFn:dashboardPage.loadedCount | filter:dashboardPage.thisWeek'}
+                %dashboard_page_thread{discussion: 'discussion', ng-repeat: 'discussion in dashboardPage.dashboardDiscussions() | filter:dashboardPage.thisWeek'}
             .dashboard-page-threads-container{ng-if: 'dashboardPage.anyThisMonth()'}
               .dashboard-page-date-range{translate: 'common.date_range.this_month'}
               .dashboard-page-threads
-                %dashboard_page_thread{discussion: 'discussion', ng-repeat: 'discussion in dashboardPage.dashboardDiscussions() | orderBy:dashboardPage.lastInboxActivity | filter:dashboardPage.unread | limitByFn:dashboardPage.loadedCount | filter:dashboardPage.thisMonth'}
+                %dashboard_page_thread{discussion: 'discussion', ng-repeat: 'discussion in dashboardPage.dashboardDiscussions() | filter:dashboardPage.thisMonth'}
             .dashboard-page-threads-container{ng-if: 'anyOlder()'}
               .dashboard-page-date-range{translate: 'common.date_range.older'}
               .dashboard-page-threads
-                %dashboard_page_thread{discussion: 'discussion', ng-repeat: 'discussion in dashboardPage.dashboardDiscussions() | orderBy:dashboardPage.lastInboxActivity | filter:dashboardPage.unread | limitByFn:dashboardPage.loadedCount | filter:dashboardPage.older'}
-            .dashboard-page-footer{in-view: '$inview && dashboardPage.footerReached(event)', in-view-options: '{debounce: 200}'} .
-            .dashboard-page-loading.page-loading{ng-show: 'dashboardPage.loadingDiscussions'}
+                %dashboard_page_thread{discussion: 'discussion', ng-repeat: 'discussion in dashboardPage.dashboardDiscussions() | filter:dashboardPage.older'}
+            .dashboard-page-footer{in-view: '$inview && dashboardPage.loadMore()', in-view-options: '{debounce: 200}'} .
+            .dashboard-page-loading.page-loading{ng-show: 'dashboardPage.loading'}
               %i.fa.fa-lg.fa-spin.fa-circle-o-notch
-          .dashboard-page-sort-date{ng-if: 'dashboardPage.sort == "group"'}
-            .dashboard-page-group{ng-repeat: 'group in dashboardPage.dashboardGroups() | orderBy:groupName'}
+          .dashboard-page-sort-date{ng-if: 'dashboardPage.sort() == "sort_by_group"'}
+            .dashboard-page-group{ng-repeat: 'group in dashboardPage.dashboardGroups() | orderBy:dashboardPage.groupName'}
               .dashboard-page-threads-container{ng-if: 'dashboardPage.anyThisGroup(group)'}
                 %img.selector-list-item-group-logo.pull-left{src: "{{group.logoUrl()}}"}>
                 %h2.dashboard-page-group-name
                   %a{href: '/g/{{group.key}}'} {{group.name}}
                 .dashboard-page-threads
-                  %dashboard_page_thread{discussion: 'discussion', hide-group-logo: true, ng-repeat: 'discussion in group.organizationDiscussions() | orderBy:dashboardPage.lastInboxActivity | limitByFn:dashboardPage.loadedCount:group.id | filter:dashboardPage.unread'}
-                  .dashboard-page-show-more
-                    %a{ng-hide: 'dashboardPage.loadingDiscussions{{group.id}} || dashboardPage.groupIsExpanded(group.id)', translate: 'dashboard_page.load_more', ng-click:'dashboardPage.loadMoreFromGroup(group)', href: '#'}
-                .dashboard-page-loading.page-loading{ng-show: 'dashboardPage.loadingDiscussions{{group.id}}'}
-                  %i.fa.fa-lg.fa-spin.fa-circle-o-notch
+                  %dashboard_page_thread{discussion: 'discussion', hide-group-logo: true, ng-repeat: 'discussion in dashboardPage.dashboardDiscussions(group)'}
+                  .dashboard-page-show-more{ng-show: 'dashboardPage.canExpand(group)'}
+                    %a{translate: 'dashboard_page.load_more', ng-click:'group.dashboardStatus = "expanded"', href: '#'}

--- a/lineman/app/components/dashboard_page/dashboard_page.scss
+++ b/lineman/app/components/dashboard_page/dashboard_page.scss
@@ -38,6 +38,8 @@
 .dashboard-page-thread {
   padding: 13px 13px;
   border-bottom: 1px solid $border-color;
+  position: relative;
+  &:hover { background-color: $list-hover-color; }
 }
 
 .dashboard-page-thread-group-logo{
@@ -45,11 +47,39 @@
   img{ width: 32px; height: 32px; }
 }
 
-.dashboard-page-unread-count {
+.dashboard-page-proposal-vote {
+  padding: 2px 5px;
+}
+
+.dashboard-page-proposal-icon{
+  width: 30px;
+  height: 30px;
+}
+
+.dashboard-page-vote-icon-yes {
+  background-image: url(/img/green_thumb_22.png);
+}
+
+.dashboard-page-vote-icon-abstain {
+  background-image: url(/img/yellow_thumb_22.png);
+}
+
+.dashboard-page-vote-icon-no {
+  background-image: url(/img/pink_thumb_22.png);
+}
+
+.dashboard-page-vote-icon-block {
+  background-image: url(/img/red_flag_22.png);
+}
+
+.dashboard-page-left {
   white-space: nowrap;
   width: 35px;
   min-height: 45px;
   float: left;
+}
+
+.dashboard-page-unread-count {
   @include fontCrapName;
   @include fontHelveticaBold;
   color: $meta-text-color;
@@ -66,12 +96,48 @@
   padding-bottom: 4px;
 }
 
+.dashboard-page-thread-title {
+  white-space: nowrap;
+  overflow: hidden;
+}
+
 .dashboard-page-thread-title.is-unread {
   font-weight: bold;
 }
 
 .dashboard-page-thread-info {
   @include metaText;
+  white-space: nowrap;
+  overflow: hidden;
+  line-height: 20px;
+}
+
+.dashboard-page-thread:hover .dashboard-page-thread-actions {
+  display: block;
+}
+
+.dashboard-page-thread-actions {
+  display: none;
+  position: absolute;
+  color: white;
+  right: 0;
+  top: 0;
+  height: 100%;
+  padding: 20px 10px;
+  background: $list-hover-transparent-color;
+  &:before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: -30px;
+    width: 30px;
+    background: linear-gradient(to left, $list-hover-transparent-color, transparent);
+    height: 100%;
+  }
+}
+
+.dashboard-page-thread-action-button {
+  padding: 10px;
 }
 
 .dashboard-page-show-more{

--- a/lineman/app/components/dashboard_page/dashboard_page_thread.haml
+++ b/lineman/app/components/dashboard_page/dashboard_page_thread.haml
@@ -1,16 +1,23 @@
 .dashboard-page-thread
   %a.selector-list-item-link{href: '/d/{{discussion.key}}'}
-    .dashboard-page-thread-group-logo{ng-hide: 'hideGroupLogo'}
-      %img{src: "{{discussion.group().logoUrl()}}"}
-    .dashboard-page-unread-count
-      %span{ng-if: 'discussion.isUnread()'}
+    .dashboard-page-left
+      .dashboard-page-unread-count{ng-if: 'discussion.isUnread()'}
         {{discussion.unreadItemsCount()}}
+      .dashboard-page-proposal-vote{ng-if: 'discussion.activeProposal() && discussion.activeProposal().lastVoteByUser()'}
+        .thread-item-vote-icon{class: 'thread-item-vote-icon-{{discussion.activeProposal().lastVoteByUser().position}}'}
     .dashboard-page-thread-header
-      %tiny_proposal_pie_chart.pull-left.dashboard-page-pie-chart{proposal: 'discussion.activeProposal()', ng-if: 'discussion.activeProposal()'}
       .dashboard-page-thread-title{ng-class: "{'is-unread': discussion.isUnread() }"}
         {{discussion.title}}
     .dashboard-page-thread-info
-      %span{ng-show: 'hideGroupLogo && !discussion.group().isParent()'}> {{ discussion.group().name }} ·
-      %span{ng-hide: 'hideGroupLogo'}> {{ discussion.group().fullName() }} ·
-      %span> {{discussion.lastInboxActivity() | timeFromNowInWords}}
+      %span.dashboard-page-proposal-info{ng-if: 'discussion.activeProposal()'}
+        %tiny_proposal_pie_chart.pull-left.dashboard-page-pie-chart{proposal: 'discussion.activeProposal()', ng-if: 'discussion.activeProposal()'}
+        %span> {{ discussion.activeProposal().name }} ·
+        %smart_time{time: 'discussion.activeProposal().closingAt'}>
+        %span> ·
+      %span> {{ discussion.group().fullName() }}
+  .dashboard-page-thread-actions
+    %a.dashboard-page-thread-action-button{ng-show: 'discussion.volume != "mute"', href: '#', ng-click: 'discussion.reader().changeVolume("mute")'}>
+      %i.fa.fa-2x.fa-volume-off
+    %a.dashboard-page-thread-action-button{ng-show: 'discussion.isUnread()', href: '#', ng-click: 'discussion.markAsRead()'}>
+      %i.fa.fa-2x.fa-check
 

--- a/lineman/app/components/mixins.scss
+++ b/lineman/app/components/mixins.scss
@@ -4,6 +4,7 @@ $kinda-dark-grey: #666;
 $meta-text-color: #999;
 $border-color: #dcdcdc;
 $list-hover-color: #E0E0E0;
+$list-hover-transparent-color: rgba(224,224,224,0.8);
 $background-color: #ebebeb;
 $light-grey: #F5F5F5;
 $card-background-color: #fff;

--- a/lineman/app/components/notification_volume/notification_volume_dropdown_controller.coffee
+++ b/lineman/app/components/notification_volume/notification_volume_dropdown_controller.coffee
@@ -6,4 +6,5 @@ angular.module('loomioApp').controller 'NotificationVolumeDropdownController', (
     else if $scope.discussion
       $scope.model = Records.discussionReaders.find($scope.discussion.id)
   $scope.init()
+
   return

--- a/lineman/app/models/discussion_model.coffee
+++ b/lineman/app/models/discussion_model.coffee
@@ -75,5 +75,4 @@ angular.module('loomioApp').factory 'DiscussionModel', (BaseModel) ->
       @activeProposalClosingAt() or @lastActivityAt
 
     markAsRead: (sequenceId) ->
-      if @reader().lastReadSequenceId < sequenceId
-        @restfulClient.patchMember(@keyOrId(), 'mark_as_read', {sequence_id: sequenceId})
+      @reader().markAsRead(sequenceId)

--- a/lineman/app/models/discussion_reader_records_interface.coffee
+++ b/lineman/app/models/discussion_reader_records_interface.coffee
@@ -5,3 +5,10 @@ angular.module('loomioApp').factory 'DiscussionReaderRecordsInterface', (BaseRec
     initialize: (data = {}) ->
       data.id = data.discussion_id if data.discussion_id?
       @baseInitialize(data)
+
+    forDashboard: (options = {}) ->
+      relation = @collection.chain()
+      relation = relation.find({ volume: { $ne: 'mute'} })     if options['unmuted']
+      relation = relation.find({ groupId: options['groupId']}) if options['groupId']
+      relation = relation.where((reader) -> reader.discussion().isUnread())   if options['unread']
+      relation

--- a/lineman/app/models/discussion_records_interface.coffee
+++ b/lineman/app/models/discussion_records_interface.coffee
@@ -14,5 +14,5 @@ angular.module('loomioApp').factory 'DiscussionRecordsInterface', (BaseRecordsIn
     fetchInboxByGroup: (options = {}) ->
       @restfulClient.get 'inbox_by_group', options
 
-    findByGroupIds: (ids) ->
-      @collection.find(groupId: {'$in': ids})
+    findByDiscussionIds: (ids) ->
+      @collection.chain().find({id: { $in: ids} })

--- a/lineman/app/models/group_model.coffee
+++ b/lineman/app/models/group_model.coffee
@@ -10,12 +10,6 @@ angular.module('loomioApp').factory 'GroupModel', (BaseModel) ->
     discussions: ->
       @discussionsView.data()
 
-    organizationDiscussions: ->
-      return unless @isParent()
-      groupIds = _.pluck(@subgroups(), 'id')
-      groupIds.push @id
-      @recordStore.discussions.findByGroupIds(groupIds)
-
     subgroups: ->
       @recordStore.groups.find(parentId: @id)
 

--- a/lineman/app/models/proposal_model.coffee
+++ b/lineman/app/models/proposal_model.coffee
@@ -51,6 +51,7 @@ angular.module('loomioApp').factory 'ProposalModel', (BaseModel) ->
       _.values @uniqueVotesByUserId()
 
     lastVoteByUser: (user) ->
+      user = user or window.Loomio.currentUser
       @uniqueVotesByUserId()[user.id]
 
     userHasVoted: (user) ->

--- a/lineman/app/models/user_model.coffee
+++ b/lineman/app/models/user_model.coffee
@@ -20,9 +20,6 @@ angular.module('loomioApp').factory 'UserModel', (BaseModel) ->
     memberships: ->
       @membershipsView.data()
 
-    inboxDiscussions: ->
-      @recordStore.discussions.where(id: {$gt: 0}, groupId: {$in: @groupIds()})
-
     notifications: ->
       @notificationsView.data()
 

--- a/lineman/app/models/vote_records_interface.coffee
+++ b/lineman/app/models/vote_records_interface.coffee
@@ -2,6 +2,9 @@ angular.module('loomioApp').factory 'VoteRecordsInterface', (BaseRecordsInterfac
   class VoteRecordsInterface extends BaseRecordsInterface
     model: VoteModel
 
+    fetchMyRecentVotes: ->
+      @restfulClient.get('my_votes')
+
     fetchMyVotesByDiscussion: (discussion) ->
       @restfulClient.get('my_votes', discussion_key: discussion.key)
 

--- a/spec/controllers/api/discussion_readers_controller_spec.rb
+++ b/spec/controllers/api/discussion_readers_controller_spec.rb
@@ -4,6 +4,7 @@ describe API::DiscussionReadersController do
   let(:user) { create :user }
   let(:another_user) { create :user }
   let(:group) { create :group }
+  let(:comment) { build(:comment, discussion: discussion) }
   let(:discussion) { create :discussion, group: group }
   let(:reader) { DiscussionReader.for(user: user, discussion: discussion) }
   let(:reader_params) { { volume: :mute } }
@@ -13,6 +14,21 @@ describe API::DiscussionReadersController do
     sign_in user
     reader.save
     reader.reload
+  end
+
+  describe 'mark_as_read', focus: true do
+    it "Marks context/discusion as read" do
+      patch :mark_as_read, id: discussion.key, sequence_id: 0
+      expect(reader.reload.last_read_at).to eq discussion.reload.last_activity_at
+      expect(reader.last_read_sequence_id).to eq 0
+    end
+
+    it "Marks thread item as read", focus: true do
+      event = CommentService.create(comment: comment, actor: discussion.author)
+      patch :mark_as_read, id: discussion.key, sequence_id: event.reload.sequence_id
+      expect(reader.reload.last_read_at).to eq event.created_at
+      expect(reader.last_read_sequence_id).to eq 1
+    end
   end
 
   describe 'update' do

--- a/spec/controllers/api/users_controller_spec.rb
+++ b/spec/controllers/api/users_controller_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+describe API::UsersController do
+
+  let(:user) { create :user }
+  let(:another_user) { create :user }
+  let(:user_params) {{
+    dashboard_sort: 'sort_by_date',
+    dashboard_filter: 'show_unread'
+  }}
+
+  before do
+    sign_in user
+  end
+
+  describe 'update' do
+    context 'success' do
+      it "updates a discussion" do
+        post :update, id: user.id, user: user_params, format: :json
+        expect(response).to be_success
+        expect(user.reload.dashboard_filter).to eq user_params[:dashboard_filter]
+      end
+    end
+
+    context 'failures' do
+      it "responds with an error when there are unpermitted params" do
+        user_params[:dontmindme] = 'wild wooly byte virus'
+        put :update, id: user.id, user: user_params
+        expect(JSON.parse(response.body)['exception']).to eq 'ActionController::UnpermittedParameters'
+      end
+
+      it "responds with an error when the user is unauthorized" do
+        sign_in another_user
+        put :update, id: user.id, user: user_params
+        expect(JSON.parse(response.body)['exception']).to eq 'CanCan::AccessDenied'
+      end
+
+      # it "responds with validation errors when they exist" do
+      #   user_params[:dashboard_sort] = 'notathing'
+      #   expect { put :update, id: user.id, user: user_params, format: :json }.to raise ArgumentError
+      # end
+    end
+  end
+
+end

--- a/spec/services/discussion_reader_cache_spec.rb
+++ b/spec/services/discussion_reader_cache_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+describe DiscussionReaderCache do
+  let(:user) { create :user }
+  let(:discussion_one) { create :discussion, author: user }
+  let(:discussion_two) { create :discussion, author: user }
+  let(:cache) { DiscussionReaderCache.new user: user, discussions: [discussion_one, discussion_two] }
+
+  describe 'initialize' do
+
+    it 'intializes a discussion reader cache' do
+      DiscussionReader.for(user: user, discussion: discussion_one).save
+      expect(cache.send(:cache).keys).to include discussion_one.id
+      expect(cache.send(:cache).keys).to_not include discussion_two.id
+    end
+  end
+
+  describe 'get_for' do
+    it 'returns an existing discussion reader if it exists' do
+      existing = DiscussionReader.for(user: user, discussion: discussion_one)
+      existing.save
+      expect(cache.get_for(discussion_one)).to eq existing
+    end
+
+    it 'returns a new discussion reader if one does not exist' do
+      created = cache.get_for(discussion_two)
+      expect(created).to be_a DiscussionReader
+      expect(created.discussion).to eq discussion_two
+      expect(created.user).to eq user
+    end
+  end
+end


### PR DESCRIPTION
Okay, lots of stuff here:

- Saves user preferences when changed
- More robust querying of client side db, so things don't slip through that shouldn't be there
- More better 'fire and forget' (things load faster and backfill later :zap:)
- Added mute and mark as unread buttons, which totally work
- Lots of cleanup and code cruft removal
- More reliably filter out muted discussions

Could likely do with a code review @robguthrie 