### PR TITLE
Group form

### DIFF
--- a/lineman/app/app.coffee
+++ b/lineman/app/app.coffee
@@ -43,6 +43,7 @@ angular.module('loomioApp').controller 'AppController', ($scope, $router) ->
     {path: '/m/:key/', component: 'proposalRedirect' },
     {path: '/m/:key/:stub', component: 'proposalRedirect' },
     {path: '/g/new', component: 'groupForm' },
+    {path: '/g/:key/edit', component: 'groupForm' },
     {path: '/g/:key', component: 'groupPage' },
     {path: '/g/:key/:stub', component: 'groupPage' },
   ]);

--- a/lineman/app/app.coffee
+++ b/lineman/app/app.coffee
@@ -42,6 +42,7 @@ angular.module('loomioApp').controller 'AppController', ($scope, $router) ->
     {path: '/d/:key/:stub', component: 'threadPage' },
     {path: '/m/:key/', component: 'proposalRedirect' },
     {path: '/m/:key/:stub', component: 'proposalRedirect' },
+    {path: '/g/new', component: 'groupForm' },
     {path: '/g/:key', component: 'groupPage' },
     {path: '/g/:key/:stub', component: 'groupPage' },
   ]);

--- a/lineman/app/components/group_form/group_form.haml
+++ b/lineman/app/components/group_form/group_form.haml
@@ -1,5 +1,6 @@
 .loading-wrapper.container.main-container
-  %form.form-card{name: 'groupForm', ng_submit: 'submit()'}
+  %loading{ng-unless: 'groupForm.group'}
+  %form.form-card{ng-if: 'groupForm.group', ng_submit: 'groupForm.submit()'}
     %fieldset{ng_disabled: 'isDisabled'}
       %h1{ng_show: 'groupForm.group.isNew() && !groupForm.group.parentId', translate: 'group_form.new_group_title'}
       %h1{ng_show: 'groupForm.group.isNew() && groupForm.group.parentId', translate: 'group_form.new_subgroup_title', translate-value-parent-group-name: '{{group.parentName()}}'}
@@ -19,7 +20,7 @@
         %label{for: 'group-visible-to-members', translate: 'group_form.privacy.visible_to_members'}
         %select#group-visible-to-members-field.form-control{ng_model: 'groupForm.group.visibleTo', ng_required: true}
           %option{value: 'public', ng_show: '!group.parentIsHidden()', translate: 'group_form.privacy.public_visibility'}
-          %option{value: 'parent_members', ng_show: 'groupForm.group.parent()', translate: 'group_form.privacy.organization_visibility'}
+          %option{value: 'parent_members', ng_show: 'groupForm.group.parentId', translate: 'group_form.privacy.organization_visibility'}
           %option{value: 'members', translate: 'group_form.privacy.private_visibility'}
 
         %label{for: 'group-membership-granted-upon', translate: 'group_form.privacy.membership_granted_upon'}
@@ -73,5 +74,5 @@
             %input#group-members-can-vote{type: 'checkbox', ng_model: 'groupForm.group.membersCanVote'}
             %span{translate: 'group_form.permissions.members_can_vote'}
 
-      %button.btn.btn-primary{type: 'submit', translate: 'group_form.new_group_submit', ng_show: 'groupForm.group.isNew()', ng-click: 'groupForm.submit()'}
-      %button.btn.btn-primary{type: 'submit', translate: 'group_form.edit_group_submit', ng_hide: 'groupForm.group.isNew()', ng-click: 'groupForm.submit()'}
+      %button.btn.btn-primary{type: 'submit', translate: 'group_form.new_group_submit', ng_show: 'groupForm.group.isNew()'}
+      %button.btn.btn-primary{type: 'submit', translate: 'group_form.edit_group_submit', ng_hide: 'groupForm.group.isNew()'}

--- a/lineman/app/components/group_form/group_form.haml
+++ b/lineman/app/components/group_form/group_form.haml
@@ -1,35 +1,35 @@
-.container#main
+.loading-wrapper.container.main-container
   %form.form-card{name: 'groupForm', ng_submit: 'submit()'}
     %fieldset{ng_disabled: 'isDisabled'}
-      %h1{ng_show: 'group.isNew() && !group.parentId', translate: 'group_form.new_group_title'}
-      %h1{ng_show: 'group.isNew() && group.parentId', translate: 'group_form.new_subgroup_title', translate-value-parent-group-name: '{{group.parentName()}}'} 
-      %h1{ng_show: '!group.isNew()', translate: 'group_form.edit_group_title'}
+      %h1{ng_show: 'groupForm.group.isNew() && !groupForm.group.parentId', translate: 'group_form.new_group_title'}
+      %h1{ng_show: 'groupForm.group.isNew() && groupForm.group.parentId', translate: 'group_form.new_subgroup_title', translate-value-parent-group-name: '{{group.parentName()}}'}
+      %h1{ng_show: '!groupForm.group.isNew()', translate: 'group_form.edit_group_title'}
       .form-group
         %h2{translate: 'group_form.profile_label'}
 
         %label{for: 'group-name-field', translate: 'group_form.name_label'}
-        %input#group-name-field.form-control{placeholder: "{{ 'group_form.name_placeholder' | translate }}", ng-model: 'group.name', ng_required: 'true'}
+        %input#group-name-field.form-control{placeholder: "{{ 'group_form.name_placeholder' | translate }}", ng-model: 'groupForm.group.name', ng_required: 'true'}
 
         %label{for: 'group-description-field', translate: 'group_form.description_label'}
-        %textarea#group-description-field.form-control{placeholder: "{{ 'group_form.description_placeholder' | translate }}", ng_model: 'group.description'}
+        %textarea#group-description-field.form-control{placeholder: "{{ 'group_form.description_placeholder' | translate }}", ng_model: 'groupForm.group.description'}
 
       .form-group
         %h2{translate: 'group_form.privacy.label'}
 
         %label{for: 'group-visible-to-members', translate: 'group_form.privacy.visible_to_members'}
-        %select#group-visible-to-members-field.form-control{ng_model: 'group.visibleTo', ng_required: true}    
+        %select#group-visible-to-members-field.form-control{ng_model: 'groupForm.group.visibleTo', ng_required: true}
           %option{value: 'public', ng_show: '!group.parentIsHidden()', translate: 'group_form.privacy.public_visibility'}
-          %option{value: 'parent_members', ng_show: 'group.parent()', translate: 'group_form.privacy.organization_visibility'}
+          %option{value: 'parent_members', ng_show: 'groupForm.group.parent()', translate: 'group_form.privacy.organization_visibility'}
           %option{value: 'members', translate: 'group_form.privacy.private_visibility'}
 
         %label{for: 'group-membership-granted-upon', translate: 'group_form.privacy.membership_granted_upon'}
-        %select#group-membership-granted-upon-field.form-control{ng_model: 'group.membershipGrantedUpon', ng_required: true}  
+        %select#group-membership-granted-upon-field.form-control{ng_model: 'groupForm.group.membershipGrantedUpon', ng_required: true}
           %option{value: 'request', translate: 'group_form.privacy.membership_by_request'}
           %option{value: 'approval', translate: 'group_form.privacy.membership_by_approval'}
           %option{value: 'invitation', translate: 'group_form.privacy.membership_by_invitation'}
 
         %label{for: 'group-discussion-privacy-options', translate: 'group_form.privacy.discussion_privacy_options'}
-        %select#group-discussion-privacy-options-field.form-control{ng_model: 'group.discussionPrivacyOptions', ng_required: true}
+        %select#group-discussion-privacy-options-field.form-control{ng_model: 'groupForm.group.discussionPrivacyOptions', ng_required: true}
           %option{value: 'public_only', translate: 'group_form.privacy.public_discussions' }
           %option{value: 'public_or_private', translate: 'group_form.privacy.public_or_private_discussions' }
           %option{value: 'private_only', translate: 'group_form.privacy.private_discussions'}
@@ -40,38 +40,38 @@
 
         .checkbox
           %label{for: 'group-members-can-add-members'}
-            %input#group-members-can-add-members{type: 'checkbox', ng_model: 'group.membersCanAddMembers'}
+            %input#group-members-can-add-members{type: 'checkbox', ng_model: 'groupForm.group.membersCanAddMembers'}
             %span{translate: 'group_form.permissions.members_can_add_members'}
 
         .checkbox
           %label{for: 'group-members-can-create-subgroups'}
-            %input#group-members-can-create-subgroups{type: 'checkbox', ng_model: 'group.membersCanCreateSubgroups'}
+            %input#group-members-can-create-subgroups{type: 'checkbox', ng_model: 'groupForm.group.membersCanCreateSubgroups'}
             %span{translate: 'group_form.permissions.members_can_create_subgroups'}
 
         .checkbox
           %label{for: 'group-members-can-start-discussions'}
-            %input#group-members-can-start-discussions{type: 'checkbox', ng_model: 'group.membersCanStartDiscussions'}
+            %input#group-members-can-start-discussions{type: 'checkbox', ng_model: 'groupForm.group.membersCanStartDiscussions'}
             %span{translate: 'group_form.permissions.members_can_start_discussions'}
 
         .checkbox
           %label{for: 'group-members-can-edit-discussions'}
-            %input#group-members-can-edit-discussions{type: 'checkbox', ng_model: 'group.membersCanEditDiscussions'}
+            %input#group-members-can-edit-discussions{type: 'checkbox', ng_model: 'groupForm.group.membersCanEditDiscussions'}
             %span{translate: 'group_form.permissions.members_can_edit_discussions'}
 
         .checkbox
           %label{for: 'group-members-can-edit-comments'}
-            %input#group-members-can-edit-comments{type: 'checkbox', ng_model: 'group.membersCanEditComments'}
+            %input#group-members-can-edit-comments{type: 'checkbox', ng_model: 'groupForm.group.membersCanEditComments'}
             %span{translate: 'group_form.permissions.members_can_edit_comments'}
 
         .checkbox
           %label{for: 'group-members-can-raise-motions'}
-            %input#group-members-can-raise-motions{type: 'checkbox', ng_model: 'group.membersCanRaiseMotions'}
+            %input#group-members-can-raise-motions{type: 'checkbox', ng_model: 'groupForm.group.membersCanRaiseMotions'}
             %span{translate: 'group_form.permissions.members_can_raise_motions'}
 
         .checkbox
           %label{for: 'group-members-can-vote'}
-            %input#group-members-can-vote{type: 'checkbox', ng_model: 'group.membersCanVote'}
+            %input#group-members-can-vote{type: 'checkbox', ng_model: 'groupForm.group.membersCanVote'}
             %span{translate: 'group_form.permissions.members_can_vote'}
 
-      %button.btn.btn-primary{type: 'submit', translate: 'group_form.new_group_submit', ng_show: 'group.isNew()'}
-      %button.btn.btn-primary{type: 'submit', translate: 'group_form.edit_group_submit', ng_hide: 'group.isNew()'}
+      %button.btn.btn-primary{type: 'submit', translate: 'group_form.new_group_submit', ng_show: 'groupForm.group.isNew()', ng-click: 'groupForm.submit()'}
+      %button.btn.btn-primary{type: 'submit', translate: 'group_form.edit_group_submit', ng_hide: 'groupForm.group.isNew()', ng-click: 'groupForm.submit()'}

--- a/lineman/app/components/group_form/group_form_controller.coffee
+++ b/lineman/app/components/group_form/group_form_controller.coffee
@@ -1,0 +1,10 @@
+angular.module('loomioApp').controller 'GroupFormController', ($location, Records, FormService) ->
+
+  @group = Records.groups.initialize()
+
+  @onSuccess = (newGroup) ->
+    $location.path "/g/#{newGroup.key}"
+
+  FormService.applyForm @, @group
+
+  return

--- a/lineman/app/components/group_form/group_form_controller.coffee
+++ b/lineman/app/components/group_form/group_form_controller.coffee
@@ -1,10 +1,32 @@
-angular.module('loomioApp').controller 'GroupFormController', ($location, Records, FormService) ->
+angular.module('loomioApp').controller 'GroupFormController', ($routeParams, $rootScope, $location, Records, FormService) ->
 
-  @group = Records.groups.initialize()
+  if $routeParams.key
+    Records.groups.findOrFetchByKey($routeParams.key).then (group) =>
+      @group = group
+      FormService.applyForm @, @group
+  else if $routeParams.parentId
+    Records.groups.findOrFetchByKey($routeParams.parentId).then (parent) =>
+      @group = Records.groups.initialize
+        parentId:                   parent.id
+        visibleTo:                  parent.visibleTo
+        membershipGrantedUpon:      parent.membershipGrantedUpon
+        discussionPrivacyOptions:   parent.discussionPrivacyOptions
+        membersCanAddMembers:       parent.membersCanAddMembers
+        membersCanStartSubgroups:   parent.membersCanStartSubgroups
+        membersCanStartDiscussions: parent.membersCanStartDiscussions
+        membersCanEditDiscussions:  parent.membersCanEditDiscussions
+        membersCanEditComments:     parent.membersCanEditComments
+        membersCanRaiseMotions:     parent.membersCanRaiseMotions
+        membersCanVote:             parent.membersCanVote
+      FormService.applyForm @, @group
+  else
+    @group = Records.groups.initialize
+      visibleTo: 'public',
+      membershipGrantedUpon: 'request',
+      discussionPrivacyOptions: 'public_only'
+    FormService.applyForm @, @group
 
   @onSuccess = (newGroup) ->
     $location.path "/g/#{newGroup.key}"
-
-  FormService.applyForm @, @group
 
   return

--- a/lineman/app/components/group_page/group_form_controller.coffee
+++ b/lineman/app/components/group_page/group_form_controller.coffee
@@ -1,7 +1,0 @@
-angular.module('loomioApp').controller 'GroupFormController', ($scope, $location, group, FormService) ->
-  $scope.group = group
-
-  $scope.onSuccess = (newGroup) ->
-    $location.path "/g/#{newGroup.key}"
-
-  FormService.applyForm $scope, group


### PR DESCRIPTION
This makes the group form workflow work again, including:

- Creating a new group (`/g/new`)
- Creating a new subgroup (`/g/new?parentId=xxx`)
- Editing an existing group (`/g/xxx/edit`)

todo before merge: 
- Privacy options (I've got a good idea of how to do this)
- Add some integration testing around group creation / editing
- Design and implement some buttons to make this an actual workflow, instead of just urls