### PR TITLE
removed non-semantic greys. killed metaText

### DIFF
--- a/lineman/app/components/group_page/group_page.scss
+++ b/lineman/app/components/group_page/group_page.scss
@@ -12,7 +12,7 @@
   top: $navbar-height;
   width: 100%;
   height: 160px;
-  background: url('http://placehold.it/640x160') no-repeat center center $light-grey;
+  background: url('http://placehold.it/640x160') no-repeat center center #f5f5f5;
   background-size: cover;
 }
 .group-page-header{

--- a/lineman/app/components/inbox/inbox.scss
+++ b/lineman/app/components/inbox/inbox.scss
@@ -1,6 +1,6 @@
 span.activity-count {
   margin-left: 0.5em;
-  color: $meta-text-color;
+  color: $grey-on-white;
 }
 .container#main {
   @media (min-width: $screen-sm-min){

--- a/lineman/app/components/mixins.scss
+++ b/lineman/app/components/mixins.scss
@@ -1,14 +1,11 @@
-/* let's come up with a good naming scheme for the greys once we lock them in*/
+/* let's only use semantic names for our colours */
 $grey-on-grey:  #666;
 $grey-on-white: #767676;
-
 $primary-text-color: #262626;
-$meta-text-color: #767676;
 $border-color: #dcdcdc;
 $list-hover-color: #E0E0E0;
 $list-hover-transparent-color: rgba(224,224,224,0.8);
 $background-color: #ebebeb;
-$light-grey: #F5F5F5;
 $card-background-color: #fff;
 
 $item-highlight-color: #FFFFE8;
@@ -38,11 +35,6 @@ $navbar-height: 45px;
 
 @mixin fontCrapName{
   font-size: 15px;
-  line-height: 20px;
-}
-
-@mixin fontModerate {
-  font-size: 16px;
   line-height: 20px;
 }
 
@@ -81,11 +73,6 @@ $navbar-height: 45px;
   font-stretch:normal;
 }
 
-@mixin metaText {
-  color: $meta-text-color;
-  @include fontSmall;
-}
-
 @mixin roundedCorners {
   -webkit-border-radius: 3px;
   -moz-border-radius: 3px;
@@ -98,9 +85,7 @@ $navbar-height: 45px;
   padding: 17px 22px;
   background: #fff;
   margin-bottom: 8px;
-  i{
-    color: $meta-text-color;
-  }
+  i{ color: $grey-on-white; }
   .card-minor-action{
     margin: 10px 0 0 0;
     clear: both;

--- a/lineman/app/components/navbar/navbar.scss
+++ b/lineman/app/components/navbar/navbar.scss
@@ -63,7 +63,7 @@
 }
 
 .lmo-navbar-btn__icon{
-  color: $meta-text-color;
+  color: $grey-on-white;
   font-size: 19px;
 }
 

--- a/lineman/app/components/navbar/navbar_search.scss
+++ b/lineman/app/components/navbar/navbar_search.scss
@@ -20,7 +20,7 @@
   position: absolute;
   top: 13px;
   right: 10px;
-  color: $meta-text-color;
+  color: $grey-on-white;
 }
 
 .navbar-search-results {

--- a/lineman/app/components/selector_list/selector_list.scss
+++ b/lineman/app/components/selector_list/selector_list.scss
@@ -7,7 +7,7 @@
   overflow-y:scroll;
 }
 .selector-list .timeago, .smart-time{
-  color: $meta-text-color;
+  color: $grey-on-white;
   @include fontTiny;
 }
 .selector-list-header {
@@ -33,7 +33,7 @@
 }
 
 .selector-list-item i{
-  color: $meta-text-color;
+  color: $grey-on-white;
 }
 .selector-list-item-link{
   display: block;
@@ -57,9 +57,6 @@
 .is-subgroup-true .selector-list-item-link{
   padding-left: 53px;
 }
-.selector-list-item.is-read{
-  background-color: $light-grey;
-}
 .is-unread .selector-list-item-discussion-title{
   font-weight: bold;
 }
@@ -82,7 +79,7 @@
   margin-bottom: 5px;
 }
 a .selector-list-item-proposal-details {
-  color: $meta-text-color;
+  color: $grey-on-white;
   @include fontHelvetica;
   @include fontSmall;
   margin-bottom: 5px;
@@ -99,7 +96,7 @@ a .selector-list-item-proposal-details {
 }
 
 .selector-list-item-thread-group-name{
-  color: $meta-text-color;
+  color: $grey-on-white;
   @include fontHelvetica;
   @include fontSmall;
 }

--- a/lineman/app/components/thread_lintel/thread_lintel.scss
+++ b/lineman/app/components/thread_lintel/thread_lintel.scss
@@ -25,7 +25,7 @@
   float: right;
   @include fontHelveticaLight;
   @include fontMedium;
-  color: $meta-text-color;
+  color: $grey-on-white;
 }
 
 .thread-lintel__progress {

--- a/lineman/app/components/thread_page/activity_card/activity_card.scss
+++ b/lineman/app/components/thread_page/activity_card/activity_card.scss
@@ -3,7 +3,8 @@
 }
 
 .activity-card__load-backwards{
-  @include metaText;
+  @include fontSmall;
+  color: $grey-on-white;
   line-height: 30px;
   span{text-decoration: underline;}
 }

--- a/lineman/app/components/thread_page/proposal_collapsed/proposal_collapsed.scss
+++ b/lineman/app/components/thread_page/proposal_collapsed/proposal_collapsed.scss
@@ -10,11 +10,12 @@ a.proposal-collapsed:hover{
   text-decoration: none;
 }
 .proposal-collapsed-outcome{
-  color: $meta-text-color;
+  color: $grey-on-white;
 }
 .proposal-collapsed-expand{
   clear: both;
   margin-top: 1em;
-  @include metaText;
+  @include fontSmall;
+  color: $grey-on-white;
   text-decoration: underline;
 }

--- a/lineman/app/components/thread_page/proposal_expanded/proposal_expanded.scss
+++ b/lineman/app/components/thread_page/proposal_expanded/proposal_expanded.scss
@@ -10,12 +10,14 @@
 }
 
 .proposal-expanded__collapse{
-  @include metaText;
+  @include fontSmall;
+  color: $grey-on-white;
   text-decoration: underline;
 }
 
 .proposal-expanded__started-by {
-  @include metaText;
+  @include fontSmall;
+  color: $grey-on-white;
   margin-bottom: 15px;
 }
 
@@ -25,7 +27,8 @@
 }
 
 .pie-chart-legend {
-  @include metaText;
+  @include fontSmall;
+  color: $grey-on-white;
   padding-top: 36px;
 }
 

--- a/lineman/app/components/thread_page/proposal_form/closing_at_field.scss
+++ b/lineman/app/components/thread_page/proposal_form/closing_at_field.scss
@@ -15,5 +15,5 @@
 }
 
 .closing-at-field__zone {
-  color: $meta-text-color;
+  color: $grey-on-white;
 }

--- a/lineman/app/components/thread_page/proposals_card/proposals_card.scss
+++ b/lineman/app/components/thread_page/proposals_card/proposals_card.scss
@@ -4,11 +4,11 @@
 }
 
 .closing-at-timezone{
-  color: $meta-text-color;
+  color: $grey-on-white;
 }
 
 .closing-at-time-in-words{
-  color: $meta-text-color;
+  color: $grey-on-white;
   margin-top: 0.5em;
 }
 


### PR DESCRIPTION
Yee haw! Only semantic colors in teh mixins file!

Also I killed metaText because we kept overriding it. Also I think it is good for you to think about if you want $grey-on-grey or $grey-on-white when you are placing de-emphasised text around the place.