### PR TITLE
Apply group to new thread

### DIFF
--- a/lineman/app/components/group_page/discussions_card/discussions_card_controller.coffee
+++ b/lineman/app/components/group_page/discussions_card/discussions_card_controller.coffee
@@ -15,4 +15,4 @@ angular.module('loomioApp').controller 'DiscussionsCardController', ($scope, $mo
   $scope.getNextPage()
 
   $scope.openDiscussionForm = ->
-    DiscussionFormService.openNewDiscussionModal()
+    DiscussionFormService.openNewDiscussionModal($scope.group)

--- a/lineman/app/components/group_page/discussions_card/discussions_card_controller.coffee
+++ b/lineman/app/components/group_page/discussions_card/discussions_card_controller.coffee
@@ -1,4 +1,4 @@
-angular.module('loomioApp').controller 'DiscussionsCardController', ($scope, $modal, Records, UserAuthService, DiscussionFormService) ->
+angular.module('loomioApp').controller 'DiscussionsCardController', ($scope, $modal, Records, DiscussionFormService, KeyEventService) ->
   nextPage = 1
   busy = false
   $scope.lastPage = false
@@ -16,3 +16,6 @@ angular.module('loomioApp').controller 'DiscussionsCardController', ($scope, $mo
 
   $scope.openDiscussionForm = ->
     DiscussionFormService.openNewDiscussionModal($scope.group)
+
+  KeyEventService.registerKeyEvent $scope, 'pressedT', ->
+    $scope.openDiscussionForm()

--- a/lineman/app/services/discussion_form_service.coffee
+++ b/lineman/app/services/discussion_form_service.coffee
@@ -7,9 +7,9 @@ angular.module('loomioApp').factory 'DiscussionFormService', ($modal, Records) -
         resolve:
           discussion: -> Records.discussions.find(discussion.id)
 
-    openNewDiscussionModal: ->
+    openNewDiscussionModal: (group = {}) ->
       $modal.open
         templateUrl: 'generated/components/thread_page/discussion_form/discussion_form.html'
         controller: 'DiscussionFormController'
         resolve:
-          discussion: -> Records.discussions.initialize()
+          discussion: -> Records.discussions.initialize group_id: group.id

--- a/lineman/app/services/key_event_service.coffee
+++ b/lineman/app/services/key_event_service.coffee
@@ -2,6 +2,7 @@ angular.module('loomioApp').factory 'KeyEventService', ($rootScope) ->
   new class KeyEventService
 
     keyboardShortcuts:
+      84:  'pressedT'
       27:  'pressedEsc'
       13:  'pressedEnter'
       191: 'pressedSlash'


### PR DESCRIPTION
Clicking 'new thread' on a group page will now default the new thread's group to that group.

Also added a 'T' keyboard shortcut to it as proof of super easiness.