### PR TITLE
Use ng-src for attachment/user images

### DIFF
--- a/app/views/layouts/angular.html.haml
+++ b/app/views/layouts/angular.html.haml
@@ -28,5 +28,5 @@
     = javascript_include_tag lineman_vendorjs_path
     = javascript_include_tag lineman_appjs_path
 
-
-    %script{src: "#{ENV['FAYE_URL']}/client.js", type: 'text/javascript'}
+    - if ENV['FAYE_URL']
+      %script{src: "#{ENV['FAYE_URL']}/client.js", type: 'text/javascript'}

--- a/lineman/app/components/dashboard_page/dashboard_page.haml
+++ b/lineman/app/components/dashboard_page/dashboard_page.haml
@@ -87,7 +87,7 @@
           .dashboard-page-sort-date{ng-if: 'dashboardPage.sort() == "sort_by_group"'}
             .dashboard-page-group{ng-repeat: 'group in dashboardPage.dashboardGroups() | orderBy:dashboardPage.groupName'}
               %section.dashboard-page-threads-container{ng-if: 'dashboardPage.anyThisGroup(group)', role: 'region', aria-label: "{{ 'dashboard_page.threads_from.group' | translate }} {{group.name}}"}
-                %img.selector-list-item-group-logo.pull-left{src: "{{group.logoUrl()}}", aria-hidden: 'true'}>
+                %img.selector-list-item-group-logo.pull-left{ng-src: "{{group.logoUrl()}}", aria-hidden: 'true'}>
                 %h2.dashboard-page-group-name
                   %a{href: '/g/{{group.key}}'} {{group.name}}
                 .dashboard-page-threads

--- a/lineman/app/components/navbar/navbar_search.haml
+++ b/lineman/app/components/navbar/navbar_search.haml
@@ -13,7 +13,7 @@
         %a.selector-list-item-link{href: '/g/{{group.key}}'}
           .media-left
             .selector-list-item-group-logo{ng-if: 'group.isSubgroup() && queryEmpty()'}
-            %img.selector-list-item-group-logo{ng-if: 'group.isParent() || queryPresent()', src: "{{group.logoUrl()}}", aria-hidden: 'true'}
+            %img.selector-list-item-group-logo{ng-if: 'group.isParent() || queryPresent()', ng-src: "{{group.logoUrl()}}", aria-hidden: 'true'}
           .selector-list-item-group-name.media-body
             .noop{ng-if: 'queryPresent()' }
               {{ group.fullName() }}

--- a/lineman/app/components/navbar/search_result.haml
+++ b/lineman/app/components/navbar/search_result.haml
@@ -21,7 +21,7 @@
         .avatar-initials{ng-if: '::(comment.author.avatar_kind == "initials")'}
           {{::comment.author.avatar_initials}}
         .avatar-image{ng-if: '::(comment.author.avatar_kind != "initials")'}
-          %img{alt: "{{::comment.author.name}}", src: '{{::comment.author.avatar_url}}'}
+          %img{alt: "{{::comment.author.name}}", ng-src: '{{::comment.author.avatar_url}}'}
     .media-body
       .search-result-child-title {{comment.author.name}}
       .search-result-blurb{ng-bind-html: 'comment.blurb'}

--- a/lineman/app/components/profile_page/profile_page.haml
+++ b/lineman/app/components/profile_page/profile_page.haml
@@ -1,6 +1,6 @@
 .profile-page
   .media-left
-    %img.img-profile.img-rounded{src: '{{user.profileUrl}}'}
+    %img.img-profile.img-rounded{ng-src: '{{user.profileUrl}}'}
   .media-body
     %h1 {{user.name}}
     %p.username
@@ -9,6 +9,6 @@
   %h3.clearfix{translate: 'profile_page.my_groups'}
   .profile-group{ng-repeat: 'group in user.groups()', ng-class: '{"profile-subgroup": group.parentId}'}
     .media-left
-      %img{src: '{{group.logoUrlSmall}}'}
+      %img{ng-src: '{{group.logoUrlSmall}}'}
     .media-body 
       %a{href: '/g/{{group.key}}'} {{group.name}}

--- a/lineman/app/components/thread_lintel/thread_lintel.haml
+++ b/lineman/app/components/thread_lintel/thread_lintel.haml
@@ -1,5 +1,5 @@
 .thread-lintel{ng-show: 'show()'}
-  %img.thread-lintel__logo{src: '{{discussion.group().logoUrl()}}'}
+  %img.thread-lintel__logo{ng-src: '{{discussion.group().logoUrl()}}'}
   .thread-lintel__title
     {{ discussion.title }}
 

--- a/lineman/app/components/thread_page/comment/attachment.haml
+++ b/lineman/app/components/thread_page/comment/attachment.haml
@@ -6,5 +6,5 @@
       {{attachment.filename }}
     %span {{attachment.formattedFilesize()}}
   .attachment-content{ng-if: 'attachment.isAnImage'}
-    %img{src: '{{::attachment.location}}', alt: "{{ 'activity_card.attachment_display.image_alt' | translate }}"}
+    %img{ng-src: '{{::attachment.location}}', alt: "{{ 'activity_card.attachment_display.image_alt' | translate }}"}
 

--- a/lineman/app/components/thread_page/thread_page.haml
+++ b/lineman/app/components/thread_page/thread_page.haml
@@ -4,7 +4,7 @@
 
     %section.media.thread-group{role: 'region', aria-label: "{{ 'thread_group.aria_label' | translate }}"}
       .media-left.thread-group__icon{aria-hidden: 'true'}
-        %img.thread-group-logo{src: "{{threadPage.group.logoUrl()}}"}
+        %img.thread-group-logo{ng-src: "{{threadPage.group.logoUrl()}}"}
       .media-body.thread-group__name
         %a{ng_show: 'threadPage.group.parentId', href: '/g/{{threadPage.group.parent().key}}'}
           {{threadPage.group.parentName()}}

--- a/lineman/app/components/user_avatar/user_avatar.haml
+++ b/lineman/app/components/user_avatar/user_avatar.haml
@@ -4,4 +4,4 @@
   .avatar-image{ng-if: '::(user.avatarKind == "gravatar")'}
     %img{gravatar-src-once: 'user.gravatarMd5', alt: "{{::user.name}}"}
   .avatar-image{ng-if: '::(user.avatarKind == "uploaded")'}
-    %img{alt: "{{::user.name}}", src: '{{::user.avatarUrl}}'}
+    %img{alt: "{{::user.name}}", ng-src: '{{::user.avatarUrl}}'}


### PR DESCRIPTION
This fixed all of the image 404's in angular for me locally; problem was using the `src` attribute instead of `ng-src`

There's likely some lingering issues around things like default group logos, I'll check that out next.