### PR TITLE
Sort discussions by latest activity

### DIFF
--- a/app/controllers/api/discussions_controller.rb
+++ b/app/controllers/api/discussions_controller.rb
@@ -35,7 +35,7 @@ class API::DiscussionsController < API::RestfulController
   end
 
   def visible_records
-    Queries::VisibleDiscussions.new(user: current_user, groups: current_user.groups)
+    Queries::VisibleDiscussions.new(user: current_user, groups: current_user.groups).sorted_by_latest_activity
   end
 
   private

--- a/app/extras/queries/visible_discussions.rb
+++ b/app/extras/queries/visible_discussions.rb
@@ -81,6 +81,11 @@ class Queries::VisibleDiscussions < Delegator
     self
   end
 
+  def sorted_by_latest_activity
+    @relation = @relation.order(last_activity_at: :desc)
+    self
+  end
+
   def sorted_by_latest_motions
     @relation = @relation.joined_to_current_motion
                          .preload(:current_motion, {group: :parent})


### PR DESCRIPTION
I was getting some really really old threads coming through the dashboard query; turns out we're not sorting discussions at all server side, which means we're not getting the right discussions back.