### PR TITLE
Ensure page load thread position

### DIFF
--- a/lineman/app/components/thread_page/activity_card/activity_card.coffee
+++ b/lineman/app/components/thread_page/activity_card/activity_card.coffee
@@ -47,7 +47,6 @@ angular.module('loomioApp').directive 'activityCard', ->
     $scope.threadItemVisible = (item) ->
       addSequenceId(item.sequenceId)
       $scope.discussion.markAsRead(item.sequenceId)
-      # $location.hash(_.min(visibleSequenceIds))
       $scope.loadEventsForwards($scope.lastLoadedSequenceId) if $scope.loadMoreAfterReading(item)
 
     $scope.loadEvents = ({from, per}) ->

--- a/lineman/app/components/thread_page/activity_card/activity_card.coffee
+++ b/lineman/app/components/thread_page/activity_card/activity_card.coffee
@@ -8,29 +8,23 @@ angular.module('loomioApp').directive 'activityCard', ->
     $scope.pageSize = 30
     $scope.firstLoadedSequenceId = 0
     $scope.lastLoadedSequenceId = 0
-    $scope.newActivitySequenceId = $scope.discussion.reader().lastReadSequenceId + 1
+    $scope.lastReadSequenceId = $scope.discussion.reader().lastReadSequenceId
     visibleSequenceIds = []
-    rollback = 2
 
     $scope.init = ->
       $scope.discussion.markAsRead(0)
 
-      target = _.parseInt($location.hash())
-      if target >= $scope.discussion.firstSequenceId and target < $scope.discussion.lastSequenceId 
-        # valid sequence id is specified in url
-        $scope.initialLoaded  = _.max [target - rollback, 0]
-        $scope.initialFocused = target
-      else if $scope.discussion.isUnread()
-        # discussion is unread
-        $scope.initialLoaded  = _.max [$scope.discussion.reader().lastReadSequenceId - rollback, 0]
-        $scope.initialFocused = $scope.initialLoaded + rollback
-      else
-        # discussion is read
-        $scope.initialLoaded  = _.max [$scope.discussion.lastSequenceId - $scope.pageSize + 1, 0]
-        $scope.initialFocused = _.max [$scope.discussion.lastSequenceId - rollback, 0]
+      $scope.loadEventsForwards($scope.initialLoadSequenceId()).then ->
+        $rootScope.$broadcast 'threadPageEventsLoaded'
 
-      $scope.loadEventsForwards($scope.initialLoaded).then ->
-        $rootScope.$broadcast 'threadPageEventsLoaded', $scope.initialFocused
+    $scope.initialLoadSequenceId = ->
+      if $scope.discussion.isUnread()
+        $scope.discussion.reader().lastReadSequenceId - 1
+      else
+        $scope.discussion.lastSequenceId - $scope.pageSize + 1
+
+    $scope.hasNewActivity = ->
+      $scope.discussion.isUnread()
 
     $scope.beforeCount = ->
       $scope.firstLoadedSequenceId - $scope.discussion.firstSequenceId
@@ -53,7 +47,7 @@ angular.module('loomioApp').directive 'activityCard', ->
     $scope.threadItemVisible = (item) ->
       addSequenceId(item.sequenceId)
       $scope.discussion.markAsRead(item.sequenceId)
-      $location.hash(_.min(visibleSequenceIds))
+      # $location.hash(_.min(visibleSequenceIds))
       $scope.loadEventsForwards($scope.lastLoadedSequenceId) if $scope.loadMoreAfterReading(item)
 
     $scope.loadEvents = ({from, per}) ->

--- a/lineman/app/components/thread_page/activity_card/activity_card.haml
+++ b/lineman/app/components/thread_page/activity_card/activity_card.haml
@@ -6,7 +6,7 @@
   %loading.activity-card__loading.page-loading{ng-show: 'loadEventsBackwardsExecuting'}
   %ul.activity-card__activity-list
     %li.activity-card__activity-list-item{ng_repeat: 'event in discussion.events() track by event.id', in-view: '($inview&&threadItemVisible(event)) || (!$inview&&threadItemHidden(event))', in-view-options: '{debounce: 100}'}
-      .activity-card__new-activity{ng-if: 'event.sequenceId == newActivitySequenceId', translate: 'activity_card.new_activity'}
       .activity-card__last-item{ng-if: '$last'}
       .activity-card-content{id: 'sequence-{{event.sequenceId}}', ng-include: "'generated/components/thread_page/activity_card/'+ event.kind + '.html'"}
+      .activity-card__last-read-activity{ng-if: 'event.sequenceId == lastReadSequenceId', ng-class: '{"activity-card__new-activity": hasNewActivity()}', translate: 'activity_card.new_activity'}
   %loading.activity-card__loading.page-loading{ng-show: 'loadEventsForwardsExecuting'}

--- a/lineman/app/components/thread_page/activity_card/activity_card.scss
+++ b/lineman/app/components/thread_page/activity_card/activity_card.scss
@@ -9,7 +9,14 @@
   span{text-decoration: underline;}
 }
 
+.activity-card__last-read-activity {
+  visibility: hidden; /* can't display none because scrolling won't work */
+  line-height: 0px;
+  margin: -10px 0;
+}
+
 .activity-card__new-activity {
+  visibility: visible;
   margin: 10px 0;
   padding-bottom: 0;
   border-bottom: 1px solid $loomio-orange;

--- a/lineman/app/components/thread_page/previous_proposals_card/previous_proposals_card.coffee
+++ b/lineman/app/components/thread_page/previous_proposals_card/previous_proposals_card.coffee
@@ -10,7 +10,8 @@ angular.module('loomioApp').directive 'previousProposalsCard', ->
       if target = $location.hash().match /^proposal-(\d+)$/
         if proposal = Records.proposals.find(parseInt(target[1]))
           $scope.selectProposal(proposal)
-          $rootScope.$broadcast 'threadPageProposalsLoaded', proposal.id
+          selectedProposalId = proposal.id
+      $rootScope.$broadcast 'threadPageProposalsLoaded', selectedProposalId
 
     $scope.selectedProposalId = 0
 

--- a/lineman/app/models/event_records_interface.coffee
+++ b/lineman/app/models/event_records_interface.coffee
@@ -9,6 +9,12 @@ angular.module('loomioApp').factory 'EventRecordsInterface', (BaseRecordsInterfa
           from: options['from']
           per: options['per']
 
+    findByDiscussionAndSequenceId: (discussion, sequenceId) ->
+      @collection.chain()
+                 .find(discussionId: discussion.id)
+                 .find(sequenceId: sequenceId)
+                 .data()[0] # so, turns out finding by multiple parameters doesn't actually work..
+
     minLoadedSequenceIdByDiscussion: (discussion) ->
       item = _.min @find(discussionId: discussion.id), (event) -> event.sequenceId or Number.MAX_VALUE
       item.sequenceId

--- a/lineman/spec/directives/activity_card_spec.coffee
+++ b/lineman/spec/directives/activity_card_spec.coffee
@@ -12,33 +12,3 @@ describe 'Activity Card Component', ->
     prepareDirective @, 'activity_card', { discussion: 'discussion' }, (parent) =>
       parent.discussion = @factory.create 'discussions', title: 'hi mom'
     expect(@$scope.discussion.title).toBe('hi mom')
-
-  it 'scrolls to unread when the discussion is unread', ->
-    prepareDirective @, 'activity_card', { discussion: 'discussion' }, (parent) =>
-      parent.discussion = @factory.create 'discussions', last_sequence_id: 50, salient_items_count: 50
-      @factory.create 'discussion_readers', discussion_id: parent.discussion.id, last_read_sequence_id: 40, read_salient_items_count: 40
-    expect(@$scope.initialLoaded).toBe(39) # last read, plus one (first unread) sequence id, minus 2 post rollback
-    expect(@$scope.initialFocused).toBe(41) # last read, plus one (first unread) sequence id
-
-  it 'scrolls to the end when the discussion is read', ->
-    prepareDirective @, 'activity_card', { discussion: 'discussion' }, (parent) =>
-      parent.discussion = @factory.create 'discussions', last_sequence_id: 50
-      @factory.create 'discussion_readers', discussion_id: parent.discussion.id, last_read_sequence_id: 50
-    expect(@$scope.initialLoaded).toBe(21) # one page back
-    expect(@$scope.initialFocused).toBe(50) # end of discussion 
-
-  it 'loads all thread items when under page size and read', ->
-    prepareDirective @, 'activity_card', { discussion: 'discussion' }, (parent) =>
-      parent.discussion = @factory.create 'discussions', last_sequence_id: 20
-      @factory.create 'discussion_readers', discussion_id: parent.discussion.id, last_read_sequence_id: 20
-    expect(@$scope.initialLoaded).toBe(0) # beginning of thread
-    expect(@$scope.initialFocused).toBe(20) # end of discussion, minus 2 post rollback   
-
-  # unimplemented hash for now.
-  # it 'loads a specified location in thread when location hash specifies it', ->
-  #   inject ($location) -> $location.hash('15')
-  #   prepareDirective @, 'activity_card', (parent) =>
-  #     parent.discussion = @factory.create 'discussions', last_sequence_id: 20
-  #     @factory.create 'discussion_readers', discussion_id: parent.discussion.id, last_read_sequence_id: 20
-  #   expect(@$scope.initialLoaded).toBe(13) # target post, minus 2 post rollback
-  #   expect(@$scope.initialFocused).toBe(15) # target post   

--- a/lineman/spec/directives/activity_card_spec.coffee
+++ b/lineman/spec/directives/activity_card_spec.coffee
@@ -17,27 +17,28 @@ describe 'Activity Card Component', ->
     prepareDirective @, 'activity_card', { discussion: 'discussion' }, (parent) =>
       parent.discussion = @factory.create 'discussions', last_sequence_id: 50, salient_items_count: 50
       @factory.create 'discussion_readers', discussion_id: parent.discussion.id, last_read_sequence_id: 40, read_salient_items_count: 40
-    expect(@$scope.initialLoaded).toBe(38) # last read sequence id, minus 2 post rollback
-    expect(@$scope.initialFocused).toBe(40) # last read
+    expect(@$scope.initialLoaded).toBe(39) # last read, plus one (first unread) sequence id, minus 2 post rollback
+    expect(@$scope.initialFocused).toBe(41) # last read, plus one (first unread) sequence id
 
   it 'scrolls to the end when the discussion is read', ->
     prepareDirective @, 'activity_card', { discussion: 'discussion' }, (parent) =>
       parent.discussion = @factory.create 'discussions', last_sequence_id: 50
       @factory.create 'discussion_readers', discussion_id: parent.discussion.id, last_read_sequence_id: 50
     expect(@$scope.initialLoaded).toBe(21) # one page back
-    expect(@$scope.initialFocused).toBe(48) # end of discussion, minus 2 post rollback   
+    expect(@$scope.initialFocused).toBe(50) # end of discussion 
 
   it 'loads all thread items when under page size and read', ->
     prepareDirective @, 'activity_card', { discussion: 'discussion' }, (parent) =>
       parent.discussion = @factory.create 'discussions', last_sequence_id: 20
       @factory.create 'discussion_readers', discussion_id: parent.discussion.id, last_read_sequence_id: 20
     expect(@$scope.initialLoaded).toBe(0) # beginning of thread
-    expect(@$scope.initialFocused).toBe(18) # end of discussion, minus 2 post rollback   
+    expect(@$scope.initialFocused).toBe(20) # end of discussion, minus 2 post rollback   
 
-  it 'loads a specified location in thread when location hash specifies it', ->
-    inject ($location) -> $location.hash('15')
-    prepareDirective @, 'activity_card', { discussion: 'discussion' }, (parent) =>
-      parent.discussion = @factory.create 'discussions', last_sequence_id: 20
-      @factory.create 'discussion_readers', discussion_id: parent.discussion.id, last_read_sequence_id: 20
-    expect(@$scope.initialLoaded).toBe(13) # target post, minus 2 post rollback
-    expect(@$scope.initialFocused).toBe(15) # target post   
+  # unimplemented hash for now.
+  # it 'loads a specified location in thread when location hash specifies it', ->
+  #   inject ($location) -> $location.hash('15')
+  #   prepareDirective @, 'activity_card', (parent) =>
+  #     parent.discussion = @factory.create 'discussions', last_sequence_id: 20
+  #     @factory.create 'discussion_readers', discussion_id: parent.discussion.id, last_read_sequence_id: 20
+  #   expect(@$scope.initialLoaded).toBe(13) # target post, minus 2 post rollback
+  #   expect(@$scope.initialFocused).toBe(15) # target post   


### PR DESCRIPTION

- Ensure page scroll happens after events & proposals are loaded
- Take out support for location hashes for now
- Ensure record is in clientside db before scrolling