### PR TITLE
Fixes default group logo and cover photo broken

### DIFF
--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -178,11 +178,11 @@ class Group < ActiveRecord::Base
 
   has_attached_file    :cover_photo,
                        styles: { desktop: "970x200#", card: "460x94#"},
-                       default_url: '/images/default-cover-photo.png'
+                       default_url: 'default-cover-photo.png'
 
   has_attached_file    :logo,
                        styles: { card: "67x67", medium: "100x100" },
-                       default_url: '/images/default-logo-:style.png'
+                       default_url: 'default-logo-:style.png'
 
   validates_attachment :cover_photo,
     size: { in: 0..10.megabytes },


### PR DESCRIPTION
This PR addresses #2039.

The changes I reverted were introduced by @robguthrie on 26th February. We should double check with his help why this was introduced.

Somebody: Please review.