### PR TITLE
Fix example discussions js error

### DIFF
--- a/lineman/app/components/group_page/discussions_card/discussions_card_controller.coffee
+++ b/lineman/app/components/group_page/discussions_card/discussions_card_controller.coffee
@@ -17,7 +17,7 @@ angular.module('loomioApp').controller 'DiscussionsCardController', ($scope, $mo
   KeyEventService.registerKeyEvent $scope, 'pressedT', $scope.openDiscussionForm
 
   $scope.showThreadsPlaceholder = ->
-    CurrentUser.isAdminOf($scope.group) and $scope.group.nonExampleDiscussions().length <= 1
+    CurrentUser.isAdminOf($scope.group) and $scope.group.discussions().length <= 1
 
   $scope.whyImEmpty = ->
     if !$scope.group.hasDiscussions

--- a/lineman/spec/directives/discussions_card_spec.coffee
+++ b/lineman/spec/directives/discussions_card_spec.coffee
@@ -63,8 +63,7 @@ describe 'Discussions Card Component', ->
     expect(@$scope.showThreadsPlaceholder()).toBe(true)
 
   it 'does not display a placeholder when there are multiple threads', ->
-    @factory.create 'discussions', groupId: @group.id
-    @factory.create 'discussions', groupId: @group.id
+    @factory.createMany 'discussions', { groupId: @group.id }, 2
     prepareDirective @, 'discussions_card', { group: 'group' }, (parent) =>
       parent.group = @group
     expect(@$scope.showThreadsPlaceholder()).toBe(false)

--- a/lineman/spec/helpers/factory.js
+++ b/lineman/spec/helpers/factory.js
@@ -6,6 +6,7 @@ window.useFactory = function() {
         attrs = attrs || {}
         this.currentIds[model] = this.currentIds[model] || 1
         attrs.id = this.currentIds[model] || 1;
+        attrs.key = "key" + attrs.id
         this.currentIds[model] = attrs.id + 1;
         return Records[_.camelCase(model)].initialize(_.extend(fixtures[model], attrs));
       },
@@ -42,7 +43,6 @@ window.useFactory = function() {
     },
 
     groups: {
-      key: 'fedcba',
       name: 'Venus: ...Ladies.',
       description: '',
       created_at: moment().subtract(2, 'day'),
@@ -51,7 +51,6 @@ window.useFactory = function() {
     },
 
     discussions: {
-      key: 'abcdef',
       title: 'Earth: The Most Recent Frontier',
       description: '',
       last_item_at: moment(),


### PR DESCRIPTION
This fixes the js errors when logged as a group admin on the group page

Also fixes a bug with creating multiple records with the lineman specs