### PR TITLE
Fix lmo url service specs

### DIFF
--- a/lineman/spec/services/lmo_url_service_spec.coffee
+++ b/lineman/spec/services/lmo_url_service_spec.coffee
@@ -15,16 +15,16 @@ describe 'LmoUrlService', ->
           host: 'localhost'
 
       it "handles a group without subdomain on localhost", ->
-        expect(@subject.group(@group)).toBe 'http://localhost:3000/g/key/name'
+        expect(@subject.group(@group)).toBe "http://localhost:3000/g/#{@group.key}/name"
 
       it "handles a group with subdomain on localhost", ->
         @group.updateFromJSON subdomain: 'subdomain'
-        expect(@subject.group(@group)).toBe 'http://subdomain.localhost:3000/'
+        expect(@subject.group(@group)).toBe "http://subdomain.localhost:3000/"
 
       it "handles a subgroup with subdomain on localhost", ->
         @group.updateFromJSON subdomain: 'subdomain'
         subgroup = @factory.create 'groups', parent_id: @group.id, key: 'subkey', name: 'subname'
-        expect(@subject.group(subgroup)).toBe 'http://subdomain.localhost:3000/g/subkey/name-subname'
+        expect(@subject.group(subgroup)).toBe "http://subdomain.localhost:3000/g/#{subgroup.key}/name-subname"
 
     describe 'on loom.io', ->
       beforeEach ->
@@ -34,7 +34,7 @@ describe 'LmoUrlService', ->
           ssl: true
 
       it 'handles a group without subdomain on loom.io', ->
-        expect(@subject.group(@group)).toBe 'https://loom.io/g/key/name'
+        expect(@subject.group(@group)).toBe "https://loom.io/g/#{@group.key}/name"
 
       it 'handles a group with subdomain on loom.io', ->
         @group.updateFromJSON subdomain: 'subdomain'
@@ -43,7 +43,7 @@ describe 'LmoUrlService', ->
       it 'handles a subgroup with subdomain on loom.io', ->
         @group.updateFromJSON subdomain: 'subdomain'
         subgroup = @factory.create 'groups', parent_id: @group.id, key: 'subkey', name: 'subname'
-        expect(@subject.group(subgroup)).toBe 'https://subdomain.loom.io/g/subkey/name-subname'
+        expect(@subject.group(subgroup)).toBe "https://subdomain.loom.io/g/#{subgroup.key}/name-subname"
 
     describe 'on loomio.org', ->
       beforeEach ->
@@ -52,16 +52,16 @@ describe 'LmoUrlService', ->
           default_subdomain: 'www'
 
       it 'handles a group without subdomain on loomio.org', ->
-        expect(@subject.group(@group)).toBe 'http://www.loomio.org/g/key/name'
+        expect(@subject.group(@group)).toBe "http://www.loomio.org/g/#{@group.key}/name"
 
       it 'handles a group with subdomain on loomio.org', ->
         @group.updateFromJSON subdomain: 'subdomain'
-        expect(@subject.group(@group)).toBe 'http://subdomain.loomio.org/'
+        expect(@subject.group(@group)).toBe "http://subdomain.loomio.org/"
 
       it 'handles a subgroup with subdomain on loomio.org', ->
         @group.updateFromJSON subdomain: 'subdomain'
         subgroup = @factory.create 'groups', parent_id: @group.id, key: 'subkey', name: 'subname'
-        expect(@subject.group(subgroup)).toBe 'http://subdomain.loomio.org/g/subkey/name-subname'
+        expect(@subject.group(subgroup)).toBe "http://subdomain.loomio.org/g/#{subgroup.key}/name-subname"
 
     describe 'on loomio.anotherdomain.com', ->
       beforeEach ->
@@ -70,13 +70,13 @@ describe 'LmoUrlService', ->
           default_subdomain: null
 
       it 'handles a group without subdomain on loomio.anotherdomain.com', ->
-        expect(@subject.group(@group)).toBe 'http://loomio.anotherdomain.com/g/key/name'
+        expect(@subject.group(@group)).toBe "http://loomio.anotherdomain.com/g/#{@group.key}/name"
 
       it 'handles a group with subdomain on loomio.anotherdomain.com', ->
         @group.updateFromJSON subdomain: 'subdomain'
-        expect(@subject.group(@group)).toBe 'http://subdomain.loomio.anotherdomain.com/'
+        expect(@subject.group(@group)).toBe "http://subdomain.loomio.anotherdomain.com/"
 
       it 'handles a subgroup with subdomain on loomio.anotherdomain.com', ->
         @group.updateFromJSON subdomain: 'subdomain'
         subgroup = @factory.create 'groups', parent_id: @group.id, key: 'subkey', name: 'subname'
-        expect(@subject.group(subgroup)).toBe 'http://subdomain.loomio.anotherdomain.com/g/subkey/name-subname'
+        expect(@subject.group(subgroup)).toBe "http://subdomain.loomio.anotherdomain.com/g/#{subgroup.key}/name-subname"


### PR DESCRIPTION
I dunno why these were passing then failing, but this should fix it. :heart_decoration: 