### PR TITLE
add heading and move thread actions on context card

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -63,6 +63,9 @@ en:
   proposal_collapsed:
     expand: Expand
 
+  context_card:
+    heading: Context
+
   volume_levels:
     loud: 'Loud'
     normal: 'Normal'

--- a/lineman/app/components/thread_page/thread_page.haml
+++ b/lineman/app/components/thread_page/thread_page.haml
@@ -25,7 +25,7 @@
         %star_toggle.pull-right{thread: 'threadPage.discussion'}
         .thread-notification-level.lmo-btn-wrapper
           %notification_volume_dropdown{translate-root: 'discussion', discussion: 'threadPage.discussion'}
-
+      %h2.lmo-card-heading{translate: 'context_card.heading'}
       %h1.lmo-h1#thread-context__heading{in-view: 'threadPage.showLintel(!$inview)'}
         {{threadPage.discussion.title}}
       .thread-context__details

--- a/lineman/app/components/thread_page/thread_page.scss
+++ b/lineman/app/components/thread_page/thread_page.scss
@@ -78,7 +78,7 @@
 }
 
 .thread-actions {
-  margin-bottom: 5px;
+  margin: -10px -17px 0 0;
 }
 
 .thread-item-vote-icon {


### PR DESCRIPTION
Having thread actions on the same line as the thread title looks stupid on mobile. So I've added a heading to the context card, which I have wanted to do for a while anyway, and pushed the thread actions up and to the right to make room for the thread title to have its own line. 

There's another pass to do to make this great, but this is an improvement at least.

![image](https://cloud.githubusercontent.com/assets/970124/8296597/644e2cca-19a6-11e5-95ee-5b2202bc7147.png)
