### PR TITLE
Don't fire hotkey events when ctrl/alt are pressed

### DIFF
--- a/lineman/app/services/key_event_service.coffee
+++ b/lineman/app/services/key_event_service.coffee
@@ -12,7 +12,7 @@ angular.module('loomioApp').factory 'KeyEventService', ($rootScope) ->
       40:  'pressedDownArrow'
 
     broadcast: (event) ->
-      if key = @keyboardShortcuts[event.which]
+      if !event.ctrlKey and !event.altKey and key = @keyboardShortcuts[event.which]
         $rootScope.$broadcast key, event, angular.element(document.activeElement)[0]
 
     registerKeyEvent: (scope, eventCode, execute, shouldExecute) ->


### PR DESCRIPTION
prevents the annoying 'invite modal shows up when you open chrome dev console' issue