### PR TITLE
Versioning

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,17 +1,22 @@
 #!/bin/bash
 
-if [ -z ${1+x} ]; then SOURCE_BRANCH='master'; else SOURCE_BRANCH=$1; fi
+if [ -z ${1+x} ]; then DEPLOY_TYPE='patch'; else DEPLOY_TYPE=$1; fi
+# Do we need the ability to push other branches to production? Seems _really_ dangerous to me
+# if [ -z ${1+x} ]; then SOURCE_BRANCH='master'; else SOURCE_BRANCH=$1; fi
 
 echo "building angular assets and deploying branch:"
 echo $BRANCH
 
 BUILD_BRANCH=production-$(date +%Y%m%d%H%M%S)
-git checkout $SOURCE_BRANCH
+git checkout master
+ruby script/bump_version $DEPLOY_TYPE commit
+git push origin master
+
 git checkout -b $BUILD_BRANCH
 cd lineman && npm install && bower install && lineman build && cd ..
 cp -R lineman/dist/* public/
 cp lineman/vendor/bower_components/airbrake-js/airbrake-shim.js public/js/airbrake-shim.js
-git add public/img public/css public/js public/fonts && git commit -m "production build commit" && git checkout $SOURCE_BRANCH && git push loomio-production $BUILD_BRANCH:master -f
+git add public/img public/css public/js public/fonts && git commit -m "production build commit" && git checkout master && git push loomio-production $BUILD_BRANCH:master -f
 git branch -D $BUILD_BRANCH
 heroku run rake db:migrate -a loomio-production
 heroku restart -a loomio-production

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,0 +1,7 @@
+module Loomio
+  module Version
+    def self.current
+      [MAJOR, MINOR, PATCH, PRE].reject(&:nil?).join('.')
+    end
+  end
+end

--- a/lib/version/major.rb
+++ b/lib/version/major.rb
@@ -1,0 +1,1 @@
+Loomio::Version::MAJOR = 0

--- a/lib/version/minor.rb
+++ b/lib/version/minor.rb
@@ -1,0 +1,1 @@
+Loomio::Version::MINOR = 10

--- a/lib/version/patch.rb
+++ b/lib/version/patch.rb
@@ -1,0 +1,1 @@
+Loomio::Version::PATCH = 0

--- a/lib/version/pre.rb
+++ b/lib/version/pre.rb
@@ -1,0 +1,1 @@
+Loomio::Version::PRE = nil

--- a/script/bump_version
+++ b/script/bump_version
@@ -1,0 +1,84 @@
+#!/usr/bin/env ruby
+
+usage = <<-END
+  Arguments:
+    <version_type>: The part of the version we are bumping.
+                    Valid values are major | minor | patch | pre
+    <pre_value>:    The string value to set to pre.
+                    Only used when the version_type is pre.
+    <action>:       Action to perform after making version changes.
+                    Valid values are no-commit | commit | push
+                    Default is commit
+
+  Example:
+    Bumping the version: (assuming the current version is 0.10.1)
+    (All examples assume the current version is 0.10.1)
+    ruby script/bump_version patch # => 0.10.2
+    ruby script/bump_version minor # => 0.11.0
+    ruby script/bump_version major # => 1.0.0
+
+    Setting the version prefix:
+    ruby script/bump_version pre rc1 # => 0.10.1.rc1
+
+    Do not commit changes:
+    ruby script/bump_version patch no-commit
+
+    Push changes to github:
+    ruby script/bump_version patch push
+ END
+
+if ARGV.length == 0 || ARGV.include?('--help')
+ puts usage
+ exit 1
+end
+
+version_type = ARGV[0]
+if version_type == 'pre'
+  pre_value, action = ARGV[1], ARGV[2] || 'commit'
+else
+  action = ARGV[1] || 'commit'
+end
+
+if !%w(major minor patch pre).include? version_type
+  puts "Invalid version_type; use the --help option for usage info."
+  exit 0
+end
+
+if !%w(no-commit commit push).include? action
+  puts "Invalid action; use the --help option for usage info."
+  exit 0
+end
+
+if version_type == 'pre' && pre_value.nil?
+  puts "No value for pre provided; use the --help option for usage info."
+  exit 0
+end
+
+require_relative '../lib/version'
+require_relative '../lib/version/major'
+require_relative '../lib/version/minor'
+require_relative '../lib/version/patch'
+require_relative '../lib/version/pre'
+
+puts "Current version: #{Loomio::Version.current}"
+
+def write_version(type, value)
+  file_path = File.expand_path "../../lib/version/#{type.downcase}.rb", __FILE__
+  File.open(file_path, 'w+') do |file|
+    puts "Updating #{file_path}..."
+    file.write "Loomio::Version::#{type.upcase} = #{value}"
+  end
+  load file_path
+end
+
+current_version_type = Loomio::Version.module_eval(version_type.upcase)
+if version_type == 'pre'
+  write_version 'pre', "'#{pre_value}'"
+else
+  write_version version_type, current_version_type.to_i + 1
+  write_version 'minor', 0 if %w(major).include? version_type
+  write_version 'patch', 0 if %w(major minor).include? version_type
+  write_version 'pre',   'nil'
+end
+
+puts "New version: #{Loomio::Version.current}"

--- a/script/bump_version
+++ b/script/bump_version
@@ -7,8 +7,8 @@ usage = <<-END
     <pre_value>:    The string value to set to pre.
                     Only used when the version_type is pre.
     <action>:       Action to perform after making version changes.
-                    Valid values are no-commit | commit | push
-                    Default is commit
+                    Valid values are commit | no-commit
+                    Default is no-commit
 
   Example:
     Bumping the version: (assuming the current version is 0.10.1)
@@ -20,11 +20,8 @@ usage = <<-END
     Setting the version prefix:
     ruby script/bump_version pre rc1 # => 0.10.1.rc1
 
-    Do not commit changes:
-    ruby script/bump_version patch no-commit
-
-    Push changes to github:
-    ruby script/bump_version patch push
+    Commit changes to git repo:
+    ruby script/bump_version patch commit
  END
 
 if ARGV.length == 0 || ARGV.include?('--help')
@@ -34,9 +31,9 @@ end
 
 version_type = ARGV[0]
 if version_type == 'pre'
-  pre_value, action = ARGV[1], ARGV[2] || 'commit'
+  pre_value, action = ARGV[1], ARGV[2] || 'no-commit'
 else
-  action = ARGV[1] || 'commit'
+  action = ARGV[1] || 'no-commit'
 end
 
 if !%w(major minor patch pre).include? version_type
@@ -44,7 +41,7 @@ if !%w(major minor patch pre).include? version_type
   exit 0
 end
 
-if !%w(no-commit commit push).include? action
+if !%w(no-commit commit).include? action
   puts "Invalid action; use the --help option for usage info."
   exit 0
 end
@@ -64,10 +61,8 @@ puts "Current version: #{Loomio::Version.current}"
 
 def write_version(type, value)
   file_path = File.expand_path "../../lib/version/#{type.downcase}.rb", __FILE__
-  File.open(file_path, 'w+') do |file|
-    puts "Updating #{file_path}..."
-    file.write "Loomio::Version::#{type.upcase} = #{value}"
-  end
+  File.open(file_path, 'w+') { |file| file.write "Loomio::Version::#{type.upcase} = #{value}" }
+  Loomio::Version.send :remove_const, type.upcase
   load file_path
 end
 
@@ -79,6 +74,13 @@ else
   write_version 'minor', 0 if %w(major).include? version_type
   write_version 'patch', 0 if %w(major minor).include? version_type
   write_version 'pre',   'nil'
+end
+
+if action == 'commit'
+  puts "Creating version bump commit..."
+  `git add lib/version.rb`
+  `git add lib/version`
+  `git commit -m "Bump version to #{Loomio::Version.current}"`
 end
 
 puts "New version: #{Loomio::Version.current}"


### PR DESCRIPTION
I've been thinking quite a bit about versioning recently, so I had a quick go at writing a script that'll 

Its based off of discourse's solution here:
https://github.com/discourse/discourse/blob/master/script/version_bump.rb
https://github.com/discourse/discourse/blob/master/lib/version.rb

And basically allows us to, with a single command, update the version in the app (and, soon, on github as well.)

The idea being that before (or even as) you deploy, you can tag what kind of deploy it is, update the repo and the github tag, and then push.

Usage is generally like this (current version assumed 0.10.1): 
```
ruby script/bump_version patch # => 0.10.2
ruby script/bump_version minor # => 0.11.0
ruby script/bump_version major # => 1.0.0
ruby script/bump_version rc1 # => 0.10.1.rc1
```

The script would perform one of three actions after writing the new version:

- no-commit: don't make a commit of the changes, just modify files
- commit: make a commit of the changes (and push to github and tag it?)
- deploy: make a commit of the changes and deploy them (run ./deploy.sh)

WIP, not for merging yet.