### PR TITLE
Tweak/tidy nav bar css

### DIFF
--- a/lineman/app/components/navbar/navbar.haml
+++ b/lineman/app/components/navbar/navbar.haml
@@ -14,13 +14,14 @@
       %a.btn.lmo-navbar__btn-icon.lmo-navbar__btn{href: '/groups', title: "{{ 'navbar.groups_title' | translate }}", tabindex: 3}
         %i.fa.fa-lg.fa-group>
         %span.lmo-navbar__btn-label{translate: 'navbar.groups'}
-
   .lmo-navbar__right
-    .lmo-navbar__item{role: 'search'}
-      %navbar_search
     .lmo-navbar__item
       %notifications
     .lmo-navbar__item
       %navbar_user_options
+  .lmo-navbar__right--search
+    .lmo-navbar__item{role: 'search'}
+      %navbar_search
+  .clearfix
   %thread_lintel
   %flash

--- a/lineman/app/components/navbar/navbar.scss
+++ b/lineman/app/components/navbar/navbar.scss
@@ -3,17 +3,29 @@
   background: white;
   height: $navbar-height;
   border-bottom: 1px solid $border-color;
-  padding: 2px 0px;
+  padding: 2px 5px;
   width: 100%;
   position: fixed;
 }
 
 .lmo-navbar__left{
   float: left;
+    padding: 3px 2px;
+  .fa-group {
+    font-size: 1.1em;
+  }
 }
 
 .lmo-navbar__right{
   float: right;
+  padding: 3px 2px;
+  .fa-bell-o {
+    font-size: 1.2em;
+  }
+}
+
+.lmo-navbar__right--search {
+    padding: 2px 2px 3px;
 }
 
 .lmo-navbar__center{
@@ -22,8 +34,13 @@
 
 .lmo-navbar__item{
   display: inline-block;
-  margin: 0 0 0 2px;
-  height: $navbar-height - 4px;
+  margin: 0;
+}
+
+.lmo-navbar__item {
+  .navbar-user-options .lmo-navbar__btn {
+    padding: 4px 5px;
+  }
 }
 
 .lmo-navbar__item--selected {
@@ -33,7 +50,7 @@
 
 .lmo-navbar__btn{
   line-height: 23px;
-  padding: 6px;
+  padding: 5px;
   background: transparent;
   border: none;
   &:hover, &:focus { background: $list-hover-color; }

--- a/lineman/app/components/navbar/navbar_search.scss
+++ b/lineman/app/components/navbar/navbar_search.scss
@@ -1,10 +1,17 @@
+.navbar-search {
+  padding: 0 5px;
+
+  input {
+    margin-bottom: 0px;
+  }
+}
+
 .navbar-search-input-wrapper{
   position: relative;
 }
 
 .navbar-search-input {
   position: relative;
-  top: 2px;
   background-color: $background-color;
   color: $primary-text-color;
   @media (max-width: $screen-xs-min){width: 100px;}
@@ -20,7 +27,7 @@
 
 .navbar-search-input-icon {
   position: absolute;
-  top: 13px;
+  top: 10px;
   right: 10px;
   color: $grey-on-white;
 }
@@ -42,4 +49,3 @@
 .navbar-search-list-item {
   background: white;
 }
-


### PR DESCRIPTION
Here are some changes to pretty up the nav bar
(pretty subtle, but as is just about every item has a different height)

before:
![screenshot 2015-07-13 18 19 25](https://cloud.githubusercontent.com/assets/1380820/8643738/dbafd0ee-298b-11e5-90cc-e3a566c28997.png)

after:
![screenshot 2015-07-13 18 18 46](https://cloud.githubusercontent.com/assets/1380820/8643742/e2b8d6f6-298b-11e5-9ffc-f6793fa8683f.png)

- Add left and right padding to nav-bar to be consistent with icon spacing
- Reduce size of group and bell icon so they don't spill out of their button and are visually consistent with other icons.
- Reduce padding on buttons to match left and right nav-bar padding
- Move search to it's own floating block as it breaks the right icon div on Firefox
- Remove margin form search input as it flows out of its container, reduce height and adjust icon
- All floating containers a standard 39px high
- All buttons a standard 33px high
