### PR TITLE
Form Service 2: ReFormation.

### DIFF
--- a/app/controllers/development_controller.rb
+++ b/app/controllers/development_controller.rb
@@ -283,7 +283,7 @@ class DevelopmentController < ApplicationController
   def test_subgroup
     unless @test_subgroup
       @test_subgroup = Group.create!(name: 'Johnny Utah',
-                                     parent_id: another_test_group.id, 
+                                     parent_id: another_test_group.id,
                                      visible_to: 'public')
       @test_subgroup.add_admin! patrick
     end

--- a/lineman/app/components/archive_group_form/archive_group_form.coffee
+++ b/lineman/app/components/archive_group_form/archive_group_form.coffee
@@ -1,12 +1,9 @@
 angular.module('loomioApp').factory 'ArchiveGroupForm', ->
   templateUrl: 'generated/components/archive_group_form/archive_group_form.html'
-  controller: ($scope, $rootScope, $location, group, FlashService, Records) ->
+  controller: ($scope, $rootScope, $location, group, FormService, Records) ->
     $scope.group = group
 
-    $scope.submit = ->
-      Records.groups.archive($scope.group).then ->
-        FlashService.success 'group_page.messages.archive_group_success'
-        $scope.$close()
-        $location.path "/dashboard"
-      , ->
-        $rootScope.$broadcast 'cantArchiveGroup', $scope.group
+    $scope.submit = FormService.submit $scope, $scope.group,
+      submitFn: Records.groups.archive
+      flashSuccess: 'group_page.messages.archive_group_success'
+      successCallback: -> $location.path '/dashboard'

--- a/lineman/app/components/change_password_form/change_password_form.coffee
+++ b/lineman/app/components/change_password_form/change_password_form.coffee
@@ -1,17 +1,8 @@
 angular.module('loomioApp').factory 'ChangePasswordForm', ->
   templateUrl: 'generated/components/change_password_form/change_password_form.html'
-  controller: ($scope, $rootScope, CurrentUser, Records, FlashService) ->
+  controller: ($scope, $rootScope, CurrentUser, Records, FormService) ->
     $scope.user = CurrentUser.clone()
 
-    $scope.submit = ->
-      $scope.isDisabled = true
-      Records.users.changePassword($scope.user).then ->
-        $scope.isDisabled = false
-        FlashService.success('profile_page.messages.password_changed')
-        $scope.$close()
-      , (response) ->
-        $scope.isDisabled = false
-        if response.status == 422
-          $scope.user.setErrors response.data.errors
-        else
-          $rootScope.$broadcast 'pageError', response
+    $scope.submit = FormService.submit $scope, $scope.user,
+      submitFn: Records.users.changePassword
+      flashSuccess: 'profile_page.messages.password_changed'

--- a/lineman/app/components/deactivate_user_form/deactivate_user_form.coffee
+++ b/lineman/app/components/deactivate_user_form/deactivate_user_form.coffee
@@ -1,13 +1,8 @@
 angular.module('loomioApp').factory 'DeactivateUserForm', ->
   templateUrl: 'generated/components/deactivate_user_form/deactivate_user_form.html'
-  controller: ($scope, $rootScope, $window, CurrentUser, Records) ->
+  controller: ($scope, $rootScope, $window, CurrentUser, Records, FormService) ->
     $scope.user = CurrentUser.clone()
 
-    $scope.submit = ->
-      $scope.isDisabled = true
-      Records.users.deactivate($scope.user).then ->
-        $scope.isDisabled = false
-        $window.location.reload()
-      , ->
-        $scope.isDisabled = false
-        $rootScope.$broadcast 'pageError', 'cantDeactivateUser', $scope.user
+    $scope.submit = FormService.submit $scope, $scope.user,
+      submitFn: Records.users.deactivate
+      successCallback: -> $window.location.reload()

--- a/lineman/app/components/discussion_form/discussion_form.coffee
+++ b/lineman/app/components/discussion_form/discussion_form.coffee
@@ -1,19 +1,12 @@
 angular.module('loomioApp').factory 'DiscussionForm', ->
   templateUrl: 'generated/components/discussion_form/discussion_form.html'
-  controller: ($scope, $controller, $location, discussion, CurrentUser, Records, FlashService) ->
+  controller: ($scope, $controller, $location, discussion, CurrentUser, Records, FormService) ->
     $scope.discussion = discussion.clone()
 
-    $scope.submit = ->
-      newDiscussion = $scope.discussion.isNew()
-      $scope.discussion.save().then (records) ->
-        $scope.discussion = records.discussions[0]
-        $scope.$close()
-        if newDiscussion
-          $location.path "/d/#{$scope.discussion.key}"
-          FlashService.success 'discussion_form.messages.created'
-        else
-          FlashService.success 'discussion_form.messages.updated'
-
+    actionName = if $scope.discussion.isNew() then 'created' else 'updated'
+    $scope.submit = FormService.submit $scope, $scope.discussion,
+      flashSuccess: "discussion_form.messages.#{actionName}"
+      successCallback: (response) => $location.path "/d/#{response.discussions[0].key}" if actionName == 'created'
 
     $scope.availableGroups = ->
       groups = _.filter CurrentUser.groups(), (group) ->

--- a/lineman/app/components/edit_group_form/edit_group_form.coffee
+++ b/lineman/app/components/edit_group_form/edit_group_form.coffee
@@ -1,19 +1,10 @@
 angular.module('loomioApp').factory 'EditGroupForm', ->
   templateUrl: 'generated/components/edit_group_form/edit_group_form.html'
-  controller: ($scope, $rootScope, group, FlashService, Records) ->
+  controller: ($scope, $rootScope, group, FormService, Records) ->
     $scope.group = group.clone()
 
-    $scope.submit = ->
-      $scope.group.save().then ->
-        $scope.$close()
-        FlashService.success 'edit_group_form.messages.success'
-      , (response) ->
-        console.log(response)
-        $scope.isDisabled = false
-        if response.status == 422
-          $scope.group.setErrors response.data.errors
-        else
-          $rootScope.$broadcast 'pageError', 'cantEditGroup', $scope.group
+    $scope.submit = FormService.submit $scope, $scope.group,
+      flashSuccess: 'edit_group_form.messages.success'
 
     $scope.validVisibilityOption = (value) =>
       switch value

--- a/lineman/app/components/email_settings_page/email_settings_page_controller.coffee
+++ b/lineman/app/components/email_settings_page/email_settings_page_controller.coffee
@@ -1,12 +1,10 @@
-angular.module('loomioApp').controller 'EmailSettingsPageController', (Records, FlashService, CurrentUser, $location) ->
+angular.module('loomioApp').controller 'EmailSettingsPageController', (Records, FormService, CurrentUser, $location) ->
 
   @user = CurrentUser.clone()
 
-  @submit = ->
-    @isDisabled = true
-    Records.users.updateProfile(@user).then =>
-      @user = Records.users.find(CurrentUser.id).clone()
-      $location.path "/dashboard"
-      FlashService.success('email_settings_page.messages.updated')
+  @submit = FormService.submit @, @user,
+    submitFn: Records.users.updateProfile
+    flashSuccess: 'email_settings_page.messages.updated'
+    successCallback: -> $location.path '/dashboard'
 
   return

--- a/lineman/app/components/group_page/membership_request_form/membership_request_form.coffee
+++ b/lineman/app/components/group_page/membership_request_form/membership_request_form.coffee
@@ -1,9 +1,9 @@
 angular.module('loomioApp').factory 'MembershipRequestForm', ->
   templateUrl: 'generated/components/group_page/membership_request_form/membership_request_form.html'
-  controller: ($scope, FlashService, Records, group, CurrentUser) ->
+  controller: ($scope, FormService, Records, group, CurrentUser) ->
     $scope.membershipRequest = Records.membershipRequests.build(groupId: group.id, requestorId: CurrentUser.id)
 
-    $scope.submit = ->
-      $scope.membershipRequest.save().then ->
-        $scope.$close()
-        FlashService.success('membership_request_form.messages.membership_requested', group: group.fullName())
+    $scope.submit = FormService.submit $scope, $scope.membershipRequest,
+      flashSuccess: 'membership_request_form.messages.membership_requested'
+      flashSuccessOptions:
+        group: group.fullName()

--- a/lineman/app/components/leave_group_form/leave_group_form.coffee
+++ b/lineman/app/components/leave_group_form/leave_group_form.coffee
@@ -1,16 +1,13 @@
 angular.module('loomioApp').factory 'LeaveGroupForm', ->
   templateUrl: 'generated/components/leave_group_form/leave_group_form.html'
-  controller: ($scope, $location, $rootScope, group, FlashService, CurrentUser, AbilityService) ->
+  controller: ($scope, $location, $rootScope, group, FormService, CurrentUser, AbilityService) ->
     $scope.group = group
+    $scope.membership = $scope.group.membershipFor(CurrentUser)
 
-    $scope.submit = ->
-      $scope.group.membershipFor(CurrentUser).destroy().then ->
-        FlashService.success 'group_page.messages.leave_group_success'
-        $scope.$close()
-        $location.path "/dashboard"
-      , ->
-        $rootScope.$broadcast 'pageError', 'cantDestroyMembership', group.membershipFor(CurrentUser)
-        $scope.$close()
+    $scope.submit = FormService.submit $scope, $scope.group,
+      submitFn: $scope.membership.destroy
+      flashSuccess: 'group_page.messages.leave_group_success'
+      successCallback: -> $location.path '/dashboard'
 
     $scope.canLeaveGroup = ->
-      AbilityService.canRemoveMembership($scope.group.membershipFor(CurrentUser))
+      AbilityService.canRemoveMembership($scope.membership)

--- a/lineman/app/components/profile_page/profile_page_controller.coffee
+++ b/lineman/app/components/profile_page/profile_page_controller.coffee
@@ -1,4 +1,4 @@
-angular.module('loomioApp').controller 'ProfilePageController', ($rootScope, Records, FlashService, $location, AbilityService, ModalService, ChangePictureForm, ChangePasswordForm, DeactivateUserForm) ->
+angular.module('loomioApp').controller 'ProfilePageController', ($rootScope, Records, FormService, $location, AbilityService, ModalService, ChangePictureForm, ChangePasswordForm, DeactivateUserForm) ->
   @init = ->
     @user = Records.users.find(window.Loomio.currentUserId)
   @init()
@@ -6,19 +6,10 @@ angular.module('loomioApp').controller 'ProfilePageController', ($rootScope, Rec
   @availableLocales = ->
     window.Loomio.locales
 
-  @submit = ->
-    @isDisabled = true
-    @user.setErrors()
-    Records.users.updateProfile(@user).then =>
-      @isDisabled = false
-      FlashService.success('profile_page.messages.updated')
-      @init()
-    , (response) =>
-      @isDisabled = false
-      if response.status == 422
-        @user.setErrors response.data.errors
-      else
-        $rootScope.$broadcast 'pageError', response
+  @submit = FormService.submit @, @user,
+    flashSuccess: 'profile_page.messages.updated'
+    submitFn: Records.users.updateProfile
+    successCallback: @init
 
   @changePicture = ->
     ModalService.open ChangePictureForm

--- a/lineman/app/components/proposal_form/proposal_form.coffee
+++ b/lineman/app/components/proposal_form/proposal_form.coffee
@@ -1,15 +1,8 @@
 angular.module('loomioApp').factory 'ProposalForm', ->
   templateUrl: 'generated/components/proposal_form/proposal_form.html'
-  controller: ($scope, $modalInstance, proposal, FlashService) ->
+  controller: ($scope, $modalInstance, proposal, FormService) ->
     $scope.proposal = proposal
 
-    $scope.submit = ->
-      proposal.save().then ->
-        $modalInstance.close()
-        if proposal.isNew()
-          FlashService.success 'proposal_form.messages.created'
-        else
-          FlashService.success 'proposal_form.messages.updated'
-
-    $scope.cancel = ->
-      $modalInstance.dismiss()
+    actionName = if $scope.proposal.isNew() then 'created' else 'updated'
+    $scope.submit = FormService.submit $scope, $scope.proposal,
+      flashSuccess: "proposal_form.messages.#{actionName}"

--- a/lineman/app/components/proposal_form/proposal_form.haml
+++ b/lineman/app/components/proposal_form/proposal_form.haml
@@ -1,6 +1,6 @@
 %form.proposal-form{ng-submit: 'submit()', ng-disabled: 'proposal.processing'}
   .modal-header
-    %button{type: 'button', class: 'close', ng-click: 'cancel($event)'}
+    %button{type: 'button', class: 'close', ng-click: '$close($event)'}
       %span{aria-hidden: true} &times;
       %span.sr-only{translate: 'common.action.cancel'}
     %h1.lmo-h1{ng-if: 'proposal.isNew()', translate: 'proposal_form.start_a_proposal'}
@@ -26,4 +26,4 @@
   .modal-footer
     %button.btn.btn-primary.proposal-form__start-btn{ng-if: 'proposal.isNew()', type: 'submit', translate: 'proposal_form.start_proposal'}
     %button.btn.btn-primary.proposal-form__save-changes-btn{ng-if: '!proposal.isNew()', type: 'submit', translate: 'common.action.save_changes'}
-    %button.btn.btn-warning.proposal-form__cancel-btn{ng-click: 'cancel($event)', type: 'button', translate: 'common.action.cancel'}
+    %button.btn.btn-warning.proposal-form__cancel-btn{ng-click: '$close($event)', type: 'button', translate: 'common.action.cancel'}

--- a/lineman/app/components/start_group_form/start_group_form.coffee
+++ b/lineman/app/components/start_group_form/start_group_form.coffee
@@ -1,12 +1,9 @@
 angular.module('loomioApp').factory 'StartGroupForm', ->
   templateUrl: 'generated/components/start_group_form/start_group_form.html'
-  controller: ($scope, $rootScope, $location, group, Records, LmoUrlService) ->
+  controller: ($scope, $rootScope, $location, group, Records, FormService) ->
     $scope.group = group
 
-    $scope.submit = ->
-      $scope.group.save().then (response) ->
-        $scope.$close()
-        $location.path LmoUrlService.group Records.groups.find(response.groups[0].id)
+    $scope.submit = FormService.submit $scope, $scope.group,
+      successCallback: (response) ->
+        $location.path "/g/#{response.groups[0].key}"
         $rootScope.$broadcast 'newGroupCreated'
-      , ->
-        $rootScope.$broadcast 'pageError', 'cantCreateGroup', $scope.group

--- a/lineman/app/components/thread_page/close_proposal_form/close_proposal_form.haml
+++ b/lineman/app/components/thread_page/close_proposal_form/close_proposal_form.haml
@@ -1,6 +1,6 @@
 %form.close-proposal-form{ng-submit: 'submit()', ng-disabled: 'proposal.processing'}
   .modal-header
-    %button{type: 'button', class: 'close', ng-click: 'cancel()'}
+    %button{type: 'button', class: 'close', ng-click: '$close()'}
       %span{aria-hidden: true} &times;
       %span.sr-only{translate: 'common.action.cancel'}
     %h1.lmo-h1{translate: 'close_proposal_form.close_proposal'}
@@ -10,4 +10,4 @@
 
   .modal-footer
     %button.btn.btn-primary.close-proposal-form__submit-btn{type: 'submit', translate: 'close_proposal_form.close_proposal_submit'}
-    %button.btn.btn-warning{type: 'button', ng-click: 'cancel($event)', translate: 'common.action.cancel'}
+    %button.btn.btn-warning{type: 'button', ng-click: '$close()', translate: 'common.action.cancel'}

--- a/lineman/app/components/thread_page/close_proposal_form/close_proposal_form_controller.coffee
+++ b/lineman/app/components/thread_page/close_proposal_form/close_proposal_form_controller.coffee
@@ -1,10 +1,6 @@
-angular.module('loomioApp').controller 'CloseProposalFormController', ($scope, $modalInstance, proposal, FlashService) ->
+angular.module('loomioApp').controller 'CloseProposalFormController', ($scope, FormService, proposal) ->
+  # TODO: add flash message
   $scope.proposal = proposal
 
-  $scope.submit = ->
-    $scope.proposal.close().then ->
-      $modalInstance.close()
-      FlashService.success 'close_proposal_form.messages.success'
-
-  $scope.cancel = ($event) ->
-    $modalInstance.dismiss('cancel')
+  $scope.submit = FormService.submit $scope, $scope.proposal,
+    submitFn: $scope.proposal.close

--- a/lineman/app/components/thread_page/proposal_outcome_form/proposal_outcome_form.haml
+++ b/lineman/app/components/thread_page/proposal_outcome_form/proposal_outcome_form.haml
@@ -1,6 +1,6 @@
 %form.proposal-form{ng-submit: 'submit()', ng-disabled: 'proposal.processing'}
   .modal-header
-    %button{type: 'button', class: 'close', ng-click: 'cancel($event)'}
+    %button{type: 'button', class: 'close', ng-click: '$close()'}
       %span{aria-hidden: true} &times;
       %span.sr-only{translate: 'common.action.cancel'}
     %h1.lmo-h1{ng-if: '!hasOutcome', translate: 'proposal_outcome_form.set_outcome'}
@@ -17,4 +17,4 @@
 
   .modal-footer
     %button.btn.btn-primary.proposal-outcome-form__publish-outcome-btn{type: 'submit', translate: 'proposal_outcome_form.publish_outcome'}
-    %button.btn.btn-warning.proposal-outcome-form__cancel-btn{ng-click: 'cancel($event)', type: 'button', translate: 'common.action.cancel'}
+    %button.btn.btn-warning.proposal-outcome-form__cancel-btn{ng-click: '$close()', type: 'button', translate: 'common.action.cancel'}

--- a/lineman/app/components/thread_page/proposal_outcome_form/proposal_outcome_form_controller.coffee
+++ b/lineman/app/components/thread_page/proposal_outcome_form/proposal_outcome_form_controller.coffee
@@ -1,11 +1,8 @@
-angular.module('loomioApp').controller 'ProposalOutcomeFormController', ($scope, $modalInstance, proposal, FlashService, Records) ->
+angular.module('loomioApp').controller 'ProposalOutcomeFormController', ($scope, proposal, FormService, Records) ->
   $scope.proposal = proposal.clone()
   $scope.hasOutcome = proposal.hasOutcome()
 
-  $scope.submit = ->
-    Records.proposals.createOutcome($scope.proposal).then ->
-      $modalInstance.close()
-      FlashService.success 'proposal_outcome_form.messages.created'
-
-  $scope.cancel = ->
-    $modalInstance.dismiss()
+  # TODO: set flash message successfully
+  $scope.submit = FormService.submit $scope, $scope.proposal,
+    submitFn: Records.proposals.createOutcome
+    flashSuccess: 'proposal_outcome_form.success'

--- a/lineman/app/models/base_model.coffee
+++ b/lineman/app/models/base_model.coffee
@@ -102,7 +102,7 @@ angular.module('loomioApp').factory 'BaseModel', ->
       else
         @id
 
-    save: ->
+    save: =>
       @setErrors()
       if @processing
         console.log "save returned, already processing:", @
@@ -114,7 +114,7 @@ angular.module('loomioApp').factory 'BaseModel', ->
       else
         @restfulClient.update(@keyOrId(), @serialize()).then(@saveSuccess, @saveFailure)
 
-    destroy: ->
+    destroy: =>
       @processing = true
       @restfulClient.destroy(@keyOrId()).then =>
         @processing = false

--- a/lineman/app/models/proposal_model.coffee
+++ b/lineman/app/models/proposal_model.coffee
@@ -91,7 +91,7 @@ angular.module('loomioApp').factory 'ProposalModel', (BaseModel) ->
     userHasVoted: (user) ->
       @lastVoteByUser(user)?
 
-    close: ->
+    close: =>
       @restfulClient.postMember(@id, "close")
 
     hasOutcome: ->

--- a/lineman/app/models/proposal_records_interface.coffee
+++ b/lineman/app/models/proposal_records_interface.coffee
@@ -8,13 +8,8 @@ angular.module('loomioApp').factory 'ProposalRecordsInterface', (BaseRecordsInte
           discussion_key: discussion.key
         cacheKey: "proposalsFor#{discussion.key}"
 
-    createOutcome: (proposal) ->
+    createOutcome: (proposal) =>
       @restfulClient.postMember proposal.id, "create_outcome",
-        motion:
-          outcome: proposal.outcome
-
-    createOutcome: (proposal) ->
-      @restfulClient.postMember proposal.id, "update_outcome",
         motion:
           outcome: proposal.outcome
 

--- a/lineman/app/models/user_records_interface.coffee
+++ b/lineman/app/models/user_records_interface.coffee
@@ -8,14 +8,14 @@ angular.module('loomioApp').factory 'UserRecordsInterface', (BaseRecordsInterfac
       @profileClient.onSuccess = (response) =>
         @recordStore.import(response.data)
 
-    updateProfile: (user) ->
+    updateProfile: (user) =>
       @profileClient.post 'update_profile', user.serialize()
 
-    uploadAvatar: (file) ->
+    uploadAvatar: (file) =>
       @profileClient.upload 'upload_avatar', file
 
-    changePassword: (user) ->
+    changePassword: (user) =>
       @profileClient.post 'change_password', user.serialize()
 
-    deactivate: (user) ->
+    deactivate: (user) =>
       @profileClient.post 'deactivate', user.serialize()

--- a/lineman/app/services/form_service.coffee
+++ b/lineman/app/services/form_service.coffee
@@ -1,0 +1,27 @@
+angular.module('loomioApp').factory 'FormService', ($rootScope, FlashService) ->
+  new class FormService
+
+    errorTypes =
+      400: 'badRequest'
+      401: 'unauthorizedRequest'
+      403: 'forbiddenRequest'
+      404: 'resourceNotFound'
+      422: 'unprocessableEntity'
+      500: 'internalServerError'
+
+    submit: (scope, model, options = {}) ->
+      submitFn = options.submitFn or model.save
+      ->
+        scope.isDisabled = true
+        submitFn(model).then (response) ->
+          scope.isDisabled = false
+          model.setErrors()
+          scope.$close()                                                  if typeof scope.$close == 'function'
+          options.successCallback(response)                               if typeof options.successCallback == 'function'
+          FlashService.success options.flashSuccess, options.flashOptions if options.flashSuccess?
+        , (response) ->
+          scope.isDisabled = false
+          model.setErrors response.data.errors if response.status == 422
+          $rootScope.$broadcast errorTypes[response.status] or 'unknownError',
+            model: model
+            response: response

--- a/lineman/spec-e2e/email_settings_spec.coffee
+++ b/lineman/spec-e2e/email_settings_spec.coffee
@@ -16,6 +16,6 @@ describe 'Email settings', ->
     expect(emailSettingsHelper.mentionedCheckbox().isSelected()).toBeTruthy()
 
   it 'redirects the user to the dashboard with flash when settings are updated', ->
-    emailSettingsHelper.updateEmailSettings()
+    emailSettingsHelper.updateEmailSettings() 
     expect(dashboardHelper.flashSection().getText()).toContain('Email settings updated')
     expect(dashboardHelper.pageHeader().getText()).toContain('Recent Threads')


### PR DESCRIPTION
Here's a first pass at a general form service:

The basic gist is we have a factory which generates a submit function, which does the following:

- Accepts a scope and a model (required)
- Accepts a method to call as a submit function (optional; model.save is the default)
- Accepts a success flash message (optional)
- Accepts a success callback, for additional stuff to do on success (like redirect to a different page; optional)
- Sets an isDisabled switch on the form once it's submitted, and takes it off once a response comes back
- Closes the modal on success, if it's a modal form
- Sets validation errors on the model for a 422 response
- Broadcasts a page error event for other error responses (bad request, resource not found, internal server error, etc.)


Be interesting to see how this holds up to spreading it through all the forms in the app; I've had a good time putting it on the user profile forms and the group forms so far.

PS: Github, no emojis in PR titles? :-1: 