### PR TITLE
adjust spacing so layout doesnt break on iphone5

### DIFF
--- a/lineman/app/components/thread_page/position_buttons_panel/position_buttons_panel.scss
+++ b/lineman/app/components/thread_page/position_buttons_panel/position_buttons_panel.scss
@@ -8,7 +8,7 @@
 }
 
 .position-button {
-  margin-right: 15px;
+  margin-right: 5px;
   display: inline-block;
   width: 55px;
   height: 55px;

--- a/lineman/app/components/thread_page/proposal_pie_chart/proposal_pie_chart.scss
+++ b/lineman/app/components/thread_page/proposal_pie_chart/proposal_pie_chart.scss
@@ -6,7 +6,7 @@
   @include fontSmall;
   color: $grey-on-white;
   padding-top: 16px;
-  padding-left: 32px;
+  padding-left: 20px;
   td {
     padding-bottom: 10px;
   }
@@ -17,8 +17,8 @@
 }
 
 .proposal-pie-chart__icon{
-  width: 24px;
-  height: 24px;
+  width: 18px;
+  height: 18px;
   border-width: 1px;
   border-style: solid;
   @include roundedCorners;
@@ -48,4 +48,11 @@
   margin-top: 10px;
   @include fontSmall;
   color: $grey-on-white;
+}
+
+@media (max-width: 480px) {
+  .proposal-pie-chart__legend{
+    display: block;
+    padding: 0 0 0 165px;
+  }
 }


### PR DESCRIPTION
Here is an easy little one that has been annoying me for a long time.

- decreases spacing between buttons
- reduces size of legend squares slightly
- positions legend bottom right of graph on screen less than 480px wide

before: (iphone5)
<img width="320" alt="screenshot 2015-07-15 20 30 55" src="https://cloud.githubusercontent.com/assets/1380820/8694091/7ad02084-2b30-11e5-9a5f-ebd876ef638a.png">

after: (iphone5)
<img width="322" alt="screenshot 2015-07-15 20 17 17" src="https://cloud.githubusercontent.com/assets/1380820/8694035/dff4de88-2b2f-11e5-9f13-8715d9e5eff1.png">

 after: (nexus5)
<img width="287" alt="screenshot 2015-07-15 20 18 09" src="https://cloud.githubusercontent.com/assets/1380820/8694047/007f5dae-2b30-11e5-91d7-2ae4c40ae89b.png">

after: (web)
<img width="873" alt="screenshot 2015-07-15 20 18 46" src="https://cloud.githubusercontent.com/assets/1380820/8694053/12fecac8-2b30-11e5-9fce-94ae7f8df791.png">
