### PR TITLE
Tweak/optimize navbar spacing for mobile

### DIFF
--- a/lineman/app/components/dropdown/dropdown.scss
+++ b/lineman/app/components/dropdown/dropdown.scss
@@ -103,8 +103,11 @@ li .dropdown-menu-item-label{
     position: static;
     .dropdown-menu{
       top: auto;
-      right: 0;
-      left: 0;
+      right: 0px;
+      left: 0px;
+      margin: 2px 8px;
+      min-width: 250px;
+      max-width: none;
     }
   }
 }

--- a/lineman/app/components/navbar/navbar.haml
+++ b/lineman/app/components/navbar/navbar.haml
@@ -1,5 +1,5 @@
 %header.lmo-navbar{role: 'navigation'}
-  .lmo-navbar__left
+  .lmo-navbar-item-container.lmo-navbar-item-container--left
     .lmo-navbar__item{ng-class: '{"lmo-navbar__item--selected": selected == "dashboardPage"}'}
       %a.btn.lmo-navbar__btn.lmo-navbar__btn-icon{href: '/dashboard', title: "{{ 'navbar.recent_title' | translate }}", tabindex: 1, ng-click: 'homePageClicked()'}
         %i.fa.fa-lg.fa-clock-o>
@@ -14,14 +14,13 @@
       %a.groups-item.btn.lmo-navbar__btn-icon.lmo-navbar__btn{href: '/groups', title: "{{ 'navbar.groups_title' | translate }}", tabindex: 3}
         %i.fa.fa-lg.fa-group>
         %span.lmo-navbar__btn-label{translate: 'navbar.groups'}
-  .lmo-navbar__right
-    .lmo-navbar__item
-      %notifications
-    .lmo-navbar__item
-      %navbar_user_options
-  .lmo-navbar__right--search
-    .lmo-navbar__item{role: 'search'}
-      %navbar_search
-  .clearfix
-  %thread_lintel
+  .lmo-navbar-item-container.lmo-navbar-item-container--right
+    .lmo-navbar-item-container__sub.lmo-navbar-item-container__sub--left
+      .lmo-navbar__item{role: 'search'}
+        %navbar_search
+    .lmo-navbar-item-container__sub.lmo-navbar-item-container__sub--right
+      .lmo-navbar__item.lmo-navbar__item--notifications
+        %notifications
+      .lmo-navbar__item.lmo-navbar__item--user
+        %navbar_user_options
   %flash

--- a/lineman/app/components/navbar/navbar.scss
+++ b/lineman/app/components/navbar/navbar.scss
@@ -2,39 +2,38 @@
   @include box_shadow(2);
   z-index: 1000;
   background: white;
-  height: $navbar-height;
   border-bottom: 1px solid $border-color;
-  padding: 0;
+  padding: 0 6px;
   width: 100%;
   position: fixed;
 }
 
-.lmo-navbar__left{
-  float: left;
-    padding: 0 2px;
+.lmo-navbar-item-container{
+  display: inline-block;
   .fa-group {
     font-size: 1.1em;
   }
-}
 
-.lmo-navbar__right{
-  float: right;
-  padding: 0 2px;
   .fa-bell-o {
     font-size: 1.2em;
   }
+
   .fa-bell {
     font-size: 1.2em;
   }
 }
 
-.lmo-navbar__right--search {
-  float: right;
-  padding: 0px 2px 3px;
+.lmo-navbar-item-container--left{
+  width: 42%;
 }
 
-.lmo-navbar__center{
-  text-align: center
+.lmo-navbar-item-container--right{
+  text-align: right;
+  width: 58%;
+}
+
+.lmo-navbar-item-container__sub{
+  display: inline-block;
 }
 
 .lmo-navbar__item{
@@ -42,15 +41,15 @@
   margin: 0;
 }
 
-.lmo-navbar__item {
-  .navbar-user-options .lmo-navbar__btn {
-    padding: 9px 6px 10px;
-  }
-}
-
 .lmo-navbar__item--selected {
   border-bottom: 4px solid $loomio-orange;
   a{ color: $primary-text-color; }
+}
+
+.lmo-navbar__item--user {
+  .lmo-navbar__btn{
+    padding: 9px 8px 10px;
+  }
 }
 
 .lmo-navbar__btn{
@@ -93,4 +92,42 @@
   color: white;
   line-height: 5px;
   text-align: center;
+}
+
+@media (max-width: 480px) {
+  .lmo-navbar-item-container--left{
+    width: 39%;
+    .lmo-navbar__item {
+      width: 33%;
+      display: inline-block;
+      text-align: center;
+    }
+  }
+
+  .lmo-navbar-item-container--right{
+    width: 61%;
+
+    .lmo-navbar-item-container__sub--left{
+      width: 59%;
+    }
+
+    .lmo-navbar-item-container__sub--right{
+      text-align: center;
+      width: 41%;
+    }
+
+    .lmo-navbar__item--notifications {
+      width: 50%;
+      .lmo-navbar__btn{
+        padding: 10px 5px 11px;
+      }
+    }
+
+    .lmo-navbar__item--user {
+      width: 50%;
+      .lmo-navbar__btn{
+        padding: 9px 6px 10px;
+      }
+    }
+  }
 }

--- a/lineman/app/components/navbar/navbar_search.scss
+++ b/lineman/app/components/navbar/navbar_search.scss
@@ -1,5 +1,5 @@
 .navbar-search {
-  padding: 5px;
+  padding: 4px 5px;
 
   input {
     margin-bottom: 0px;
@@ -14,7 +14,7 @@
   position: relative;
   background-color: $background-color;
   color: $primary-text-color;
-  @media (max-width: $screen-xs-min){width: 100px;}
+  /*@media (max-width: $screen-xs-min){width: 100px;}*/
   @media (min-width: $screen-xs-min){width: 250px;}
 }
 
@@ -37,10 +37,10 @@
   position: absolute;
   background-color: white;
 
-  top: 42px;
+  top: $navbar-height;
   text-align: left;
   max-width: 320px;
-  width: 100%;
+  margin-top: 2px;
   box-shadow: 5px 5px 10px #ccc;
   overflow-y: scroll;
   max-height: 800px;
@@ -48,4 +48,18 @@
 
 .navbar-search-list-item {
   background: white;
+}
+
+@media (max-width: 480px) {
+  .navbar-search-input{
+    width: 100%;
+  }
+
+  .navbar-search-results {
+    right: 0px;
+    left: 0px;
+    margin: 2px 8px;
+    min-width: 250px;
+    max-width: none;
+  }
 }

--- a/lineman/app/components/thread_lintel/thread_lintel.coffee
+++ b/lineman/app/components/thread_lintel/thread_lintel.coffee
@@ -4,7 +4,7 @@ angular.module('loomioApp').directive 'threadLintel', ->
   replace: true
   controller: ($scope, CurrentUser, ScrollService) ->
     $scope.show = ->
-      $scope.scrolled && $scope.currentComponent == 'threadPage' && $scope.discussion
+      $scope.showLintel && $scope.discussion
 
     $scope.scrollToThread = ->
       ScrollService.scrollTo 'h1:first'
@@ -19,7 +19,7 @@ angular.module('loomioApp').directive 'threadLintel', ->
       $scope.discussion = discussion
 
     $scope.$on 'showThreadLintel', (event, bool) ->
-      $scope.scrolled = bool
+      $scope.showLintel = bool
 
     $scope.$on 'proposalInView', (event, bool) ->
       $scope.proposalInView = bool
@@ -31,4 +31,3 @@ angular.module('loomioApp').directive 'threadLintel', ->
       $scope.position = position
       $scope.discussion = discussion
       $scope.positionPercent = (position / discussion.lastSequenceId) *100
-

--- a/lineman/app/components/thread_lintel/thread_lintel.haml
+++ b/lineman/app/components/thread_lintel/thread_lintel.haml
@@ -1,11 +1,12 @@
-.thread-lintel{ng-if: 'show()'}
-  .thread-lintel__left{ng-class: "{'lmo-width-75': !proposalButtonInView}"}
-    .lmo-truncate.thread-lintel__title{ng-click: 'scrollToThread()'} {{ discussion.title }}
-    .lmo-truncate.thread-lintel__proposal{ng-if: 'discussion.activeProposal() && !proposalInView', ng-click: 'scrollToProposal()'}
-      %pie_chart.thread-lintel__proposal-pie-chart.pie-chart--tiny{votes: 'discussion.activeProposal().voteCounts'}
-      %span {{ discussion.activeProposal().name }}
-  .thread-lintel__right{ng-if: '!discussion.activeProposal() && !proposalButtonInView'}
-    %start_proposal_button.hidden-xs{discussion: 'discussion'}
+.thread-lintel__wrapper{ng-if: 'show()'}
+  .thread-lintel__content
+    .thread-lintel__left{ng-class: "{'lmo-width-75': !proposalButtonInView}"}
+      .lmo-truncate.thread-lintel__title{ng-click: 'scrollToThread()'} {{ discussion.title }}
+      .lmo-truncate.thread-lintel__proposal{ng-if: 'discussion.activeProposal() && !proposalInView', ng-click: 'scrollToProposal()'}
+        %pie_chart.thread-lintel__proposal-pie-chart.pie-chart--tiny{votes: 'discussion.activeProposal().voteCounts'}
+        %span {{ discussion.activeProposal().name }}
+    .thread-lintel__right{ng-if: '!discussion.activeProposal() && !proposalButtonInView'}
+      %start_proposal_button.hidden-xs{discussion: 'discussion'}
 
-  .thread-lintel__progress-wrap.thread-lintel__progress
-    .thread-lintel__progress-bar.thread-lintel__progress{style: 'width: {{positionPercent}}%'}
+    .thread-lintel__progress-wrap.thread-lintel__progress
+      .thread-lintel__progress-bar.thread-lintel__progress{style: 'width: {{positionPercent}}%'}

--- a/lineman/app/components/thread_lintel/thread_lintel.scss
+++ b/lineman/app/components/thread_lintel/thread_lintel.scss
@@ -1,10 +1,18 @@
-.thread-lintel {
-  margin: 0 auto;
-  border: 1px solid $border-color;
-  max-width: $main-max-width;
-  background-color: $card-background-color;
+.thread-lintel__wrapper {
   @include fontMedium;
+  position: fixed;
+  top: $navbar-height;
+  left: 0;
+  width: 100% ;
+}
+
+.thread-lintel__content {
+  @include box_shadow(1);
+  border: 1px solid $border-color;
+  background-color: $card-background-color;
   clear: both;
+  margin: 0 auto;
+  max-width: $main-max-width;
 }
 
 .thread-lintel__left {
@@ -51,4 +59,10 @@
   left: 0;
   position: absolute;
   top: 0;
+}
+
+@media (max-width: 480px) {
+  .thread-lintel__content {
+    margin: 0 10px;
+  }
 }

--- a/lineman/app/components/thread_page/thread_page.haml
+++ b/lineman/app/components/thread_page/thread_page.haml
@@ -52,3 +52,5 @@
 
     %activity_card{discussion: 'threadPage.discussion'}
     %comment_form{comment: 'threadPage.comment'}
+
+    %thread_lintel


### PR DESCRIPTION
#### Not ready for merge - broken lintel style ####

I decided to redo the navbar as I wasn't happy with the spacing on my iphone5

This PR optimises the navbar spacing on mobiles,  it now uses percentage widths instead of the floats.
- on mobile it gives more space for fat fingers to change nav filters
- on mobile it spreads search input to fill unused space
- keeps every nav item equally spaced across mobile devises
- fixes search dropdown positioning as it was half of the screen and at a different y-pos
- gives all nav dropdowns a consistent width and position.

before: iphone 6
<img width="302" alt="screenshot 2015-07-18 15 41 04" src="https://cloud.githubusercontent.com/assets/1380820/8760247/d76b8b18-2d64-11e5-83a1-b7b7d3989c79.png">

after: S4
<img width="289" alt="s4" src="https://cloud.githubusercontent.com/assets/1380820/8760273/a4339050-2d65-11e5-82c6-805638d5c00a.png">


after: iphone 5
<img width="321" alt="iphone 5" src="https://cloud.githubusercontent.com/assets/1380820/8760262/264b3ba2-2d65-11e5-87c6-95f3da03286d.png">

after: web
<img width="802" alt="web" src="https://cloud.githubusercontent.com/assets/1380820/8760264/3c9bbc7e-2d65-11e5-9ce9-67327249492a.png">



