### PR TITLE
add loomio 1.0 progress bars to /translation

### DIFF
--- a/app/assets/stylesheets/unstructured/_pages.scss
+++ b/app/assets/stylesheets/unstructured/_pages.scss
@@ -537,7 +537,7 @@ body.pages.translation {
     margin-bottom: 10px;
   }
   p.code { padding-left: 16px; }
-  td { padding: 5px 15px; }
+  td, th { padding: 5px 15px; }
 
   .progress {
     height: 5px;
@@ -545,6 +545,9 @@ body.pages.translation {
     margin: 0;
     border-radius: 0;
   }
+
+  th.beta-translation { color: #A9A9A9; }
+  .progress-bar.beta-translation { background-color: #A9A9A9; }
 
   tr.spacer-row {
     background-color: $lighter-grey;

--- a/app/views/pages/translation.html.haml
+++ b/app/views/pages/translation.html.haml
@@ -9,6 +9,13 @@
 
         %h2 Supported languages (#{selectable_locales.count})
         %table.code
+          %tr
+            %th Language
+            %th Loomio 1.0
+            %th.beta-translation Loomio Beta (old)
+            %th Code
+            %th English name
+
           - selectable_locales.each_with_index do |locale, index|
             %tr
               %td= link_to locale_name(locale), root_path(locale: locale)
@@ -16,9 +23,15 @@
               %td
                 -if coverage
                   -coverage.each do |resource, percentage|
-                    -if resource == 'main'
+                    -if resource == 'main_1_0'
                       .progress
                         .progress-bar{role: 'progressbar', 'aria-valuenow': percentage, 'aria-valuemin': 0, 'aria-valuemax': 100, style: "width:#{percentage}%"}
+              %td
+                -if coverage
+                  -coverage.each do |resource, percentage|
+                    -if resource == 'main'
+                      .progress
+                        .progress-bar.beta-translation{role: 'progressbar', 'aria-valuenow': percentage, 'aria-valuemin': 0, 'aria-valuemax': 100, style: "width:#{percentage}%"}
               %td= locale
               %td= t(locale)
 
@@ -31,9 +44,15 @@
               %td
                 -if coverage
                   -coverage.each do |resource, percentage|
-                    -if resource == 'main'
+                    -if resource == 'main_1_0'
                       .progress
                         .progress-bar{role: 'progressbar', 'aria-valuenow': percentage, 'aria-valuemin': 0, 'aria-valuemax': 100, style: "width:#{percentage}%"}
+              %td
+                -if coverage
+                  -coverage.each do |resource, percentage|
+                    -if resource == 'main'
+                      .progress
+                        .progress-bar.beta-translation{role: 'progressbar', 'aria-valuenow': percentage, 'aria-valuemin': 0, 'aria-valuemax': 100, style: "width:#{percentage}%"}
               %td= locale
               %td= t(locale)
 

--- a/config/locales/language_names.en.yml
+++ b/config/locales/language_names.en.yml
@@ -38,6 +38,7 @@ en:
   fi: Finnish
   gl: Galician
   'ga-IE': Gaelic (Ireland)
+  hi: Hindi
   km: Khmer
   lv: Latvian
   mk: Macedonian

--- a/config/locales/native_language_names.yml
+++ b/config/locales/native_language_names.yml
@@ -46,6 +46,7 @@ en:
     fi: Suomen kieli
     gl: galego
     'ga-IE': Gaeilge
+    hi: हिन्दी
     km: ភាសាខ្មែរ
     lv: latviešu valoda
     mk: Македонски јазик


### PR DESCRIPTION
adds table headers, and allows translators to see progress of new 1.0 translations:

![selection_313](https://cloud.githubusercontent.com/assets/2665886/8760450/35b94988-2d71-11e5-8460-f06b8d3b7c62.png)
