### PR TITLE
add dropdown arrows via mixin

### DIFF
--- a/lineman/app/components/mixins.scss
+++ b/lineman/app/components/mixins.scss
@@ -163,7 +163,6 @@ $cardPaddingSize: 15px;
 }
 
 @mixin box_shadow ($level) {
-
   @if $level == 1 {
     box-shadow: 0 1px 3px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.24);
   } @else if $level == 2 {
@@ -175,7 +174,6 @@ $cardPaddingSize: 15px;
   } @else if $level == 5 {
     box-shadow: 0 19px 38px rgba(0,0,0,0.30), 0 15px 12px rgba(0,0,0,0.22);
   }
-
 }
 
 @mixin displayFlex {
@@ -186,6 +184,42 @@ $cardPaddingSize: 15px;
   display: -webkit-flex;
 }
 
+@mixin dropdown_arrow($left) {
+  /* NOTE: $left is used as a percentage here */
+    border-width: 11px;
+    border-bottom-color: rgba(0, 0, 0, 0.25);
+    right: 45%;
+    top: -22px;
+  }
+
+  .dropdown-arrow::before {
+    position: absolute;
+    display: block;
+    width: 0;
+    height: 0;
+    border-color: transparent;
+    border-style: solid;
+    border-bottom-color: #cccccc;
+    left: 50%;
+    top: -21px;
+    border-width: 10px;
+    content: "";
+  }
+
+  .dropdown-arrow::after {
+    position: absolute;
+    display: block;
+    width: 0;
+    height: 0;
+    border-color: transparent;
+    border-style: solid;
+    border-bottom-color: white;
+    left: 50%;
+    top: -20px;
+    border-width: 10px;
+    content: "";
+  }
+}
 
 #turn-off-angular {
   z-index: 100;

--- a/lineman/app/components/navbar/navbar.scss
+++ b/lineman/app/components/navbar/navbar.scss
@@ -55,6 +55,10 @@
   }
 }
 
+.user-options-dropdown, .notifications__dropdown {
+  @include dropdown_arrow(90%);
+}
+
 .lmo-navbar__item--user {
   .lmo-navbar__btn{
     padding: 6px;
@@ -124,31 +128,39 @@
 
   .lmo-navbar-item-container--right{
     width: 61%;
+  }
 
-    .lmo-navbar-item-container__sub--left{
-      width: 59%;
-    }
+  .lmo-navbar-item-container__sub--left{
+    width: 59%;
+  }
 
-    .lmo-navbar-item-container__sub--right{
-      text-align: center;
-      width: 41%;
-    }
+  .lmo-navbar-item-container__sub--right{
+    text-align: center;
+    width: 41%;
+  }
 
-    .lmo-navbar__item--notifications {
-      width: 50%;
-      .lmo-navbar__btn{
-        padding: 10px 5px 11px;
-      }
+  .lmo-navbar__item--notifications {
+    width: 50%;
+    .lmo-navbar__btn{
+      padding: 10px 5px 11px;
     }
+  }
 
-    .lmo-navbar__item--user {
-      width: 50%;
-      .lmo-navbar__btn{
-        padding: 5px 5px 3px;
-      }
-      .user-avatar {
-        display: inline-block;
-      }
+  .notifications__dropdown {
+    @include dropdown_arrow(79%);
+  }
+
+  .lmo-navbar__item--user {
+    width: 50%;
+    .lmo-navbar__btn{
+      padding: 5px 5px 3px;
     }
+    .user-avatar {
+      display: inline-block;
+    }
+  }
+
+  .user-options-dropdown {
+    @include dropdown_arrow(92%);
   }
 }

--- a/lineman/app/components/navbar/navbar_user_options.haml
+++ b/lineman/app/components/navbar/navbar_user_options.haml
@@ -4,6 +4,7 @@
       .sr-only{translate: 'navbar.user_options.label'}
       %user_avatar{user: 'currentUser', size: 'small'}
     .dropdown-menu.dropdown-menu-right.user-options-dropdown.dropdown-menu-with-icons
+      .dropdown-arrow
       %ul.dropdown-menu-items
         %li.dropdown-menu-item
           %a.navbar-user-options__profile-link{href: '/profile'}

--- a/lineman/app/components/notifications/notifications.haml
+++ b/lineman/app/components/notifications/notifications.haml
@@ -5,6 +5,7 @@
     %span.badge.notifications__activity{ng-if: 'unread()'}
       {{unreadCount()}}
   .dropdown-menu.dropdown-menu-right.dropdown-menu-with-selector-list.notifications__dropdown{role: 'menu'}
+    .dropdown-arrow
     .navbar-notifications
       %ul.selector-list
         %li.selector-list-header{translate: "notifications.header", role: 'heading'}


### PR DESCRIPTION
Here is some more pretty :lips: 

https://trello.com/c/pAcsh2JU/567-add-arrows-to-dropdowns-via-mixin

Arrows added to the notification and user dropdowns.
Made a mixin so feel free to use it. 
I will add this to the search when someone gets around to fixing the it. It's a little more difficult at the mo.

Tested: Crome(Mac) Firefox(Mac), S4, iPhone5,6+ portrait and landscape. (although I need to tweak the nav in general in lanscape on small devices)


Before:
<img width="321" alt="screenshot 2015-07-22 22 40 14" src="https://cloud.githubusercontent.com/assets/1380820/8823684/f9822cd2-30c2-11e5-8d4d-c5df8c866228.png">

After:
<img width="322" alt="screenshot 2015-07-22 22 40 44" src="https://cloud.githubusercontent.com/assets/1380820/8823693/188a7e2c-30c3-11e5-9a75-821fcea60280.png">
<img width="321" alt="screenshot 2015-07-22 22 39 48" src="https://cloud.githubusercontent.com/assets/1380820/8823696/1f2a0950-30c3-11e5-8fa5-f42060bb8866.png">