### PR TITLE
fix for landscape

### DIFF
--- a/lineman/app/components/navbar/navbar.scss
+++ b/lineman/app/components/navbar/navbar.scss
@@ -94,13 +94,22 @@
   text-align: center;
 }
 
-@media (max-width: 480px) {
+@media (max-width: 767px) {
+  .lmo-navbar__item {
+    display: inline-block;
+    text-align: center;
+    .lmo-navbar__btn {
+      width: 100%;
+      &:hover, &:focus {
+        background: $list-hover-color;
+      }
+    }
+  }
+
   .lmo-navbar-item-container--left{
     width: 39%;
     .lmo-navbar__item {
       width: 33%;
-      display: inline-block;
-      text-align: center;
     }
   }
 
@@ -126,7 +135,10 @@
     .lmo-navbar__item--user {
       width: 50%;
       .lmo-navbar__btn{
-        padding: 6px;
+        padding: 5px 5px 3px;
+      }
+      .user-avatar {
+        display: inline-block;
       }
     }
   }

--- a/lineman/app/components/navbar/navbar_search.scss
+++ b/lineman/app/components/navbar/navbar_search.scss
@@ -47,7 +47,7 @@
   background: white;
 }
 
-@media (max-width: 480px) {
+@media (max-width: 767px) {
   .navbar-search-input{
     width: 100%;
   }


### PR DESCRIPTION
- Extend navbar auto centring icons for landscape phone and portrait tablet
- Expand button link to fill .lmo-navbar__item container so it looks prettier.

Before:
<img width="455" alt="screenshot 2015-07-24 21 29 33" src="https://cloud.githubusercontent.com/assets/1380820/8871772/e9be622c-324b-11e5-999d-c8652d969db2.png">

After:
<img width="457" alt="screenshot 2015-07-24 21 29 01" src="https://cloud.githubusercontent.com/assets/1380820/8871781/f811281e-324b-11e5-958c-088052f7911c.png">
