### PR TITLE
general polish

### DIFF
--- a/lineman/app/components/dashboard_page/dashboard_page.scss
+++ b/lineman/app/components/dashboard_page/dashboard_page.scss
@@ -4,7 +4,7 @@
 }
 
 .dashboard-page__heading{
-  margin: 20px 0;
+  margin: 20px 0 20px 13px;
 }
 
 .dashboard-page__options{
@@ -14,10 +14,12 @@
 .dashboard-page__date-range{
   @include fontSmall;
   color: $grey-on-grey;
+  margin-left: 13px;
 }
 
 .dashboard-page__no-threads {
   text-align: center;
+  margin-left: 13px;
 }
 
 .dashboard-page__footer {

--- a/lineman/app/components/groups_page/groups_page.haml
+++ b/lineman/app/components/groups_page/groups_page.haml
@@ -1,13 +1,10 @@
 .container.main-container
   %main.groups-page
     .row.groups-page__heading
-      .col-xs-8
-        %h1.lmo-h1-medium{translate: 'groups_page.page_header'}
-      .col-xs-4
-        %a.btn.btn-success.groups-page__new-group{ng-click: 'groupsPage.startGroup()', href: '#'}
-          %i.fa.fa-lg.fa-plus{aria-hidden: 'true'}>
-          %span{translate: 'navbar.user_options.new_group'}
-
+      %h1.lmo-h1-medium{translate: 'groups_page.page_header'}
+      %a.btn.btn-success.groups-page__new-group{ng-click: 'groupsPage.startGroup()', href: '#'}
+        %i.fa.fa-lg.fa-plus{aria-hidden: 'true'}>
+        %span{translate: 'navbar.user_options.new_group'}
     .groups-page__groups
       %section.groups-page__group{ng-repeat: 'group in groupsPage.groups() | orderBy: "name" track by group.id', aria-labelledby: '{{::group.key}}'}
         .groups-page__group-header.clearfix

--- a/lineman/app/components/groups_page/groups_page.scss
+++ b/lineman/app/components/groups_page/groups_page.scss
@@ -4,8 +4,10 @@
 }
 
 .groups-page__heading{
-  margin-top: 20px;
-  margin-bottom: 20px;
+  margin: 20px 13px;
+  h1 {
+    float: left;
+  }
 }
 
 .groups-page__new-group{

--- a/lineman/app/components/inbox_page/inbox_page.scss
+++ b/lineman/app/components/inbox_page/inbox_page.scss
@@ -4,7 +4,11 @@
 }
 
 .inbox-page__heading{
-  margin: 20px 0;
+  margin: 20px 13px;
+}
+
+.inbox-page__no-threads {
+  margin-left: 13px;
 }
 
 .inbox-page__group-name a{

--- a/lineman/app/components/mixins.scss
+++ b/lineman/app/components/mixins.scss
@@ -118,7 +118,7 @@ $block-border-color: darken($block-color, 10%);
   @include roundedCorners;
   @include box_shadow(1);
   border: 1px solid $border-color;
-  padding: 17px 17px;
+  padding: 17px;
   background: #fff;
   margin-bottom: 8px;
   i{ color: $grey-on-white; }

--- a/lineman/app/components/thread_page/comment_form/comment_form.haml
+++ b/lineman/app/components/thread_page/comment_form/comment_form.haml
@@ -11,8 +11,8 @@
         {{attachment.formattedFilesize()}}
       %a.close.remove-upload{href: '', ng_click: 'removeAttachment(attachment)', title: "{{ 'comment_form.attachments.remove_attachment' | translate }}"}
         %span{aria-hidden: 'true'}&times;
-    .thread-comment-form-actions.clearfix
-      %button.btn.btn-default.btn-primary.pull-left.submit.comment-form__submit-button{type: 'submit', translate: 'comment_form.submit_button.label'}
-      %button.btn.btn-default.pull-left.comment-form-button{translate: 'comment_form.cancel_reply', ng-show: 'comment.parentId', ng-click: 'comment.parentId = null'}
-      %attachment_form.pull-left{comment: 'comment'}
-      %button#post-comment-cancel.btn.btn-default.pull-right{type: 'button', translate: 'common.action.cancel', ng-click: 'cancel($event)', ng-hide: 'comment.isNew()'}
+    .thread-comment-form-actions
+      %button.btn.btn-default.btn-primary.submit.comment-form__submit-button{type: 'submit', translate: 'comment_form.submit_button.label'}
+      %button.btn.btn-default.comment-form-button{translate: 'comment_form.cancel_reply', ng-show: 'comment.parentId', ng-click: 'comment.parentId = null'}
+      %attachment_form{comment: 'comment'}
+      %button#post-comment-cancel.btn.btn-default{type: 'button', translate: 'common.action.cancel', ng-click: 'cancel($event)', ng-hide: 'comment.isNew()'}

--- a/lineman/app/components/thread_page/comment_form/comment_form.scss
+++ b/lineman/app/components/thread_page/comment_form/comment_form.scss
@@ -17,7 +17,8 @@
 }
 
 .comment-form-attachments{
-  display: inline;
+  display: inline-block;
+  margin-left: 10px;
 }
 
 .thread-comment-form-actions {

--- a/lineman/app/components/thread_page/position_buttons_panel/position_buttons_panel.scss
+++ b/lineman/app/components/thread_page/position_buttons_panel/position_buttons_panel.scss
@@ -8,6 +8,7 @@
 }
 
 .position-button {
+  @include box_shadow(1);
   margin-right: 5px;
   display: inline-block;
   width: 55px;

--- a/lineman/app/components/thread_page/thread_page.haml
+++ b/lineman/app/components/thread_page/thread_page.haml
@@ -13,19 +13,20 @@
           {{threadPage.group.name}}
 
     %section.thread-context{aria-labelledby: "thread-context__heading"}
-      .thread-actions.lmo-btn-group.lmo-btn-group-right
-        .lmo-btn-wrapper.dropdown{ng-if: 'threadPage.showContextMenu()'}
+      %h2.lmo-card-heading{translate: 'context_card.heading'}
+      .thread-actions.lmo-btn-group.pull-right
+        .thread-notification-level.lmo-btn-wrapper
+          %notification_volume_dropdown{translate-root: 'discussion', discussion: 'threadPage.discussion'}
+        %star_toggle{thread: 'threadPage.discussion'}
+        %span.lmo-btn-wrapper.dropdown{ng-if: 'threadPage.showContextMenu()'}
           %button.btn.lmo-btn-nude.dropdown-toggle{href:''}
             .sr-only{translate: 'thread_context.thread_options'}
-            %i.fa.fa-fw.fa-chevron-down.pull-right{aria-hidden: 'true'}
+            %i.fa.fa-fw.fa-chevron-down{aria-hidden: 'true'}
           .dropdown-menu.dropdown-menu-right
             %ul.dropdown-menu-items
               %li.dropdown-menu-item
                 %a.dropdown-menu-item-label{href: '', ng-click: 'threadPage.editDiscussion()', translate: 'common.action.edit', ng-if: 'threadPage.canEditDiscussion()'}
-        %star_toggle.pull-right{thread: 'threadPage.discussion'}
-        .thread-notification-level.lmo-btn-wrapper
-          %notification_volume_dropdown{translate-root: 'discussion', discussion: 'threadPage.discussion'}
-      %h2.lmo-card-heading{translate: 'context_card.heading'}
+      .clearfix
       %h1.lmo-h1#thread-context__heading{in-view: 'threadPage.showLintel(!$inview)'}
         {{threadPage.discussion.title}}
       .thread-context__details

--- a/lineman/app/components/thread_page/thread_page.scss
+++ b/lineman/app/components/thread_page/thread_page.scss
@@ -3,12 +3,25 @@
   max-width: $main-max-width;
 }
 
-.thread-actions { margin: -9px -17px 0 0; }
+.thread-context__heading {
+  .lmo-card-heading {
+    display: inline-block;
+  }
+}
 
-.thread-actions .star-toggle a {
-  min-width: 30px;
-  display: block;
+.thread-actions .star-toggle {
+  display: inline-block;
   text-align: center;
+  vertical-align: middle;
+  width: 30px;
+  a {
+    min-width: 30px;
+    text-align: center;
+  }
+}
+
+.thread-notification-level {
+  display: inline-block;
 }
 
 .thread-group{
@@ -28,6 +41,10 @@
 
 .thread-context{
   @include card;
+  padding-top: 10px;
+  .lmo-card-heading {
+    margin-top: 7px;
+  }
 }
 
 // hey no ids in BEM, mate

--- a/lineman/app/components/thread_preview/thread_preview.scss
+++ b/lineman/app/components/thread_preview/thread_preview.scss
@@ -36,18 +36,21 @@
 }
 
 .thread-preview__proposal-name{
-  padding-left: 2px;
-  line-height: 23px;
   color: $primary-text-color;
+  display: inline-block;
+  line-height: 23px;
+  padding-left: 2px;
 }
 
 .thread-preview__proposal-closing-at {
   @include fontSmall;
   color: $highlight-red;
+  display: inline-block;
 }
 
 .thread-preview__proposal-closing-soon {
   min-width: 160px;
+  display: inline-block;
   padding-left: 4px;
 }
 

--- a/lineman/app/components/utilities.scss
+++ b/lineman/app/components/utilities.scss
@@ -157,6 +157,7 @@ label.label-with-details{
 .lmo-card-heading{
   @include fontHelveticaMedium;
   @include fontSmall;
+  display: inline-block;
   text-transform: uppercase;
   color: $grey-on-white;
   margin-top: 0;


### PR DESCRIPTION
Sorry to keep bombarding you all with PRs.
Here is a goodie.  I've been through the entire app on chrome/firefox/safari and a few mobile devices and done all the little tweaks to make the app nice an pretty.
Most of these are just aligning to the inner card margin, which is currently done in some places and not in others.

Here is the gist:

#### Dashboard page ####
- Move heading in 13px to match padding of discussion card padding
- Move filter in 1px to match padding of discussion card padding
- Move date range headers in 13px to match discussion card padding
- Move 'no discussion message' in 13px to match discussion card padding
- Fix closing_at format wrapping in safari

#### Inbox page ####
- Move header in 13 px to match discussion card padding
- Move 'no discussion message' in 13px to match discussion card padding

#### Groups page ####
- Move header and button in 13px to match discussion card padding
- remove unnecessary col spans from html

#### Discussion page ####
- Fix the float disaster around the thread actions
- give attachment button some margin (remove floats)
- lift position buttons onto next material level
- give star some breathing space

discussion before alignment:
<img width="836" alt="screenshot 2015-07-26 10 47 26" src="https://cloud.githubusercontent.com/assets/1380820/8891594/cb942374-3384-11e5-80a0-f4db389595b3.png">

discussion after alignment:
<img width="834" alt="screenshot 2015-07-26 10 46 45" src="https://cloud.githubusercontent.com/assets/1380820/8891595/de4e34e6-3384-11e5-9084-fb968b8fda2e.png">

groups before alignment:
<img width="836" alt="screenshot 2015-07-26 10 48 17" src="https://cloud.githubusercontent.com/assets/1380820/8891602/fa6d1b42-3384-11e5-9900-ddf5d2b2c036.png">

groups after alignment:
<img width="835" alt="screenshot 2015-07-26 10 48 45" src="https://cloud.githubusercontent.com/assets/1380820/8891604/0bbbc1c8-3385-11e5-81f5-3eb022210327.png">

Safari wapping before:
<img width="1274" alt="screenshot 2015-07-26 10 11 22" src="https://cloud.githubusercontent.com/assets/1380820/8891606/3163c628-3385-11e5-91e8-341848199a1a.png">

Safari not wrapping after:
<img width="1276" alt="screenshot 2015-07-26 10 16 16" src="https://cloud.githubusercontent.com/assets/1380820/8891608/533a02f8-3385-11e5-84f7-c80f17ca1da6.png">

discussion action button floating before:
<img width="714" alt="screenshot 2015-07-26 10 50 51" src="https://cloud.githubusercontent.com/assets/1380820/8891609/7fdfcef0-3385-11e5-91b4-8418daa7966d.png">

dicussion action button without floats after:
<img width="689" alt="screenshot 2015-07-26 10 51 15" src="https://cloud.githubusercontent.com/assets/1380820/8891614/a2873c40-3385-11e5-9729-619befcd32d4.png">

comment form attachment floating before:
<img width="663" alt="screenshot 2015-07-26 10 51 52" src="https://cloud.githubusercontent.com/assets/1380820/8891617/c17c0446-3385-11e5-9aff-d972469cfc8a.png">

comment form attachment without floats after:
<img width="679" alt="screenshot 2015-07-26 10 51 29" src="https://cloud.githubusercontent.com/assets/1380820/8891618/d7f3995a-3385-11e5-960e-286f32612242.png">

position buttons before:
<img width="676" alt="screenshot 2015-07-26 11 05 31" src="https://cloud.githubusercontent.com/assets/1380820/8891630/8bb66c2e-3386-11e5-82fd-cd0947fdcbfa.png">

position buttons after:
<img width="678" alt="screenshot 2015-07-26 11 06 04" src="https://cloud.githubusercontent.com/assets/1380820/8891632/92ae6162-3386-11e5-802b-06aa6e4b692e.png">







