### PR TITLE
Dashboard shuffle (not for merging yet)

### DIFF
--- a/app/controllers/api/discussions_controller.rb
+++ b/app/controllers/api/discussions_controller.rb
@@ -3,60 +3,44 @@ class API::DiscussionsController < API::RestfulController
   load_resource only: [:create, :update]
 
   def dashboard
-    instantiate_collection { |collection| filter_collection collection }
-    respond_with_discussions
+    instantiate_collection { |collection| collection_for_dashboard collection }
+    respond_with_collection serializer: DiscussionWrapperSerializer, root: 'discussion_wrappers'
+  end
+
+  def inbox
+    instantiate_collection { |collection| collection_for_inbox collection }
+    respond_with_collection serializer: DiscussionWrapperSerializer, root: 'discussion_wrappers'
   end
 
   def index
     load_and_authorize :group if params[:group_id] || params[:group_key]
     instantiate_collection
-    respond_with_discussions
-  end
-
-  def show
-    respond_with_discussion
+    respond_with_collection serializer: DiscussionWrapperSerializer, root: 'discussion_wrappers'
   end
 
   private
-
-  def respond_with_discussion
-    if resource.errors.empty?
-      render json: DiscussionWrapper.new(discussion: resource, discussion_reader: discussion_reader),
-             serializer: DiscussionWrapperSerializer,
-             root: 'discussion_wrappers'
-    else
-      respond_with_errors
-    end
-  end
-
-  def respond_with_discussions
-    render json: DiscussionWrapper.new_collection(user: current_user, discussions: @discussions),
-           each_serializer: DiscussionWrapperSerializer,
-           root: 'discussion_wrappers'
-  end
 
   def visible_records
-    Queries::VisibleDiscussions.new(user: current_user, groups: visible_groups).sorted_by_latest_activity
+    Queries::VisibleDiscussions.new(user: current_user, groups: visible_groups)
   end
-
-  private
 
   def visible_groups
     Array(@group).presence || current_user.groups
   end
 
-  def filter_collection(collection, filter = params[:filter])
+  def collection_for_dashboard(collection, filter: params[:filter])
     case filter
-    when 'show_proposals'     then collection.not_muted.with_active_motions
-    when 'show_participating' then collection.not_muted.participating
-    when 'show_starred'       then collection.not_muted.starred
-    when 'show_muted'         then collection.muted
-    when 'show_unread'        then collection.not_muted.unread
-    else                           collection.not_muted
+    when 'show_participating' then collection.not_muted.participating.sorted_by_importance
+    when 'show_muted'         then collection.muted.sorted_by_latest_activity
+    else                           collection.not_muted.sorted_by_importance
     end
   end
 
-  def discussion_reader
-    @dr ||= DiscussionReader.for(user: current_user, discussion: @discussion)
+  def collection_for_inbox(collection)
+    collection.not_muted.unread.sorted_by_latest_activity
+  end
+
+  def collection=(value)
+    @discussions = DiscussionWrapper.new_collection user: current_user, discussions: value
   end
 end

--- a/app/controllers/api/groups_controller.rb
+++ b/app/controllers/api/groups_controller.rb
@@ -1,10 +1,6 @@
 class API::GroupsController < API::RestfulController
   load_and_authorize_resource only: :show, find_by: :key
 
-  def show
-    respond_with_resource
-  end
-
   def archive
     load_resource
     GroupService.archive(group: @group, actor: current_user)

--- a/app/controllers/api/motions_controller.rb
+++ b/app/controllers/api/motions_controller.rb
@@ -1,10 +1,6 @@
 class API::MotionsController < API::RestfulController
   load_and_authorize_resource only: [:show], find_by: :key
 
-  def show
-    respond_with_resource
-  end
-
   def close
     load_resource
     MotionService.close_by_user(@motion, current_user)
@@ -21,8 +17,8 @@ class API::MotionsController < API::RestfulController
 
   def update_outcome
     load_and_authorize(:motion, :update_outcome)
-    MotionService.update_outcome(motion: @motion, 
-                                 params: permitted_params.motion, 
+    MotionService.update_outcome(motion: @motion,
+                                 params: permitted_params.motion,
                                  actor:  current_user)
     respond_with_resource
   end

--- a/app/controllers/development_controller.rb
+++ b/app/controllers/development_controller.rb
@@ -1,4 +1,6 @@
 class DevelopmentController < ApplicationController
+  include Development::DashboardHelper
+
   around_filter :ensure_testing_environment
 
   def last_email
@@ -16,6 +18,26 @@ class DevelopmentController < ApplicationController
 
   def dashboard_url
     "http://localhost:8000/dashboard"
+  end
+
+  def inbox_url
+    "http://localhost:8000/inbox"
+  end
+
+  def setup_dashboard
+    cleanup_database
+    sign_in patrick
+    starred_proposal_discussion; proposal_discussion; starred_discussion
+    recent_discussion; old_discussion; participating_discussion; muted_discussion
+    redirect_to dashboard_url
+  end
+
+  def setup_inbox
+    cleanup_database
+    sign_in patrick
+    starred_discussion; recent_discussion group: another_test_group
+    old_discussion; muted_discussion
+    redirect_to inbox_url
   end
 
   def setup_group

--- a/app/extras/queries/visible_discussions.rb
+++ b/app/extras/queries/visible_discussions.rb
@@ -43,6 +43,14 @@ class Queries::VisibleDiscussions < Delegator
     end
   end
 
+  def join_to_starred_motions
+    unless @joined_to_starred_motions
+      join_to_discussion_readers
+      @relation = @relation.joins("LEFT OUTER JOIN motions smo ON smo.discussion_id = discussions.id AND smo.closed_at IS NULL AND dv.starred = true")
+      @joined_to_starred_motions = true
+    end
+  end
+
   def with_active_motions
     join_to_motions
     @relation = @relation.where('mo.id IS NOT NULL')
@@ -69,7 +77,7 @@ class Queries::VisibleDiscussions < Delegator
 
   def muted
     join_to_discussion_readers && join_to_memberships
-    @relation = @relation.where('(dv.volume = :mute) OR (dv.volume IS NULL AND m.volume = :mute) ', 
+    @relation = @relation.where('(dv.volume = :mute) OR (dv.volume IS NULL AND m.volume = :mute) ',
                                 {mute: DiscussionReader.volumes[:mute]})
     self
   end
@@ -86,10 +94,9 @@ class Queries::VisibleDiscussions < Delegator
     self
   end
 
-  def sorted_by_latest_motions
-    @relation = @relation.joined_to_current_motion
-                         .preload(:current_motion, {group: :parent})
-                         .order('motions.closing_at ASC, last_activity_at DESC')
+  def sorted_by_importance
+    join_to_starred_motions && join_to_motions
+    @relation = @relation.order('smo.closing_at ASC, mo.closing_at ASC, dv.starred DESC NULLS LAST, last_activity_at DESC')
     self
   end
 

--- a/app/helpers/development/dashboard_helper.rb
+++ b/app/helpers/development/dashboard_helper.rb
@@ -1,0 +1,59 @@
+module Development::DashboardHelper
+  def starred_proposal_discussion
+    create_discussion!(:starred_proposal_discussion) { |discussion| star!(discussion); add_proposal!(discussion) }
+  end
+
+  def proposal_discussion
+    create_discussion!(:proposal_discussion) { |discussion| add_proposal!(discussion) }
+  end
+
+  def starred_discussion
+    create_discussion!(:starred_discussion) { |discussion| star!(discussion) }
+  end
+
+  def participating_discussion
+    create_discussion!(:participating_discussion) { |discussion| participate!(discussion) }
+  end
+
+  def recent_discussion(group: test_group)
+    create_discussion!(:recent_discussion, group: group)
+  end
+
+  def old_discussion
+    create_discussion!(:old_discussion) { |discussion| discussion.update last_activity_at: 2.years.ago }
+  end
+
+  def muted_discussion
+    create_discussion!(:muted_discussion) { |discussion| mute!(discussion) }
+  end
+
+  private
+
+  def create_discussion!(name, group: test_group, author: patrick)
+    var_name = :"@#{name}"
+    if existing = instance_variable_get(var_name)
+      existing
+    else
+      instance_variable_set(var_name, Discussion.create!(title: name.to_s.humanize, group: group, author: author, private: false).tap do |discussion|
+        yield discussion if block_given?
+      end)
+    end
+  end
+
+  def star!(discussion, user: patrick)
+    DiscussionReader.for(discussion: discussion, user: user).update starred: true
+  end
+
+  def mute!(discussion, user: patrick)
+    DiscussionReader.for(discussion: discussion, user: user).update volume: DiscussionReader.volumes[:mute]
+  end
+
+  def participate!(discussion, user: patrick)
+    DiscussionReader.for(discussion: discussion, user: user).participate!
+  end
+
+  def add_proposal!(discussion, name: 'Test proposal', actor: jennifer)
+    MotionService.create(motion: Motion.new(name: name, closing_at: 3.days.from_now, discussion: discussion), actor: actor)
+  end
+
+end

--- a/app/serializers/discussion_serializer.rb
+++ b/app/serializers/discussion_serializer.rb
@@ -35,4 +35,5 @@ class DiscussionSerializer < ActiveModel::Serializer
     keys.delete(:active_proposal) unless object.current_motion.present?
     keys
   end
+
 end

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -562,6 +562,8 @@ en:
       you_voted: 'You voted: {{position}}.'
     threads_from:
       group: 'Threads from'
+      proposals: 'Proposals'
+      starred: 'Starred'
       today: 'Today'
       yesterday: 'Yesterday'
       thisweek: 'This week'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,8 @@ Loomio::Application.routes.draw do
 
   namespace :development do
     get 'last_email'
+    get 'setup_dashboard'
+    get 'setup_inbox'
     get 'setup_group'
     get 'setup_group_for_invitations'
     get 'setup_group_to_join'
@@ -95,6 +97,7 @@ Loomio::Application.routes.draw do
 
     resources :discussions, only: [:show, :index, :create, :update, :destroy] do
       get :dashboard, on: :collection
+      get :inbox, on: :collection
     end
 
     resources :discussion_readers, only: :update do

--- a/lineman/app/components/dashboard_page/dashboard_page.haml
+++ b/lineman/app/components/dashboard_page/dashboard_page.haml
@@ -12,63 +12,44 @@
             .dropdown-menu.dropdown-menu-with-labels.dropdown-menu-right{role: 'menu'}
               .dropdown-heading{role: 'heading', translate: 'dashboard_page.filtering.dropdown_heading'}
               %ul.dropdown-menu-items.filtering-options
-                %li.dropdown-menu-item.filtering-option
+                %li.dropdown-menu-item.filtering-option.dashboard-page__filter-recent
                   %a{href: '', ng-click: 'dashboardPage.setFilter("show_all")'}
                     .dropdown-menu-item-label
                       %span{translate: 'dashboard_page.filtering.all', aria-hidden: 'true'}>
                       %i.fa.fa-lg.fa-check{ng-show: 'dashboardPage.filter == "show_all"'}
                     .dropdown-menu-item-details{translate: 'dashboard_page.filtering.all_description'}
-                %li.dropdown-menu-item.filtering-option
-                  %a{href: '', ng-click: 'dashboardPage.setFilter("show_starred")'}
-                    .dropdown-menu-item-label
-                      %span{translate: 'dashboard_page.filtering.starred', aria-hidden: 'true'}>
-                      %i.fa.fa-lg.fa-check{ng-show: 'dashboardPage.filter == "show_starred"'}
-                    .dropdown-menu-item-details{translate: 'dashboard_page.filtering.starred_description'}
-                %li.dropdown-menu-item.filtering-option
+                %li.dropdown-menu-item.filtering-option.dashboard-page__filter-participating
                   %a{href: '', ng-click: 'dashboardPage.setFilter("show_participating")'}
                     .dropdown-menu-item-label
                       %span{translate: 'dashboard_page.filtering.participating', aria-hidden: 'true'}>
                       %i.fa.fa-lg.fa-check{ng-show: 'dashboardPage.filter == "show_participating"'}
                     .dropdown-menu-item-details{translate: 'dashboard_page.filtering.participating_description'}
-                %li.dropdown-menu-item.filtering-option
-                  %a{href: '', ng-click: 'dashboardPage.setFilter("show_proposals")'}
-                    .dropdown-menu-item-label
-                      %span{translate: 'dashboard_page.filtering.proposals', aria-hidden: 'true'}>
-                      %i.fa.fa-lg.fa-check{ng-show: 'dashboardPage.filter == "show_proposals"'}
-                    .dropdown-menu-item-details{translate: 'dashboard_page.filtering.proposals_description'}
-                %li.dropdown-menu-item.filtering-option
+                %li.dropdown-menu-item.filtering-option.dashboard-page__filter-muted
                   %a{href: '', ng-click: 'dashboardPage.setFilter("show_muted")'}
                     .dropdown-menu-item-label
                       %span{translate: 'dashboard_page.filtering.muted', aria-hidden: 'true'}>
                       %i.fa.fa-lg.fa-check{ng-show: 'dashboardPage.filter == "show_muted"'}
                     .dropdown-menu-item-details{translate: 'dashboard_page.filtering.muted_description'}
 
-
     %h1.lmo-h1-medium.dashboard-page__heading{translate: 'dashboard_page.filtering.all', ng-show: 'dashboardPage.filter == "show_all"'}
-    %h1.lmo-h1-medium.dashboard-page__heading{translate: 'dashboard_page.filtering.starred', ng-show: 'dashboardPage.filter == "show_starred"'}
     %h1.lmo-h1-medium.dashboard-page__heading{translate: 'dashboard_page.filtering.participating', ng-show: 'dashboardPage.filter == "show_participating"'}
-    %h1.lmo-h1-medium.dashboard-page__heading{translate: 'dashboard_page.filtering.proposals', ng-show: 'dashboardPage.filter == "show_proposals"'}
     %h1.lmo-h1-medium.dashboard-page__heading{translate: 'dashboard_page.filtering.muted', ng-show: 'dashboardPage.filter == "show_muted"'}
     .dashboard-page__no-threads{ng-hide: 'dashboardPage.loadMoreExecuting || dashboardPage.currentBaseQuery.any()'}
       %span{ng-show: 'dashboardPage.filter == "show_all"', translate: 'dashboard_page.no_threads.show_all'}>
-      %span{ng-show: 'dashboardPage.filter == "show_starred"', translate: 'dashboard_page.no_threads.show_starred'}>
       %span{ng-show: 'dashboardPage.filter == "show_participating"', translate: 'dashboard_page.no_threads.show_participating'}>
-      %span{ng-show: 'dashboardPage.filter == "show_proposals"', translate: 'dashboard_page.no_threads.show_proposals'}>
       %span{ng-show: 'dashboardPage.filter == "show_muted"', translate: 'dashboard_page.no_threads.show_muted'}>
       %a{ng-show: 'dashboardPage.filter != "show_all"', translate: 'dashboard_page.view_recent', href: '', ng-click: 'dashboardPage.setFilter("show_all")'}>
     .dashboard-page__collections{ng-if: '!dashboardPage.displayByGroup()'}
-      %section.thread-preview-collection__container{ng-show: 'dashboardPage.timeframeQueryFor(timeframe).any()', aria-labelledby: '{{timeframe}}', ng-repeat: 'timeframe in dashboardPage.timeframeNames'}
-        .dashboard-page__date-range{translate: 'dashboard_page.threads_from.{{timeframe}}'}
-        %thread_preview_collection.thread-previews-container{query: 'dashboardPage.timeframeQueryFor(timeframe)'}
+      %section.thread-preview-collection__container{ng-if: 'dashboardPage.views.recent[viewName].any()', class: 'dashboard-page__{{viewName}}', ng-repeat: 'viewName in dashboardPage.recentViewNames'}
+        .dashboard-page__date-range{translate: 'dashboard_page.threads_from.{{viewName}}'}
+        %thread_preview_collection.thread-previews-container{query: 'dashboardPage.views.recent[viewName]'}
       .dashboard-page__footer{in-view: '$inview && dashboardPage.loadMore()', in-view-options: '{debounce: 200}'} .
       %loading{ng-show: 'dashboardPage.loadMoreExecuting'}
     .dashboard-page__collections{ng-if: 'dashboardPage.displayByGroup()'}
-      .dashboard-page__group{ng-repeat: 'group in dashboardPage.groups() track by group.id | orderBy:dashboardPage.groupName'}
-        %section{ng-if: 'dashboardPage.groupQueryFor(group).any()', role: 'region', aria-label: "{{ 'dashboard_page.threads_from.group' | translate }} {{group.name}}"}
+      .dashboard-page__group{ng-repeat: 'group in dashboardPage.groups() | orderBy:"name" track by group.id'}
+        %section{ng-if: 'dashboardPage.views.groups[group.key].any()', role: 'region', aria-label: "{{ 'dashboard_page.threads_from.group' | translate }} {{group.name}}"}
           %img.selector-list-item-group-logo.pull-left{ng-src: "{{group.logoUrl()}}", aria-hidden: 'true'}>
           %h2.dashboard-page__group-name
             %a{lmo-href-for: 'group'} {{group.name}}
           .dashboard-groups.thread-previews-container
-            %thread_preview_collection{query: 'dashboardPage.groupQueryFor(group)', limit: 'dashboardPage.groupThreadLimit'}
-            .dashboard-page__show-more{ng-show: 'dashboardPage.moreForThisGroup(group)'}
-              %a{translate: 'dashboard_page.view_more', href: '/g/{{group.key}}'}
+            %thread_preview_collection{query: 'dashboardPage.views.groups[group.key]', limit: 'dashboardPage.groupThreadLimit'}

--- a/lineman/app/components/dashboard_page/dashboard_page.scss
+++ b/lineman/app/components/dashboard_page/dashboard_page.scss
@@ -14,7 +14,7 @@
 .dashboard-page__date-range{
   @include fontSmall;
   color: $grey-on-grey;
-  margin-left: 13px;
+  padding: 0 $cardPaddingSize;
 }
 
 .dashboard-page__no-threads {

--- a/lineman/app/components/dashboard_page/dashboard_page_controller.coffee
+++ b/lineman/app/components/dashboard_page/dashboard_page_controller.coffee
@@ -5,60 +5,66 @@ angular.module('loomioApp').controller 'DashboardPageController', ($rootScope, $
 
   Records.votes.fetchMyRecentVotes()
 
-  @perPage = 25
+  @perPage = 50
   @loaded =
     show_all:           0
     show_muted:         0
-    show_proposals:     0
     show_participating: 0
 
+  @views =
+    recent: {}
+    groups: {}
+
   @timeframes =
-    today:     { from: '1 second ago', to: '-10 year ago' }
+    today:     { from: '1 second ago', to: '-10 year ago' } # into the future!
     yesterday: { from: '1 day ago',    to: '1 second ago' }
     thisweek:  { from: '1 week ago',   to: '1 day ago' }
     thismonth: { from: '1 month ago',  to: '1 week ago' }
     older:     { from: '3 month ago',  to: '1 month ago' }
   @timeframeNames = _.map @timeframes, (timeframe, name) -> name
-  @timeframeQueryFor = (name) -> @timeframes[name].view
 
-  @groups = {}
+  @recentViewNames = ['proposals', 'starred', 'today', 'yesterday', 'thisweek', 'thismonth', 'older']
+
   @groupThreadLimit = 5
   @groups = -> CurrentUser.parentGroups()
-  @groupName = (group) -> group.name
-  @groupQueryFor = (group) -> @groups[group.key]
-  @moreForThisGroup = (group) -> @groupQueryFor(group, { filter: @filter }).length() > @groupThreadLimit
+  @moreForThisGroup = (group) -> @views.groups[group.key].length() > @groupThreadLimit
 
   @displayByGroup = ->
-    _.contains ['show_starred', 'show_muted'], @filter
+    _.contains ['show_muted'], @filter
 
-  @updateQueries = ->
-    _.each @groups(), (group) =>
-      @groups[group.key] = ThreadQueryService.groupQuery(group, { filter: @filter })
-    _.each @timeframeNames, (name) =>
-      @timeframes[name].view = ThreadQueryService.timeframeQuery
-        name: name
-        filter: @filter
-        timeframe: @timeframes[name]
+  @updateQueries = =>
+    @currentBaseQuery = ThreadQueryService.filterQuery(@filter)
+    if @displayByGroup()
+      _.each @groups(), (group) =>
+        @views.groups[group.key] = ThreadQueryService.groupQuery(group, { filter: @filter, queryType: 'all' })
+    else
+      @views.recent.proposals = ThreadQueryService.filterQuery ['show_proposals', @filter], queryType: 'important'
+      @views.recent.starred   = ThreadQueryService.filterQuery ['show_starred', 'hide_proposals', @filter], queryType: 'important'
+      _.each @timeframeNames, (name) =>
+        @views.recent[name] = ThreadQueryService.timeframeQuery
+          name: name
+          filter: @filter
+          timeframe: @timeframes[name]
 
   @loadMore = =>
     from = @loaded[@filter]
     @loaded[@filter] = @loaded[@filter] + @perPage
 
-    Records.discussions.fetchDashboard
+    Records.discussions.fetchDashboard(
       filter: @filter
       from:   from
-      per:    @perPage
+      per:    @perPage).then @updateQueries
   LoadingService.applyLoadingFunction @, 'loadMore'
 
-  @refresh = ->
+  @refresh = =>
     @updateQueries()
     @loadMore() if @loaded[@filter] == 0
 
   @setFilter = (filter = 'show_all') =>
     @filter = filter
-    @currentBaseQuery = ThreadQueryService.filterQuery(@filter)
     @refresh()
   @setFilter()
   $scope.$on 'homePageClicked', => @setFilter()
+  $scope.$on 'starToggled', @refresh
 
   return

--- a/lineman/app/components/inbox_page/inbox_page.haml
+++ b/lineman/app/components/inbox_page/inbox_page.haml
@@ -2,15 +2,15 @@
   %main.inbox-page
     .thread-preview-collection__container
       %h1.lmo-h1-medium.inbox-page__heading{translate: 'inbox_page.unread_threads'}
-      .inbox-page__no-threads{ng-hide: 'inboxPage.baseQuery.any()'}
-        %span{translate: 'inbox_page.no_threads'}>
-      .inbox-page__group{ng-repeat: 'group in inboxPage.groups() | orderBy:"name" track by group.id'}
-        %section{ng-if: 'inboxPage.queryFor(group).any()', role: 'region', aria-label: "{{ 'inbox_page.threads_from.group' | translate }} {{group.name}}"}
-          .inbox-page__group-name-container
-            %img.selector-list-item-group-logo.pull-left{ng-src: "{{group.logoUrl()}}", aria-hidden: 'true'}>
-            %h2.inbox-page__group-name
-              %a{lmo-href-for: 'group'} {{group.name}}
-          .inbox-page__groups.thread-previews-container
-            %thread_preview_collection{query: 'inboxPage.queryFor(group)', limit: 'inboxPage.threadLimit'}
-            .lmo-show-more{ng-show: 'inboxPage.moreForThisGroup(group)'}
-              %a{translate: 'inbox_page.view_more', href: '/g/{{group.key}}'}
+      %loading{ng-if: 'inboxPage.loading()'}
+      .inbox-page__threads{ng-if: '!inboxPage.loading()'}
+        .inbox-page__no-threads{ng-show: '!inboxPage.hasThreads()'}
+          %span{translate: 'inbox_page.no_threads'}>
+        .inbox-page__group{ng-repeat: 'group in inboxPage.groups() | orderBy:"name" track by group.id'}
+          %section{ng-if: 'inboxPage.views.groups[group.key].any()', role: 'region', aria-label: "{{ 'inbox_page.threads_from.group' | translate }} {{group.name}}"}
+            .inbox-page__group-name-container
+              %img.selector-list-item-group-logo.pull-left{ng-src: "{{group.logoUrl()}}", aria-hidden: 'true'}>
+              %h2.inbox-page__group-name
+                %a{href: '/g/{{group.key}}'} {{group.name}}
+            .inbox-page__groups.thread-previews-container
+              %thread_preview_collection{query: 'inboxPage.views.groups[group.key]', limit: 'inboxPage.threadLimit'}

--- a/lineman/app/components/inbox_page/inbox_page_controller.coffee
+++ b/lineman/app/components/inbox_page/inbox_page_controller.coffee
@@ -3,22 +3,27 @@ angular.module('loomioApp').controller 'InboxPageController', ($scope, $rootScop
   $rootScope.$broadcast('setTitle', 'Inbox')
   $rootScope.$broadcast('analyticsClearGroup')
 
-  @threadLimit = 5
+  @threadLimit = 50
+  @views =
+    groups: {}
+
+  @loading = -> !(CurrentUser.inboxLoaded and CurrentUser.membershipsLoaded)
 
   @groups = ->
     CurrentUser.parentGroups()
 
   @init = =>
+    return if @loading()
     _.each @groups(), (group) =>
-      @["group#{group.id}"] = ThreadQueryService.groupQuery(group)
-    @baseQuery = ThreadQueryService.filterQuery('show_unread')
-  @init()
+      @views.groups[group.key] = ThreadQueryService.groupQuery(group)
   $scope.$on 'currentUserMembershipsLoaded', @init
+  $scope.$on 'currentUserInboxLoaded', @init
+  @init()
 
-  @queryFor = (group) ->
-    @["group#{group.id}"]
+  @hasThreads = ->
+    ThreadQueryService.filterQuery('show_unread', queryType: 'inbox').any()
 
   @moreForThisGroup = (group) ->
-    @queryFor(group).length() > @threadLimit
+    @views.groups[group.key].length() > @threadLimit
 
   return

--- a/lineman/app/components/navbar/navbar.coffee
+++ b/lineman/app/components/navbar/navbar.coffee
@@ -8,11 +8,7 @@ angular.module('loomioApp').directive 'navbar', ->
       $scope.selected = component.page
 
     $scope.unreadThreadCount = ->
-      ThreadQueryService.filterQuery('show_unread').length()
+      ThreadQueryService.filterQuery('show_unread', queryType: 'inbox').length()
 
     $scope.homePageClicked = ->
       $rootScope.$broadcast 'homePageClicked'
-
-    if !$scope.inboxLoaded
-      Records.discussions.fetchInbox().then ->
-        $scope.inboxLoaded = true

--- a/lineman/app/components/star_toggle/star_toggle.coffee
+++ b/lineman/app/components/star_toggle/star_toggle.coffee
@@ -3,5 +3,7 @@ angular.module('loomioApp').directive 'starToggle', ->
   restrict: 'E'
   templateUrl: 'generated/components/star_toggle/star_toggle.html'
   replace: true
-  controller: ($scope) ->
-    
+  controller: ($scope, $rootScope) ->
+    $scope.toggle = ->
+      $scope.thread.reader().toggleStar()
+      $rootScope.$broadcast 'starToggled', $scope.thread

--- a/lineman/app/components/star_toggle/star_toggle.haml
+++ b/lineman/app/components/star_toggle/star_toggle.haml
@@ -1,4 +1,4 @@
 .star-toggle
-  %a{ng-click: 'thread.reader().toggleStar()'}
+  %a{ng-click: 'toggle()'}
     %i.fa.fa-star{ng-show: 'thread.isStarred()'}
     %i.fa.fa-star-o{ng-hide: 'thread.isStarred()'}

--- a/lineman/app/components/thread_preview_collection/thread_preview_collection.coffee
+++ b/lineman/app/components/thread_preview_collection/thread_preview_collection.coffee
@@ -3,3 +3,11 @@ angular.module('loomioApp').directive 'threadPreviewCollection', ->
   restrict: 'E'
   templateUrl: 'generated/components/thread_preview_collection/thread_preview_collection.html'
   replace: true
+  controller: ($scope) ->
+
+      $scope.importance = (thread) ->
+        multiplier = if thread.hasActiveProposal() and thread.isStarred() then -100000
+        else if         thread.hasActiveProposal() then -10000
+        else if         thread.isStarred() then -1000
+        else            -1
+        multiplier * thread.lastActivityAt

--- a/lineman/app/components/thread_preview_collection/thread_preview_collection.haml
+++ b/lineman/app/components/thread_preview_collection/thread_preview_collection.haml
@@ -1,3 +1,3 @@
 .thread-previews
-  .blank{ng-repeat: 'thread in query.threads() track by thread.id | limitTo: limit'}
+  .blank{ng-repeat: 'thread in query.threads() | orderBy:importance track by thread.key | limitTo: limit'}
     %thread_preview{thread: 'thread'}

--- a/lineman/app/models/discussion_model.coffee
+++ b/lineman/app/models/discussion_model.coffee
@@ -90,6 +90,9 @@ angular.module('loomioApp').factory 'DiscussionModel', (BaseModel) ->
     isStarred: ->
       @reader().starred
 
+    isImportant: ->
+      @isStarred() or @hasActiveProposal()
+
     unreadItemsCount: ->
       (@itemsCount - @reader().readItemsCount)
 

--- a/lineman/app/models/discussion_records_interface.coffee
+++ b/lineman/app/models/discussion_records_interface.coffee
@@ -4,24 +4,18 @@ angular.module('loomioApp').factory 'DiscussionRecordsInterface', (BaseRecordsIn
 
     fetchByGroup: (options = {}) ->
       @fetch
-        params:
-          group_id: options['group_id']
-          from: options['from']
-          per: options['per']
+        params: options
 
     fetchDashboard: (options = {}) ->
       @fetch
         path: 'dashboard'
         params: options
-        cacheKey: dashboardCacheKeyFor(options)
 
-    dashboardCacheKeyFor = (options) ->
-      "#{options['filter']}Dashboard" unless options['filter'] == 'show_all'
-
-    fetchInbox: ->
-      @fetchDashboard
-        filter: 'show_unread'
-        from: 0
-        per: 100
-        since: moment().startOf('day').subtract(3, 'month').toDate()
-        timeframe_for: 'last_activity_at'
+    fetchInbox: (options = {}) ->
+      @fetch
+        path: 'inbox'
+        params:
+          from:          options['from'] or 0
+          per:           options['per'] or 100
+          since:         options['since'] or moment().startOf('day').subtract(6, 'week').toDate()
+          timeframe_for: options['timeframe_for'] or 'last_activity_at'

--- a/lineman/app/services/current_user.coffee
+++ b/lineman/app/services/current_user.coffee
@@ -4,8 +4,15 @@ angular.module('loomioApp').factory 'CurrentUser', ($rootScope, Records) ->
     window.Loomio.seedRecords.users = [] unless window.Loomio.seedRecords.users?
     window.Loomio.seedRecords.users.push window.Loomio.seedRecords.current_user
     Records.import(window.Loomio.seedRecords)
-    Records.memberships.fetchMyMemberships().then ->
-      $rootScope.$broadcast 'currentUserMembershipsLoaded'
+
     currentUser =  Records.users.find(window.Loomio.currentUserId)
+
+    Records.memberships.fetchMyMemberships().then ->
+      currentUser.updateFromJSON membershipsLoaded: true
+      $rootScope.$broadcast 'currentUserMembershipsLoaded'
+
+    Records.discussions.fetchInbox().then ->
+      currentUser.updateFromJSON inboxLoaded: true
+      $rootScope.$broadcast 'currentUserInboxLoaded'
 
   currentUser

--- a/lineman/app/services/thread_query_service.coffee
+++ b/lineman/app/services/thread_query_service.coffee
@@ -1,49 +1,40 @@
 angular.module('loomioApp').factory 'ThreadQueryService', (Records) ->
   new class ThreadQueryService
 
-    filterQuery: (filter) ->
-      threadQueryFor createBaseView(), filter
-
-    groupQuery: (group = {}, options = {}) ->
-      threadQueryFor createGroupView(group), 
-                     options['filter'] or 'show_unread',
-                     options['limit'] or 5
+    filterQuery: (filter, options = {}) ->
+      threadQueryFor createBaseView(filter, options['queryType'] or 'all')
 
     timeframeQuery: (options = {}) ->
-      threadQueryFor createTimeframeView(options['name'], options['timeframe']),
-                     options['filter'] or 'show_all',
-                     options['limit'] or 100
+      threadQueryFor createTimeframeView(options['name'], options['filter'] or 'show_all', 'timeframe', options['timeframe']['from'], options['timeframe']['to'])
 
-    threadQueryFor = (view, filter) ->
-      view: view
-      filter: createFilter(filter)
-      threads: ->
-        @filter @view.data()
-      length: ->
-        @threads().length
-      any: ->
-        @length() > 0
+    groupQuery: (group = {}, options = {}) ->
+      threadQueryFor createGroupView(group, options['filter'] or 'show_unread', options['queryType'] or 'inbox')
 
-    createBaseView = ->
+    threadQueryFor = (view) ->
+      threads: -> view.data()
+      length: ->  @threads().length
+      any: ->     @length() > 0
+
+    createBaseView = (filters, queryType) ->
       _.memoize(->
         view = Records.discussions.collection.addDynamicView 'default'
-        view.applySimpleSort('lastActivityAt', true)
+        applyFilters(view, filters, queryType)
         view)()
 
-    createGroupView = (group) ->
+    createGroupView = (group, filters, queryType) ->
       _.memoize(->
         view = Records.discussions.collection.addDynamicView group.name
         view.applyFind({groupId: { $in: group.organisationIds() }})
-        view.applySimpleSort('lastActivityAt', true)
+        applyFilters(view, filters, queryType)
         view)()
 
-    createTimeframeView = (name, options = {}) ->
+    createTimeframeView = (name, filters, queryType, from, to) ->
       today = moment().startOf 'day'
       _.memoize(->
         view = Records.discussions.collection.addDynamicView name
-        view.applyFind(lastActivityAt: { $gt: parseTimeOption(options['from']) })
-        view.applyFind(lastActivityAt: { $lt: parseTimeOption(options['to']) })
-        view.applySimpleSort('lastActivityAt', true)
+        view.applyFind(lastActivityAt: { $gt: parseTimeOption(from) })
+        view.applyFind(lastActivityAt: { $lt: parseTimeOption(to) })
+        applyFilters(view, filters, queryType)
         view)()
 
     parseTimeOption = (options) ->
@@ -52,15 +43,19 @@ angular.module('loomioApp').factory 'ThreadQueryService', (Records) ->
       parts = options.split ' '
       moment().startOf('day').subtract(parseInt(parts[0]), parts[1])
 
-    createFilter = (filter = 'show_all') ->
-      (viewData) ->
-        _.filter viewData, (thread) ->
-          return false if thread.isMuted() and filter != 'show_muted'
-          return false if thread.readerNotLoaded()
-          switch filter
-            when 'show_all'           then true
-            when 'show_muted'         then thread.isMuted()
-            when 'show_unread'        then thread.isUnread()
-            when 'show_participating' then thread.isParticipating()
-            when 'show_starred'       then thread.isStarred()
-            when 'show_proposals'     then thread.hasActiveProposal()
+    applyFilters = (view, filters, queryType) ->
+      switch queryType
+        when 'important' then view.applyWhere (thread) -> thread.isImportant()
+        when 'timeframe' then view.applyWhere (thread) -> !thread.isImportant()
+        when 'inbox'     then view.applyWhere (thread) -> thread.isUnread()
+
+      view.applyWhere (thread) -> thread.isMuted() == _.contains(filters, 'show_muted')
+
+      _.each filters, (filter) ->
+        switch filter
+          when 'show_participating' then view.applyWhere (thread) -> thread.isParticipating()
+          when 'show_starred'       then view.applyWhere (thread) -> thread.isStarred()
+          when 'show_proposals'     then view.applyWhere (thread) -> thread.hasActiveProposal()
+          when 'hide_proposals'     then view.applyWhere (thread) -> !thread.hasActiveProposal()
+
+      view

--- a/lineman/spec-e2e/dashboard_spec.coffee
+++ b/lineman/spec-e2e/dashboard_spec.coffee
@@ -1,0 +1,34 @@
+describe 'Dashboard Page', ->
+
+  dashboardHelper = require './helpers/dashboard_helper.coffee'
+
+  beforeEach ->
+    dashboardHelper.load()
+
+  it 'displays a view of recent threads', ->
+    expect(dashboardHelper.proposalsThreads()).toContain('Starred proposal discussion')
+    expect(dashboardHelper.proposalsThreads()).toContain('Proposal discussion')
+    expect(dashboardHelper.proposalsThreads()).not.toContain('Starred discussion')
+
+    expect(dashboardHelper.starredThreads()).toContain('Starred discussion')
+    expect(dashboardHelper.starredThreads()).not.toContain('Starred proposal discussion')
+
+    expect(dashboardHelper.todayThreads()).toContain('Recent discussion')
+
+    expect(dashboardHelper.anyThreads()).not.toContain('Muted discussion')
+    expect(dashboardHelper.anyThreads()).not.toContain('Old discussion')
+
+  xit 'displays a view of participating threads', ->
+    dashboardHelper.openFilterDropdown()
+    dashboardHelper.visitParticipatingView()
+    expect(dashboardHelper.anyThreads()).not.toContain('Starred proposal discussion')
+    expect(dashboardHelper.anyThreads()).not.toContain('Recent discussion')
+    expect(dashboardHelper.anyThreads()).toContain('Participating discussion')
+
+  xit 'displays a view of muted threads by group', ->
+    dashboardHelper.openFilterDropdown()
+    dashboardHelper.visitMutedView()
+    browser.driver.sleep(10000)
+    expect(dashboardHelper.firstGroupTitle()).toContain('Dirty Dancing Shoes')
+    expect(dashboardHelper.anyThreads()).toContain('Muted discussion')
+    expect(dashboardHelper.anyThreads()).not.toContain('Recent discussion')

--- a/lineman/spec-e2e/helpers/dashboard_helper.coffee
+++ b/lineman/spec-e2e/helpers/dashboard_helper.coffee
@@ -1,4 +1,34 @@
 module.exports = new class DashboardHelper
 
+  load: ->
+    browser.get('http://localhost:8000/development/setup_dashboard')
+
   pageHeader: ->
     element.all(By.css('.lmo-h1-medium.dashboard-page__heading')).first()
+
+  openFilterDropdown: ->
+    element(By.css('.dashboard-page__filter-dropdown button')).click()
+
+  visitParticipatingView: ->
+    element(By.css('.dashboard-page__filter-participating a')).click()
+
+  visitMutedView: ->
+    element(By.css('.dashboard-page__filter-muted a')).click()
+
+  proposalsThreads: ->
+    element(By.css('.dashboard-page__proposals')).getText()
+
+  starredThreads: ->
+    element(By.css('.dashboard-page__starred')).getText()
+
+  todayThreads: ->
+    element(By.css('.dashboard-page__today')).getText()
+
+  yesterdayThreads: ->
+    element(By.css('.dashboard-page__yesterday')).getText()
+
+  anyThreads: ->
+    element(By.css('.dashboard-page__collections')).getText()
+
+  firstGroupTitle: ->
+    element.all(By.css('.dashboard-page__group-name')).first().getText()

--- a/lineman/spec-e2e/helpers/inbox_helper.coffee
+++ b/lineman/spec-e2e/helpers/inbox_helper.coffee
@@ -1,0 +1,13 @@
+module.exports = new class InboxHelper
+
+  load: ->
+    browser.get('http://localhost:8000/development/setup_inbox')
+
+  firstGroup: ->
+    element.all(By.css('.inbox-page__group')).first().getText()
+
+  lastGroup: ->
+    element.all(By.css('.inbox-page__group')).last().getText()
+
+  anyThreads: ->
+    element(By.css('.inbox-page__threads')).getText()

--- a/lineman/spec-e2e/inbox_spec.coffee
+++ b/lineman/spec-e2e/inbox_spec.coffee
@@ -1,0 +1,15 @@
+describe 'Inbox Page', ->
+
+  inboxHelper = require './helpers/inbox_helper.coffee'
+
+  beforeEach ->
+    inboxHelper.load()
+
+  it 'displays unread threads by group', ->
+    expect(inboxHelper.firstGroup()).toContain('Dirty Dancing Shoes')
+    expect(inboxHelper.firstGroup()).toContain('Starred discussion')
+    expect(inboxHelper.lastGroup()).toContain('Point Break')
+    expect(inboxHelper.lastGroup()).toContain('Recent discussion')
+
+    expect(inboxHelper.anyThreads()).not.toContain('Muted discussion')
+    expect(inboxHelper.anyThreads()).not.toContain('Old discussion')


### PR DESCRIPTION
Alright, this is ready for a look I think.

Notable things that are still bad at the moment:

- Visit inbox, then visit dashboard. No starred / proposal threads. Hit the 'recent' button again. Starred / proposal threads show up. Weep softly. (EDIT: fixed this, which takes me from `weep` to `wee!`)
- The muted e2e is failing for me because it's saying no muted threads are found. Works perfectly for the participating e2e (which is activated the same way), and works fine manually in the browser. Sigh.
- Need some optimization work on the dashboard query, I think because the discussion_serializer is loading up an author, group, and motion for each of 50 discussions.
