### PR TITLE
Remove linguring focus from buttons

### DIFF
--- a/lineman/app/components/base.scss
+++ b/lineman/app/components/base.scss
@@ -39,4 +39,8 @@ strong{
   &:hover {
     @include box_shadow(2);
   }
+
+  &:focus {
+    outline-style: none;
+  }
 }


### PR DESCRIPTION
This remove the focus which seems to stay on the navbar filter buttons.

Before:
<img width="149" alt="screenshot 2015-08-04 21 36 34" src="https://cloud.githubusercontent.com/assets/1380820/9147951/7025f168-3dc3-11e5-8b3e-ced3e1abfe27.png">

After:
<img width="115" alt="screenshot 2015-08-08 11 55 13" src="https://cloud.githubusercontent.com/assets/1380820/9147992/67452e28-3dc4-11e5-9e18-8c91cad3881d.png">

https://trello.com/c/QFbcnDHq/565-remove-blue-focus-highlighting-around-filters-once-selected