### PR TITLE
Position label counts in the navbar correctly

### DIFF
--- a/lineman/app/components/base.scss
+++ b/lineman/app/components/base.scss
@@ -40,3 +40,7 @@ strong{
     @include box_shadow(2);
   }
 }
+
+.badge {
+  @include box_shadow(1);
+}

--- a/lineman/app/components/navbar/navbar.haml
+++ b/lineman/app/components/navbar/navbar.haml
@@ -7,9 +7,9 @@
     .lmo-navbar__item{ng-class: '{"lmo-navbar__item--selected": selected == "inboxPage"}'}
       %a.btn.lmo-navbar__btn.lmo-navbar__btn-icon.has-badge{href: '/inbox', title: "{{ 'navbar.unread_title' | translate }}", tabindex: 2}
         %i.fa.fa-lg.fa-inbox>
+          %span.badge{ng-show: 'unreadThreadCount() > 0'}
+            {{unreadThreadCount()}}
         %span.lmo-navbar__btn-label{translate: 'navbar.unread'}
-        %span.badge{ng-show: 'unreadThreadCount() > 0'}
-          {{unreadThreadCount()}}
     .lmo-navbar__item{ng-class: '{"lmo-navbar__item--selected": selected == "groupsPage"}'}
       %a.groups-item.btn.lmo-navbar__btn-icon.lmo-navbar__btn{href: '/groups', title: "{{ 'navbar.groups_title' | translate }}", tabindex: 3}
         %i.fa.fa-lg.fa-group>

--- a/lineman/app/components/navbar/navbar.scss
+++ b/lineman/app/components/navbar/navbar.scss
@@ -90,11 +90,15 @@
   position: relative;
 }
 
+.lmo-navbar__btn.has-badge i {
+  position: relative;
+}
+
 .lmo-navbar__btn.has-badge .badge {
   font-size: 10px;
   position: absolute;
   left: 16px;
-  top: 1px;
+  top: -10px;
   background: #4A90E2;
   border-radius: 10px;
   padding: 5px;


### PR DESCRIPTION
- This PR repositions badges in navbar absolute relative to the %i instead of the button.
- Also added drop shadow to badge class app wide

https://trello.com/c/fAIz9MAm/566-label-counts-in-the-navbar-aren-t-nested-correctly

before:
<img width="87" alt="screenshot 2015-08-04 21 38 57" src="https://cloud.githubusercontent.com/assets/1380820/9148232/27c673e2-3dc9-11e5-8248-86403e4d913f.png">

after:
<img width="100" alt="screenshot 2015-08-08 12 26 24" src="https://cloud.githubusercontent.com/assets/1380820/9148233/32d60428-3dc9-11e5-9bbf-961c40a8b9f7.png">

