### PR TITLE
Tweak avatar padding and drop filter selector

### DIFF
--- a/lineman/app/components/navbar/navbar.scss
+++ b/lineman/app/components/navbar/navbar.scss
@@ -49,7 +49,7 @@
     position: absolute;
     width: 100%;
     left: 0;
-    bottom: 0;
+    bottom: -1px;
     height: 4px;
     background: $loomio-orange;
   }
@@ -57,7 +57,7 @@
 
 .lmo-navbar__item--user {
   .lmo-navbar__btn{
-    padding: 6px;
+    padding: 7px 6px;
   }
 }
 


### PR DESCRIPTION
- Pad avatar button to navbar height (short 2px)
- Lower filter selector 1px to remove gap. Looks cleaner.

before:
<img width="847" alt="screenshot 2015-08-09 09 13 48" src="https://cloud.githubusercontent.com/assets/1380820/9152324/91638822-3e77-11e5-8879-fdafe99ea372.png">

after:
<img width="846" alt="screenshot 2015-08-09 09 13 19" src="https://cloud.githubusercontent.com/assets/1380820/9152326/9f20a5d0-3e77-11e5-9115-4249a9df5bd1.png">
