### PR TITLE
Remove background color on filter button focus

### DIFF
--- a/lineman/app/components/navbar/navbar.scss
+++ b/lineman/app/components/navbar/navbar.scss
@@ -68,8 +68,10 @@
   border-radius: 0;
   line-height: 23px;
   padding: 10px 6px 11px;
-  &:hover, &:focus {
+  &:hover {
     background: $list-hover-color;
+  }
+  &:hover, &:focus {
     box-shadow: none;
   }
 }


### PR DESCRIPTION
This one keeps the button behaviour consistent with the other buttons in the navbar. That is once you click it and move away the grey hover effect leaves.  The issue is most notable when you change filters from say Unread to Groups where you get a big ugly grey block that doesn't really indicate anything(see attach).
The orange selector pseudo element should be enough to indicate what page you are on.

<img width="304" alt="screenshot 2015-08-09 09 30 33" src="https://cloud.githubusercontent.com/assets/1380820/9152380/d21a3b48-3e79-11e5-90fd-f99fc92030a2.png">

before:
<img width="306" alt="screenshot 2015-08-09 09 26 41" src="https://cloud.githubusercontent.com/assets/1380820/9152386/efdc64c6-3e79-11e5-909e-36fef7f51900.png">

after:
<img width="320" alt="screenshot 2015-08-09 09 25 58" src="https://cloud.githubusercontent.com/assets/1380820/9152388/f9ea37c2-3e79-11e5-805f-9198ba694ff9.png">

