### PR TITLE
Style feedback card

### DIFF
--- a/lineman/app/components/mixins.scss
+++ b/lineman/app/components/mixins.scss
@@ -190,16 +190,22 @@ $cardPaddingSize: 15px;
 #turn-off-angular {
   z-index: 100;
   position: fixed;
-  left: 11px;
+  left: 0px;
   bottom: 10px;
-  width: 120px;
+  width: auto;
   text-align: center;
-  padding: 3px;
+  padding: 10px;
   background-color: white;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.24);
+  border-radius: 0 4px 4px 0;
+  box-shadow: 0 0 4px rgba(0,0,0,.14),0 4px 8px rgba(0,0,0,.28);
 }
 
+.lmo-switch {
+  font-size: 12px;
+}
 .lmo-version {
-  color: #666;
-  font-size: 11px;
+  font-size: 12px;
+  a {
+    color: #666;
+  }
 }


### PR DESCRIPTION
Hey peeps just a trial with this one.

I know @rdbartlett has already voice some concerns. Which is fair enough, just trying to clear my list. Have a look and close it if you don't think it is an improvement.
(If you give it enough lift it does not look like it is a component of the app)

- More depth to separate it from app
- Rounded corners to fit with app styling
- More emphasys on Feedback
- Simplify text on switch link
- Color a correctly
- Trim unused width so it doesn't get in the way

Before:
<img width="757" alt="screenshot 2015-08-09 15 11 34" src="https://cloud.githubusercontent.com/assets/1380820/9153425/f92c09b2-3ea8-11e5-960c-ca3ae74465d8.png">

After:
<img width="756" alt="screenshot 2015-08-09 15 02 22" src="https://cloud.githubusercontent.com/assets/1380820/9153412/2b0875ac-3ea8-11e5-9868-19b397e19b8a.png">
