### PR TITLE
pop to mobile layout at 767

### DIFF
--- a/lineman/app/components/navbar/navbar.scss
+++ b/lineman/app/components/navbar/navbar.scss
@@ -83,7 +83,6 @@
 .lmo-navbar__btn-label{
   @include fontMedium;
   padding: 5px;
-  @media (max-width: 650px){display: none;}
 }
 
 .lmo-navbar__btn.has-badge{
@@ -113,6 +112,10 @@
         background: $list-hover-color;
       }
     }
+  }
+
+  .lmo-navbar__btn-label {
+    display: none;
   }
 
   .lmo-navbar-item-container--left{


### PR DESCRIPTION
This PR simply pops to the new layout when the other buttons pop.  767px wide.  Which is the width of tablets or phablets in landscape.

before:
<img width="666" alt="screenshot 2015-08-10 08 35 19" src="https://cloud.githubusercontent.com/assets/1380820/9156824/7ad23cce-3f3b-11e5-9832-5464366db41a.png">

after:
<img width="671" alt="screenshot 2015-08-10 08 37 40" src="https://cloud.githubusercontent.com/assets/1380820/9156825/85f2c3c6-3f3b-11e5-8c6d-273d93856eca.png">
