### PR TITLE
Sanitize filenames for upload

### DIFF
--- a/lineman/app/models/attachment_records_interface.coffee
+++ b/lineman/app/models/attachment_records_interface.coffee
@@ -18,8 +18,11 @@ angular.module('loomioApp').factory 'AttachmentRecordsInterface', ($upload, Base
       else
         $.Deferred().resolve() # resolve an empty promise to return
 
+    sanitizeFilename: (fileName) ->
+      fileName.replace(/[^a-z0-9_\-\.]/gi, '_')
+
     attachmentParams: (file) ->
-      filename: file.name
+      filename: @sanitizeFilename(file.name)
       filesize: file.size
       location: @credentials.url + @uploadKey(file)
 
@@ -37,4 +40,4 @@ angular.module('loomioApp').factory 'AttachmentRecordsInterface', ($upload, Base
         "Content-Type": file.type or 'application/octet-stream'
 
     uploadKey: (file) ->
-      @credentials.key.replace('${filename}', file.name)
+      @credentials.key.replace('${filename}', @sanitizeFilename(file.name))


### PR DESCRIPTION
Sanitising filenames in 1.0 - beta proved more tricky so this is an interim fix for the new interface.