### PR TITLE
increase group page cover photo size to 320px

### DIFF
--- a/lineman/app/components/group_page/group_page.scss
+++ b/lineman/app/components/group_page/group_page.scss
@@ -12,7 +12,7 @@
   top: $navbar-height;
   left: 0;
   width: 100%;
-  height: 160px;
+  height: 320px;
   background: url('http://placehold.it/640x160') no-repeat center center #f5f5f5;
   background-size: cover;
 }
@@ -24,7 +24,7 @@
 .group-page__header{
   width: 100%;
   position: relative;
-  min-height: 225px;
+  min-height: 335px;
 }
 
 .group-page__header .btn{
@@ -33,7 +33,7 @@
 
 .group-page__logo{
   position: relative;
-  top: 100px;
+  top: 215px;
   width: 108px;
   height: 108px;
   background: url('http://placehold.it/100x100') no-repeat top center white;
@@ -41,7 +41,7 @@
 }
 
 .group-page__name-and-actions{
-  margin-top: 60px;
+  margin-top: 175px;
 }
 
 .group-page__nonmember-actions { float: right; }


### PR DESCRIPTION
Merging this step now will make the following design + dev steps a lot easier.

![image](https://cloud.githubusercontent.com/assets/970124/9241613/c280d19e-41c9-11e5-83e4-531a68e9ad7b.png)

Still looks bung on mobile but I'm most of the way to figuring out a nice solution for that.