### PR TITLE
Fix 'show more' functionality for discussions on group page

### DIFF
--- a/lineman/app/components/group_page/discussions_card/discussions_card.coffee
+++ b/lineman/app/components/group_page/discussions_card/discussions_card.coffee
@@ -15,7 +15,7 @@ angular.module('loomioApp').directive 'discussionsCard', ->
         per:      $scope.perPage
       $scope.loaded += $scope.perPage
       Records.discussions.fetchByGroup(options).then (data) ->
-        if (data.discussions or []).length < $scope.perPage?
+        if (data.discussions or []).length < $scope.perPage
           $scope.canLoadMoreDiscussions = false
 
     LoadingService.applyLoadingFunction $scope, 'loadMore'


### PR DESCRIPTION
The 'Show more' link was displaying when there were no more discussions to show (confirmed bug report from angular feedback form). This tweak should fix it