### PR TITLE
Slack webhook upgrades

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -42,7 +42,7 @@ class Event < ActiveRecord::Base
     group = self.discussion.group
     self.discussion.webhooks.each { |webhook| WebhookService.publish! webhook: webhook, event: self }
     group.webhooks.each           { |webhook| WebhookService.publish! webhook: webhook, event: self }
-    group.parent.webhooks.each    { |webhook| WebhookService.publish! webhook: webhook, event: self } if group.is_subgroup?
+    group.parent.webhooks.each    { |webhook| WebhookService.publish! webhook: webhook, event: self } if group.is_subgroup? && group.is_visible_to_parent_members
   end
   handle_asynchronously :notify_webhooks!
 

--- a/app/models/webhooks/slack/base.rb
+++ b/app/models/webhooks/slack/base.rb
@@ -11,7 +11,7 @@ Webhooks::Slack::Base = Struct.new(:event) do
   end
 
   def text
-    I18n.t :"webhooks.slack.#{event.kind}", author: author.name, name: eventable_name
+    I18n.t :"webhooks.slack.#{event.kind}", author: author.name, name: proposal_link(eventable)
   end
 
   def attachments
@@ -27,17 +27,13 @@ Webhooks::Slack::Base = Struct.new(:event) do
 
   private
 
-  def eventable_name
-    eventable.discussion.title
-  end
-
   def motion_vote_field
     {
       title: "Vote on this proposal",
-      value: "#{vote_on_this("yes")} · " +
-             "#{vote_on_this("abstain")} · " +
-             "#{vote_on_this("no")} · " +
-             "#{vote_on_this("block")}"
+      value: "#{proposal_link(eventable, "yes")} · " +
+             "#{proposal_link(eventable, "abstain")} · " +
+             "#{proposal_link(eventable, "no")} · " +
+             "#{proposal_link(eventable, "block")}"
     }
   end
 
@@ -49,8 +45,8 @@ Webhooks::Slack::Base = Struct.new(:event) do
     { value: discussion_link(I18n.t(:"webhooks.slack.view_it_on_loomio"), params) }
   end
 
-  def vote_on_this(position)
-    discussion_link position, { proposal: eventable.key, position: position }
+  def proposal_link(proposal, position = nil)
+    discussion_link position || proposal.name, { proposal: proposal.key, position: position }
   end
 
   def discussion_link(text = nil, params = {})

--- a/app/models/webhooks/slack/motion_closing_soon.rb
+++ b/app/models/webhooks/slack/motion_closing_soon.rb
@@ -5,7 +5,7 @@ class Webhooks::Slack::MotionClosingSoon < Webhooks::Slack::Base
   end
 
   def attachment_title
-    eventable.name
+    proposal_link(eventable)
   end
 
   def attachment_text

--- a/app/models/webhooks/slack/motion_outcome_created.rb
+++ b/app/models/webhooks/slack/motion_outcome_created.rb
@@ -5,7 +5,7 @@ class Webhooks::Slack::MotionOutcomeCreated < Webhooks::Slack::Base
   end
 
   def attachment_title
-    eventable.name
+    proposal_link(eventable)
   end
 
   def attachment_text

--- a/app/models/webhooks/slack/motion_outcome_updated.rb
+++ b/app/models/webhooks/slack/motion_outcome_updated.rb
@@ -5,7 +5,7 @@ class Webhooks::Slack::MotionOutcomeUpdated < Webhooks::Slack::Base
   end
 
   def attachment_title
-    eventable.name
+    proposal_link(eventable)
   end
 
   def attachment_text

--- a/app/models/webhooks/slack/new_motion.rb
+++ b/app/models/webhooks/slack/new_motion.rb
@@ -1,11 +1,15 @@
 class Webhooks::Slack::NewMotion < Webhooks::Slack::Base
 
+  def text
+    I18n.t :"webhooks.slack.new_motion", author: author.name, name: discussion_link
+  end
+
   def attachment_fallback
     "*#{eventable.name}*\n#{eventable.description}\n"
   end
 
   def attachment_title
-    eventable.name
+    proposal_link(eventable)
   end
 
   def attachment_text


### PR DESCRIPTION
- Add links to proposal and discussion titles
- Don't send payload for subgroups which aren't visible to parent group