### PR TITLE
Tighten up mentioning matching

### DIFF
--- a/app/extras/queries/visible_autocompletes.rb
+++ b/app/extras/queries/visible_autocompletes.rb
@@ -1,11 +1,21 @@
 class Queries::VisibleAutocompletes < Delegator
 
   def initialize(query: , group: , limit: , current_user: )
+    # want to match only first part of each word
+    #
+    # searching for 'rob'
+    # 'robguthrie' should be true
+    # 'emrob guthrie' should be false
+    # 'james robinson' should be true
+    #
     @relation = Membership.active.joins(:user).joins(:group)
                           .where(group: group)
                           .where("users.id != ?", current_user.id)
-                          .where("users.name ilike :q OR
-                                  users.username ilike :q", q: "%#{query}%")
+                          .where("users.name ilike :qFirstWord OR
+                                  users.name ilike :qOtherWord OR
+                                  users.username ilike :qFirstWord",
+                                  qFirstWord: "#{query}%",
+                                  qOtherWord: "% #{query}%")
                           .limit(limit)
     super @relation
   end

--- a/lineman/app/components/thread_page/comment_form/comment_form.coffee
+++ b/lineman/app/components/thread_page/comment_form/comment_form.coffee
@@ -25,11 +25,11 @@ angular.module('loomioApp').directive 'commentForm', ->
       Records.attachments.destroy(attachment.id)
 
     $scope.updateMentionables = (fragment) ->
-      allMentionables = _.filter group.members(), (member) ->
-        member.id != CurrentUser.id and \
-        (~member.name.search(new RegExp(fragment, 'i')) or \
-         ~member.label.search(new RegExp(fragment, 'i')))
-      $scope.mentionables = _.take allMentionables, 5 # filters are being annoying
+      regex = new RegExp("(^#{fragment}| +#{fragment})", 'i')
+      allMembers = _.filter group.members(), (member) ->
+        return false if member.id == CurrentUser.id
+        (regex.test(member.name) or regex.test(member.username))
+      $scope.mentionables = allMembers.slice(0, 5)
 
     $scope.fetchByNameFragment = (fragment) ->
       $scope.updateMentionables(fragment)

--- a/lineman/package.json
+++ b/lineman/package.json
@@ -8,7 +8,10 @@
     "company": "DAVEMO Consulting"
   },
   "dependencies": {
-    "angular_record_store": "git://github.com/loomio/angular_record_store.git#1.0.3",
+    "angular": "^1.4.4",
+    "angular-ui-bootstrap": "0.13.3",
+    "angular_record_store": "git://github.com/loomio/angular_record_store.git#2.1.0",
+    "bootstrap": "^3.3.5",
     "coffee-script": "^1.8.0",
     "grunt": "~0.4.5",
     "grunt-angular-templates": "0.5.7",


### PR DESCRIPTION
I've been frustrated that current angular mentioning matches strings at any point. A quick recap of how we do this in beta and how it works on other sites tells me that we only want to match against the beginnings of words so I've gone and done a wee update so that is the case for us. 

EG when searching for 'rob'
* 'robguthrie' should be true
* 'emrob guthrie' should be false (but it is currently a match without this PR)
* 'james robinson' should be true

Sorry I couldn't help myself.