### PR TITLE
remove border and add padding to user profile btn in nav

### DIFF
--- a/lineman/app/components/navbar/navbar.scss
+++ b/lineman/app/components/navbar/navbar.scss
@@ -2,7 +2,6 @@
   @include box_shadow(2);
   z-index: 1000;
   background: white;
-  border-bottom: 1px solid $border-color;
   padding: 0 6px;
   width: 100%;
   position: fixed;
@@ -57,7 +56,7 @@
 
 .lmo-navbar__item--user {
   .lmo-navbar__btn{
-    padding: 6px;
+    padding: 6px 7px;
   }
 }
 


### PR DESCRIPTION
I hope this PR doesn't get in anybodies way but I would love it if someone could merge this as it bugs me daily.

Finally realised what the issue was that has been bugging me.  The navbar has a border bottom that it doesn't need. Removing this adds the crispness back to the shadow too.

This PR:
- removes border bottom from navbar 
- pads out user profile button to full height of navbar

Before:
<img width="834" alt="screenshot 2015-08-22 10 24 02" src="https://cloud.githubusercontent.com/assets/1380820/9420326/787407f6-48b8-11e5-8f8a-80ffdc78cde7.png">

After:
<img width="836" alt="screenshot 2015-08-22 10 23 28" src="https://cloud.githubusercontent.com/assets/1380820/9420328/80f63c46-48b8-11e5-8189-b2992da4ae55.png">
