### PR TITLE
Fix scroll to latest unread comment

### DIFF
--- a/lineman/app/components/thread_page/thread_page_controller.coffee
+++ b/lineman/app/components/thread_page/thread_page_controller.coffee
@@ -53,7 +53,8 @@ angular.module('loomioApp').controller 'ThreadPageController', ($scope, $routePa
 
   $scope.$on 'threadPageEventsLoaded',    (event) =>
     @eventsLoaded = true
-    @commentToFocus = Records.comments.find parseInt($location.search().comment)
+    commentId = parseInt($location.search().comment)
+    @commentToFocus = Records.comments.find(commentId) unless isNaN(commentId)
     @performScroll() if @proposalsLoaded or !@discussion.anyClosedProposals()
   $scope.$on 'threadPageProposalsLoaded', (event) =>
     @proposalsLoaded = true


### PR DESCRIPTION
This comes from a change in behaviour in the find method on the record store

Before, I could get away with `Records.comments.find(NaN)`, which would return undefined
Now, instead, calling find with NaN returns some odd anonymous function thing which b0rks stuff.

We're calling with NaN at times because we need to parse an integer from the query string (we couldn't do it with, say, `Records.comments.find("1")`, and `parseInt(undefined)` is NaN

I figure it's okay to just patch this from my end, tho.