### PR TITLE
fix margins around activity item headers

### DIFF
--- a/lineman/app/components/thread_page/activity_card/thread_item.scss
+++ b/lineman/app/components/thread_page/activity_card/thread_item.scss
@@ -2,7 +2,7 @@
   margin-bottom: 25px;
 }
 
-.thread-item__title {
+.thread-item__header {
   strong {
     color: $primary-text-color;
     @include fontHelveticaBold;


### PR DESCRIPTION
Before:

![image](https://cloud.githubusercontent.com/assets/970124/9514599/89fe60da-4cef-11e5-8de8-df0015045955.png)

After:

![image](https://cloud.githubusercontent.com/assets/970124/9514603/9506db38-4cef-11e5-9f2d-3b404bcec173.png)


Wanted to make a PR because I know you are working in the area @robguthrie @HSalmon. Just checking I'm not treading in your jello.