### PR TITLE
Update toast for comment replies

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -96,6 +96,7 @@ en:
       remove_attachment: 'Remove attachment'
     messages:
       created: 'Comment added'
+      replied: '{{name}} notified of reply'
       updated: 'Comment updated'
       destroyed: 'Comment deleted'
     edit_comment: 'Edit comment'

--- a/lineman/app/components/thread_page/comment_form/comment_form.coffee
+++ b/lineman/app/components/thread_page/comment_form/comment_form.coffee
@@ -11,8 +11,11 @@ angular.module('loomioApp').directive 'commentForm', ->
       $scope.isDisabled = true
       $scope.comment.save().then ->
         $scope.isDisabled = false
+        if $scope.comment.isReply()
+          FlashService.success('comment_form.messages.replied', name: $scope.comment.parent().authorName())
+        else
+          FlashService.success('comment_form.messages.created')
         $scope.comment = Records.comments.build(discussionId: discussion.id)
-        FlashService.success('comment_form.messages.created')
       , ->
         $scope.isDisabled = false
 

--- a/lineman/app/models/comment_model.coffee
+++ b/lineman/app/models/comment_model.coffee
@@ -30,6 +30,9 @@ angular.module('loomioApp').factory 'CommentModel', (BaseModel, AppConfig) ->
     isReply: ->
       @parentId?
 
+    parent: ->
+      @recordStore.comments.find(@parentId)
+
     likers: ->
       @recordStore.users.find(@likerIds)
 

--- a/lineman/spec-e2e/discussion_spec.coffee
+++ b/lineman/spec-e2e/discussion_spec.coffee
@@ -3,6 +3,7 @@ describe 'Discussion Page', ->
   groupsHelper = require './helpers/groups_helper.coffee'
   discussionForm = require './helpers/discussion_form_helper.coffee'
   threadPage = require './helpers/thread_helper.coffee'
+  flashHelper = require './helpers/flash_helper.coffee'
 
   beforeEach ->
     threadPage.load()
@@ -13,8 +14,8 @@ describe 'Discussion Page', ->
       discussionForm.fillInTitle('better title')
       discussionForm.fillInDescription("improved description")
       discussionForm.clickUpdate()
-      expect(threadPage.discussionTitle().getText()).toContain('better title')
-      expect(threadPage.discussionTitle().getText()).toContain("improved description")
+      expect(threadPage.discussionTitle()).toContain('better title')
+      expect(threadPage.discussionTitle()).toContain("improved description")
 
     it 'lets you accidentally cancel then save', ->
       threadPage.openEditThreadForm()
@@ -24,8 +25,8 @@ describe 'Discussion Page', ->
       alert = browser.switchTo().alert()
       alert.dismiss()
       discussionForm.clickUpdate()
-      expect(threadPage.discussionTitle().getText()).toContain('even better title')
-      expect(threadPage.discussionTitle().getText()).toContain("more improved description")
+      expect(threadPage.discussionTitle()).toContain('even better title')
+      expect(threadPage.discussionTitle()).toContain("more improved description")
 
     it 'confirms you really want to cancel', ->
       threadPage.openEditThreadForm()
@@ -34,31 +35,30 @@ describe 'Discussion Page', ->
       discussionForm.clickCancel()
       alert = browser.switchTo().alert()
       alert.accept()
-      expect(threadPage.discussionTitle().getText()).toContain('What star sign are you?')
+      expect(threadPage.discussionTitle()).toContain('What star sign are you?')
 
   it 'adds a comment', ->
     threadPage.addComment('hi this is my comment')
-    expect(threadPage.mostRecentComment().getText()).toContain('hi this is my comment')
+    expect(threadPage.mostRecentComment()).toContain('hi this is my comment')
 
   it 'replies to a comment', ->
     threadPage.addComment('original comment right heerrr')
     threadPage.replyLinkOnMostRecentComment().click()
     threadPage.addComment('hi this is my comment')
-    expect(threadPage.inReplyToOnMostRecentComment().getText()).toContain('in reply to')
-    # threadPage.openNotificationDropdown()
-    # expect(threadPage.notificationDropdown().getText()).toContain('replied to your comment')
+    expect(threadPage.inReplyToOnMostRecentComment()).toContain('in reply to')
+    expect(flashHelper.flashMessage()).toContain('Patrick Swayze notified of reply')
 
   it 'likes a comment', ->
     threadPage.addComment('hi')
     threadPage.likeLinkOnMostRecentComment().click()
-    expect(threadPage.likedByOnMostRecentComment().getText()).toContain('You like this.')
+    expect(threadPage.likedByOnMostRecentComment()).toContain('You like this.')
 
   it 'mentions a user', ->
     threadPage.enterCommentText('@jennifer')
     expect(threadPage.mentionList().getText()).toContain('Jennifer Grey')
     threadPage.firstMentionOption().click()
     threadPage.submitComment()
-    expect(threadPage.mostRecentComment().getText()).toContain('@jennifergrey')
+    expect(threadPage.mostRecentComment()).toContain('@jennifergrey')
 
   it 'edits a comment', ->
     threadPage.addComment('original comment right hur')
@@ -66,11 +66,11 @@ describe 'Discussion Page', ->
     threadPage.selectEditCommentOption()
     threadPage.editCommentText('edited comment right thur')
     threadPage.submitEditedComment()
-    expect(threadPage.mostRecentComment().getText()).toContain('edited comment right thur')
+    expect(threadPage.mostRecentComment()).toContain('edited comment right thur')
 
   it 'deletes a comment', ->
     threadPage.addComment('original comment right hur')
     threadPage.clickThreadItemOptionsButton()
     threadPage.selectDeleteCommentOption()
     threadPage.confirmCommentDeletion()
-    expect(threadPage.activityPanel().getText()).not.toContain('original comment right thur')
+    expect(threadPage.activityPanel()).not.toContain('original comment right thur')

--- a/lineman/spec-e2e/helpers/thread_helper.coffee
+++ b/lineman/spec-e2e/helpers/thread_helper.coffee
@@ -43,7 +43,7 @@ module.exports = new class ThreadHelper
     element(By.css('.delete-comment-form__delete-button')).click()
 
   activityPanel: ->
-    element(By.css('.activity-card')).click()
+    element(By.css('.activity-card')).getText()
 
   openNotificationDropdown: ->
     element(By.css('.dropdown-toggle')).click()
@@ -52,19 +52,19 @@ module.exports = new class ThreadHelper
     element(By.css('.lmo-navbar__btn--notifications'))
 
   mostRecentComment: ->
-    element.all(By.css('.thread-item--comment')).last()
+    element.all(By.css('.thread-item--comment')).last().getText()
 
   replyLinkOnMostRecentComment: ->
     element.all(By.css('.thread-item__action--reply')).last()
 
   inReplyToOnMostRecentComment: ->
-    element.all(By.css('.new-comment__in-reply-to')).last()
+    element.all(By.css('.new-comment__in-reply-to')).last().getText()
 
   likeLinkOnMostRecentComment: ->
     element.all(By.css('.thread-item__action--like')).last()
 
   likedByOnMostRecentComment: ->
-    element.all(By.css('.thread-item__liked-by')).last()
+    element.all(By.css('.thread-item__liked-by')).last().getText()
 
   flashMessageText: ->
     element(By.css('.flash-container')).getText()
@@ -117,4 +117,4 @@ module.exports = new class ThreadHelper
     element(By.css('.thread-context__dropdown-options-edit')).click()
 
   discussionTitle: ->
-    element(By.css('.thread-context'))
+    element(By.css('.thread-context')).getText()


### PR DESCRIPTION
Toast notifies replier that recipient has been notified:

![screen shot 2015-08-31 at 1 04 50 pm](https://cloud.githubusercontent.com/assets/2882097/9570494/99a17c76-4fe1-11e5-9490-f102f692ff6b.png)

(+ minor test updates)