### PR TITLE
fix linking to comments

### DIFF
--- a/lineman/app/services/lmo_url_service.coffee
+++ b/lineman/app/services/lmo_url_service.coffee
@@ -22,7 +22,7 @@ angular.module('loomioApp').factory 'LmoUrlService', ->
       @buildModelRoute('m', p.key, p.name, params, options)
 
     comment: (c, params = {}, options = {}) ->
-      @discussion c.discussion(), _.merge(params, {comment: c.key})
+      @discussion c.discussion(), _.merge(params, {comment: c.id})
 
     buildModelRoute: (path, key, name, params, options) ->
       result = "/#{path}/#{key}"

--- a/lineman/spec/services/lmo_url_service_spec.coffee
+++ b/lineman/spec/services/lmo_url_service_spec.coffee
@@ -59,4 +59,4 @@ describe 'LmoUrlService', ->
 
     describe 'comment', ->
       it 'gives a comment path', ->
-        expect(service.comment(comment)).toBe("/d/#{thread.key}/discussion-title?comment=#{comment.key}")
+        expect(service.comment(comment)).toBe("/d/#{thread.key}/discussion-title?comment=#{comment.id}")


### PR DESCRIPTION
there is still a weird html encoding issue: When these links are sent to the browser they look like this: http://localhost:8000/d/Fxdes1CL/what-star-sign-are-you-%3Fcomment=722017