### PR TITLE
Temp fix for groups not appearing after deactivate

### DIFF
--- a/lineman/app/components/groups_page/groups_page_controller.coffee
+++ b/lineman/app/components/groups_page/groups_page_controller.coffee
@@ -3,7 +3,7 @@ angular.module('loomioApp').controller 'GroupsPageController', ($rootScope, Curr
   $rootScope.$broadcast('setTitle', 'Groups')
 
   @parentGroups = =>
-    _.unique _.map CurrentUser.memberships(), (membership) =>
+    _.unique _.compact _.map CurrentUser.memberships(), (membership) =>
       if membership.group().isParent()
         membership.group()
       else if !CurrentUser.isMemberOf(membership.group().parent())

--- a/lineman/app/models/group_model.coffee
+++ b/lineman/app/models/group_model.coffee
@@ -127,5 +127,5 @@ angular.module('loomioApp').factory 'GroupModel', (BaseModel, AppConfig) ->
 
     archive: =>
       @remote.patchMember(@key, 'archive').then =>
-        @recordsInterface.collection.remove(@)
-
+        @remove()
+        _.each @memberships(), (m) -> m.remove()

--- a/lineman/package.json
+++ b/lineman/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "angular": "^1.4.4",
     "angular-ui-bootstrap": "0.13.3",
-    "angular_record_store": "git://github.com/loomio/angular_record_store.git#2.1.5",
+    "angular_record_store": "git://github.com/loomio/angular_record_store.git#2.3.0",
     "bootstrap": "^3.3.5",
     "coffee-script": "^1.8.0",
     "loomio-angular-router": "0.5.6"


### PR DESCRIPTION
I just wanted to put this up for a little discussion before I worked on the record store itself @robguthrie 

I think the minimum viable fix here is to add a `vanish` (naming? Something which says 'remove from client database') method to `base_model`, and manually call it for dependant: destroy relationships.

Later on, when we have more use cases, we can put in a more automatic way of dealing with orphans.

```
@remote.patchMember(@key, 'archive').then =>
  @vanish()
  _.each @memberships(), (m) -> m.vanish()
```