### PR TITLE
small changes from a11y review 3 sept 2015

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -188,6 +188,7 @@ en:
     change_your_vote: Change your vote.
 
   undecided_panel:
+    aria_label: 'Undecided members'
     show_undecided: Show undecided members
     hide_undecided: Hide undecided members
 
@@ -565,7 +566,7 @@ en:
     threads_from:
       group: 'Threads from'
       proposals: 'Proposals'
-      starred: 'Starred'
+      starred: 'Starred threads'
       today: 'Today'
       yesterday: 'Yesterday'
       thisweek: 'This week'

--- a/lineman/app/components/start_proposal_button/start_proposal_button.haml
+++ b/lineman/app/components/start_proposal_button/start_proposal_button.haml
@@ -1,4 +1,4 @@
 .start-proposal-button{ng-show: 'canStartProposal()'}
   %button.btn.btn-success.start-proposal-button__button{type: 'button', ng-click: 'startProposal()'}
-    %i.fa.fa-lg.fa-rocket>
+    %i.fa.fa-lg.fa-rocket{aria-hidden: 'true'}>
     %span{translate: 'proposal_form.start_proposal'}

--- a/lineman/app/components/thread_page/comment_form/comment_form.haml
+++ b/lineman/app/components/thread_page/comment_form/comment_form.haml
@@ -4,7 +4,7 @@
     %input{type: 'hidden', ng-model: 'comment.usesMarkdown'}
     %h2.lmo-card-heading#comment-form-title{translate: 'comment_form.aria_label'}>
     %span{translate: 'comment_form.in_reply_to', translate-values: "{name: '{{comment.parent().authorName()}}' }", ng-show: 'comment.parent().authorName()'}
-    %textarea.form-control.comment-form__comment-field.lmo-primary-form-input{name: 'body', placeholder: "Say something...", ng_model: 'comment.body', mentio: true, mentio-trigger-char: "'@'", mentio_items: 'mentionables', mentio-template-url: 'generated/components/thread_page/comment_form/mentio_menu.html', mentio-search: 'fetchByNameFragment(term)', mentio-id: 'comment-field', ng-model-options: "{ updateOn: 'default blur', debounce: {'default': 300, 'blur': 0} }"}
+    %textarea.form-control.comment-form__comment-field.lmo-primary-form-input{aria-labelledby: 'comment-form-title', name: 'body', placeholder: "Say something...", ng_model: 'comment.body', mentio: true, mentio-trigger-char: "'@'", mentio_items: 'mentionables', mentio-template-url: 'generated/components/thread_page/comment_form/mentio_menu.html', mentio-search: 'fetchByNameFragment(term)', mentio-id: 'comment-field', ng-model-options: "{ updateOn: 'default blur', debounce: {'default': 300, 'blur': 0} }"}
     .comment-row.comment-attachments{ng_repeat: 'attachment in comment.newAttachments()'}
       %a.attachment-link{ng_href: '{{attachment.location}}', target: '_blank'}>
         {{ attachment.filename }}

--- a/lineman/app/components/thread_page/proposal_positions_panel/proposal_positions_panel.haml
+++ b/lineman/app/components/thread_page/proposal_positions_panel/proposal_positions_panel.haml
@@ -5,8 +5,8 @@
     .proposal-pie-chart__pie.media-left
       %pie_chart.proposal-positions-panel__pie-chart{votes: 'proposal.voteCounts'}
     .proposal-pie-chart__legend.media-body
-      %label.sr-only{translate: 'proposal_expanded.current_votes'}
-      %table
+      %table#proposal-current-positions{role: 'presentation'}
+        %caption.sr-only{translate: 'proposal_expanded.current_votes'}
         %tbody
           %tr{ng-repeat: 'position in proposal.positions'}
             %td

--- a/lineman/app/components/thread_page/thread_page.haml
+++ b/lineman/app/components/thread_page/thread_page.haml
@@ -40,7 +40,7 @@
           %i.fa.fa-globe{aria-hidden: 'true'}>
           %span{translate: 'common.privacy.public'}
 
-      %article.thread-context__description.lmo-markdown-wrapper{marked: 'threadPage.discussion.description', aria-label: "{{ 'thread_context.aria_label' | translate }}" }
+      .thread-context__description.lmo-markdown-wrapper{marked: 'threadPage.discussion.description', aria-label: "{{ 'thread_context.aria_label' | translate }}" }
 
     %section.start-proposal-card{in-view: 'threadPage.proposalButtonInView($inview)', in-view-options: '{debounce: 200}', ng-if: 'threadPage.canStartProposal()', aria-label: '{{ "start_proposal_card.title" | translate }}'}
       %h2.lmo-card-heading{translate: 'common.models.proposal'}

--- a/lineman/app/components/thread_page/undecided_panel/undecided_panel.coffee
+++ b/lineman/app/components/thread_page/undecided_panel/undecided_panel.coffee
@@ -3,13 +3,15 @@ angular.module('loomioApp').directive 'undecidedPanel', ->
   restrict: 'E'
   templateUrl: 'generated/components/thread_page/undecided_panel/undecided_panel.html'
   replace: true
-  controller: ($scope, Records) ->
+  controller: ($scope, $timeout, Records) ->
 
     $scope.undecidedPanelOpen = false
 
     $scope.showUndecided = ->
       $scope.proposal.fetchUndecidedMembers()
       $scope.undecidedPanelOpen = true
+      $timeout ->
+        document.querySelector('.undecided-panel__heading').focus()
 
     $scope.hideUndecided = ->
       $scope.undecidedPanelOpen = false

--- a/lineman/app/components/thread_page/undecided_panel/undecided_panel.haml
+++ b/lineman/app/components/thread_page/undecided_panel/undecided_panel.haml
@@ -1,9 +1,10 @@
 .undecided-panel
   %a.undecided-panel__show-undecided-link{href: '', ng-click: 'showUndecided()', ng-show: '!undecidedPanelOpen', translate: 'undecided_panel.show_undecided'}
+  %h3.undecided-panel__heading.sr-only{ng-show: 'undecidedPanelOpen', translate: 'undecided_panel.aria_label', tabindex: 0}
   %ul.undecided-panel__list{ng-if: 'undecidedPanelOpen'}
     %li.media{ng-repeat: 'user in proposal.undecidedMembers() track by user.id'}
       .media-left
-        %i.fa.fa-question-circle.undecided-panel__icon
+        %i.fa.fa-question-circle.undecided-panel__icon{aria-hidden: 'true'}
       .media-body
         %span.undecided-panel__user {{user.name}}
   %a.undecided-panel__hide-undecided-link{href: '', ng-click: 'hideUndecided()', ng-show: 'undecidedPanelOpen', translate: 'undecided_panel.hide_undecided'}


### PR DESCRIPTION
dashboard - replace "starred" with "starred threads"?
Thread page - remove %article from Thread context region
Label (aria-labelledby) the comment textarea by the h2 above it
Question mark dangling in the Start proposal button
Current votes table try role=presentation, use caption element to label
it
add sr-only heading for undecided memebers and focus it when showing
undecided members