### PR TITLE
Fix thread options dropdown formatting

### DIFF
--- a/lineman/app/components/thread_page/thread_page.haml
+++ b/lineman/app/components/thread_page/thread_page.haml
@@ -24,10 +24,10 @@
             %i.fa.fa-fw.fa-chevron-down{aria-hidden: 'true'}
           .dropdown-menu.dropdown-menu-right
             %ul.dropdown-menu-items
-              %li.dropdown-menu-item
-                %a.thread-context__dropdown-options-edit.dropdown-menu-item-label{href: '', ng-click: 'threadPage.editDiscussion()', translate: 'thread_context.edit_thread', ng-if: 'threadPage.canEditDiscussion()'}
-              %li.dropdown-menu-item
-                %a.thread-context__dropdown-options-delete.dropdown-menu-item-label{href: '', ng-click: 'threadPage.deleteDiscussion()', translate: 'thread_context.delete_thread', ng-if: 'threadPage.canDeleteDiscussion()'}
+              %li.dropdown-menu-item{ng-if: 'threadPage.canEditDiscussion()'}
+                %a.thread-context__dropdown-options-edit.dropdown-menu-item-label{href: '', ng-click: 'threadPage.editDiscussion()', translate: 'thread_context.edit_thread'}
+              %li.dropdown-menu-item{ng-if: 'threadPage.canDeleteDiscussion()'}
+                %a.thread-context__dropdown-options-delete.dropdown-menu-item-label{href: '', ng-click: 'threadPage.deleteDiscussion()', translate: 'thread_context.delete_thread'}
       .clearfix
       %h1.lmo-h1#thread-context__heading{in-view: 'threadPage.showLintel(!$inview)'}
         {{threadPage.discussion.title}}


### PR DESCRIPTION
Fix extra spacing in thread options dropdown

<img width="340" alt="screen shot 2015-09-15 at 4 07 21 pm" src="https://cloud.githubusercontent.com/assets/2882097/9867614/e86cab8a-5bc3-11e5-8ffd-1949637266b8.png">
