### PR TITLE
tell intercom which users are on beta

### DIFF
--- a/config/initializers/intercom.rb
+++ b/config/initializers/intercom.rb
@@ -46,7 +46,8 @@ if Rails.application.secrets.intercom_app_id
     # }
 
     config.user.custom_data = {
-        is_coordinator: :is_group_admin?
+        is_coordinator: :is_group_admin?,
+        angular_ui: false
     }
 
     # == User -> Company association


### PR DESCRIPTION
Minor tweak. Currently beta users turn up in Intercom as "angular=unknown".