### PR TITLE
Fix inbox unread count

### DIFF
--- a/app/serializers/discussion_serializer.rb
+++ b/app/serializers/discussion_serializer.rb
@@ -3,10 +3,10 @@ class DiscussionSerializer < ActiveModel::Serializer
   def self.attributes_from_reader(*attrs)
     attrs.each do |attr|
       case attr
-      when :discussion_reader_id then define_method attr, -> { reader.try(:id) }
-      else                            define_method attr, -> { reader.try(attr) }
+      when :discussion_reader_id then define_method attr, -> { reader.id }
+      else                            define_method attr, -> { reader.send(attr) }
       end
-      define_method :"#{attr}_included?", -> { reader.present? }
+      define_method :"include_#{attr}?", -> { reader.present? }
     end
     attributes *attrs
   end

--- a/spec/controllers/api/notifications_controller_spec.rb
+++ b/spec/controllers/api/notifications_controller_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+describe API::NotificationsController do
+
+  let(:user) { create(:user) }
+  let(:another_user) { create(:user) }
+  let(:discussion) { create(:discussion, author: user) }
+  let(:comment) { build(:comment, discussion: discussion, body: "Hello @#{user.username}") }
+
+  before do
+    discussion.group.users << another_user
+    sign_in user
+    CommentService.create(comment: comment, actor: another_user)
+  end
+
+  describe 'index' do
+
+    context 'success' do
+      it 'does not serialize out null values for discussion readers' do
+        get :index
+        json = JSON.parse(response.body)
+        discussion_json = json['discussions'][0]
+        expect(json['discussions'][0].keys).not_to include 'discussion_reader_id'
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
The current bug:

- We serialize out discussions in the inbox query, and discussions in the notifications query on page load.
- Discussions on the inbox query have discussion readers attached to them, notifications do not
- [BUG]: the notifications query has discussion_reader_id keys on them set to null  (So, it's `{ id: 101, discussion_reader_id: null }` but should be `{id: 101 }`)
- This means that when notifications serialize out, they're overwriting the existing discussion_reader_id as null, which means we're not including those discussions in inbox (because the inbox won't include any discussions which have a null discussion reader id)

All due to a silly oversight on my part, heh; this is basically a typo fix. :heart: 