### PR TITLE
Generalize group theme

### DIFF
--- a/lineman/app/components/group_page/group_page.haml
+++ b/lineman/app/components/group_page/group_page.haml
@@ -1,28 +1,7 @@
 .loading-wrapper.container.main-container
   %loading{ng-if: '!groupPage.group'}
   %main.group-page{ng-if: 'groupPage.group'}
-    .group-page__cover{ng-style:'groupPage.coverStyle()'}
-      %button.lmo-btn-link.group-page__upload-photo{ng-click: 'groupPage.openUploadCoverForm()', ng-show: 'groupPage.canUploadPhotos()'}
-        %i.fa.fa-lg.fa-camera
-    %section.group-page__header{aria-label: "{{ 'group_page.header.aria_label' | translate }}"}
-      .group-page__logo{ng-style:'groupPage.logoStyle()', alt: "{{ 'group_page.group_logo' | translate }}"}
-        %button.lmo-btn-link.group-page__upload-photo{ng-click: 'groupPage.openUploadLogoForm()', ng-show: 'groupPage.canUploadPhotos()'}
-          %i.fa.fa-lg.fa-camera
-      .group-page__name-and-actions
-        .group-page__name
-          %h1.lmo-h1
-            %a{ng_show: 'groupPage.group.parentId', href: '/g/{{groupPage.group.parent().key}}'}
-              {{groupPage.group.parentName()}}
-            %span{ng_show: 'groupPage.group.parentId'}> \-
-            {{groupPage.group.name}}
-        %group_privacy_dropdown{group: 'groupPage.group'}
-        .group-page__member-actions.lmo-btn-group.lmo-btn-group-right{ng-if: 'groupPage.isMember()'}
-          .lmo-btn-wrapper
-            %group_actions_dropdown{group: 'groupPage.group'}
-          .lmo-btn-wrapper
-            %notification_volume_dropdown{translate-root: 'group_page', group: 'groupPage.group'}
-        %join_group_button{group: 'groupPage.group'}
-        .clearfix
+    %group_theme{group: 'groupPage.group', home-page: 'true'}
     .row
       .col-sm-8
         %section.group-page__description{aria-labelledby: 'description-card-title'}

--- a/lineman/app/components/group_page/group_page.scss
+++ b/lineman/app/components/group_page/group_page.scss
@@ -8,66 +8,6 @@
   }
 }
 
-.group-page__cover{
-  position: absolute;
-  top: $navbar-height;
-  left: 0;
-  width: 100%;
-  height: 320px;
-  background: url('http://placehold.it/640x160') no-repeat center center #f5f5f5;
-  background-size: cover;
-}
-
 .group-page__description {
   @include card;
-}
-
-.group-page__header{
-  width: 100%;
-  position: relative;
-  min-height: 335px;
-}
-
-.group-page__header .btn{
-  @include fontSmall;
-}
-
-.group-page__logo{
-  position: relative;
-  top: 215px;
-  width: 108px;
-  height: 108px;
-  background: url('http://placehold.it/100x100') no-repeat top center white;
-  border: 4px solid #fff;
-}
-
-.group-page__name-and-actions{
-  margin-top: 175px;
-}
-
-.group-page__nonmember-actions { float: right; }
-.group-page__member-actions .btn { @include fontHelveticaBold; }
-
-.group-page__name {
-  float: left;
-  max-width: 50%;
-  margin-left: 108px + 15px;
-  a{color: $primary-text-color;}
-}
-
-.group-page__privacy{
-  float: left;
-  margin-left: 15px;
-}
-
-.group-page__upload-photo {
-  position: relative;
-  left: 5px;
-  top: 5px;
-  cursor: pointer;
-}
-
-.group-page__upload-photo i {
-  color: white;
-  text-shadow: 1px 1px 4px $grey-on-grey;
 }

--- a/lineman/app/components/group_page/group_page_controller.coffee
+++ b/lineman/app/components/group_page/group_page_controller.coffee
@@ -1,4 +1,4 @@
-angular.module('loomioApp').controller 'GroupPageController', ($rootScope, $routeParams, Records, CurrentUser, ScrollService, MessageChannelService, AbilityService, ModalService, CoverPhotoForm, LogoPhotoForm) ->
+angular.module('loomioApp').controller 'GroupPageController', ($rootScope, $routeParams, Records, CurrentUser, MessageChannelService, AbilityService) ->
   $rootScope.$broadcast 'currentComponent', {page: 'groupPage'}
 
   Records.groups.findOrFetchById($routeParams.key).then (group) =>
@@ -11,28 +11,10 @@ angular.module('loomioApp').controller 'GroupPageController', ($rootScope, $rout
   , (error) ->
     $rootScope.$broadcast('pageError', error)
 
-  @logoStyle = ->
-    { 'background-image': "url(#{@group.logoUrl()})" }
-
-  @coverStyle = ->
-    { 'background-image': "url(#{@group.coverUrl()})" }
-
-  @isMember = ->
-    CurrentUser.membershipFor(@group)?
-
   @showDescriptionPlaceholder = ->
     AbilityService.canAdministerGroup(@group) and !@group.description
 
   @canManageMembershipRequests = ->
     AbilityService.canManageMembershipRequests(@group)
-
-  @canUploadPhotos = ->
-    AbilityService.canAdministerGroup(@group)
-
-  @openUploadCoverForm = ->
-    ModalService.open CoverPhotoForm, group: => @group
-
-  @openUploadLogoForm = ->
-    ModalService.open LogoPhotoForm, group: => @group
 
   return

--- a/lineman/app/components/group_page/group_privacy_dropdown/group_privacy_dropdown.haml
+++ b/lineman/app/components/group_page/group_privacy_dropdown/group_privacy_dropdown.haml
@@ -1,4 +1,4 @@
-.group-page__privacy{dropdown: ''}
+.group-theme__privacy{dropdown: ''}
   %button.btn.lmo-btn-nude{dropdown-toggle:''}
     .group-visibility-public{ng_show: 'group.visibleToPublic()'}
       .sr-only{translate: 'group_page.privacy.public'}

--- a/lineman/app/components/group_page/group_theme/group_theme.coffee
+++ b/lineman/app/components/group_page/group_theme/group_theme.coffee
@@ -1,0 +1,24 @@
+angular.module('loomioApp').directive 'groupTheme', ->
+  scope: {group: '=', homePage: '=', compact: '='}
+  restrict: 'E'
+  templateUrl: 'generated/components/group_page/group_theme/group_theme.html'
+  replace: true
+  controller: ($scope, CurrentUser, AbilityService, ModalService, CoverPhotoForm, LogoPhotoForm) ->
+
+    $scope.logoStyle = ->
+      { 'background-image': "url(#{$scope.group.logoUrl()})" }
+
+    $scope.coverStyle = ->
+      { 'background-image': "url(#{$scope.group.coverUrl()})", 'z-index': (-1 if $scope.compact) }
+
+    $scope.isMember = ->
+      CurrentUser.membershipFor($scope.group)?
+
+    $scope.canUploadPhotos = ->
+      $scope.homePage and AbilityService.canAdministerGroup($scope.group)
+
+    $scope.openUploadCoverForm = ->
+      ModalService.open CoverPhotoForm, group: => $scope.group
+
+    $scope.openUploadLogoForm = ->
+      ModalService.open LogoPhotoForm, group: => $scope.group

--- a/lineman/app/components/group_page/group_theme/group_theme.haml
+++ b/lineman/app/components/group_page/group_theme/group_theme.haml
@@ -1,0 +1,36 @@
+.group-theme
+  .group-theme__cover{ng-style:'coverStyle()'}
+    %button.lmo-btn-link.group-theme__upload-photo{ng-click: 'openUploadCoverForm()', ng-if: 'canUploadPhotos()'}
+      %i.fa.fa-lg.fa-camera
+
+  %section.group-theme__header--compact{ng-if: 'compact', aria-label: "{{ 'thread_group.aria_label | translate'}}"}
+    .group-theme__logo--compact{aria-hidden: 'true'}
+      %img{ng-src: "{{group.logoUrl()}}"}
+    .group-theme__name--compact
+      %a{ng-if: 'group.isSubgroup()', lmo-href-for: 'group.parent()'}
+        {{group.parentName()}}
+      %span{ng-if: 'group.isSubgroup()'}> \-
+      %a{lmo-href-for: 'group'}
+        {{group.name}}
+
+  %section.group-theme__header{ng-if: '!compact', aria-label: "{{ 'group_page.header.aria_label' | translate }}"}
+    .group-theme__logo{ng-style:'logoStyle()', alt: "{{ 'group_page.group_logo' | translate }}"}
+      %button.lmo-btn-link.group-theme__upload-photo{ng-click: 'openUploadLogoForm()', ng-if: 'canUploadPhotos()'}
+        %i.fa.fa-lg.fa-camera
+    .group-theme__name-and-actions
+      .group-theme__name
+        %h1.lmo-h1
+          %a{ng-if: 'group.isSubgroup()', lmo-href-for: 'group.parent()'}
+            {{group.parentName()}}
+          %span{ng-if: 'group.isSubgroup()'}> \-
+          %a{lmo-href-for: 'group'}
+            {{group.name}}
+      .group-theme__actions{ng-if: 'homePage'}
+        %group_privacy_dropdown{group: 'group'}
+        .group-theme__member-actions.lmo-btn-group.lmo-btn-group-right{ng-if: 'isMember()'}
+          .lmo-btn-wrapper
+            %group_actions_dropdown{group: 'group'}
+          .lmo-btn-wrapper
+            %notification_volume_dropdown{translate-root: 'group_page', group: 'group'}
+        %join_group_button{group: 'group'}
+      .clearfix

--- a/lineman/app/components/group_page/group_theme/group_theme.scss
+++ b/lineman/app/components/group_page/group_theme/group_theme.scss
@@ -1,0 +1,95 @@
+.group-page {
+  max-width: $large-max-width;
+  margin: 0 auto;
+  padding-top: 48px;
+  /* over-riding bootstrap */
+  .media:first-child{
+    margin-top: 10px;
+  }
+}
+
+.group-theme__cover{
+  position: absolute;
+  top: $navbar-height;
+  left: 0;
+  width: 100%;
+  height: 320px;
+  background: url('http://placehold.it/640x160') no-repeat center center #f5f5f5;
+  background-size: cover;
+  z-index: 0;
+}
+
+.group-theme__header{
+  width: 100%;
+  position: relative;
+  min-height: 335px;
+}
+
+.group-theme__header .btn{
+  @include fontSmall;
+}
+
+.group-theme__header--compact {
+  margin: 215px 0 15px;
+}
+
+.group-theme__header--compact img {
+  @include smallIcon;
+}
+
+.group-theme__logo{
+  position: relative;
+  top: 215px;
+  width: 108px;
+  height: 108px;
+  background: url('http://placehold.it/100x100') no-repeat top center white;
+  border: 4px solid #fff;
+}
+
+.group-theme__logo--compact {
+  display: table-cell;
+}
+
+.group-theme__name-and-actions{
+  margin-top: 175px;
+}
+
+.group-theme__nonmember-actions { float: right; }
+.group-theme__member-actions .btn { @include fontHelveticaBold; }
+
+.group-theme__name {
+  float: left;
+  max-width: 50%;
+  margin-left: 108px + 15px;
+  a{color: $primary-text-color;}
+}
+
+.group-theme__name--compact {
+  display: table-cell;
+  vertical-align: middle;
+  background: rgba(0,0,0,.5);
+  color: white;
+  padding: 0 10px;
+}
+
+.group-theme__name--compact a {
+  color: white;
+  font-weight: bold;
+}
+
+.group-theme__privacy{
+  float: left;
+  margin-left: 15px;
+}
+
+.group-theme__upload-photo {
+  position: relative;
+  left: 5px;
+  top: 5px;
+  cursor: pointer;
+}
+
+.group-theme__upload-photo i {
+  color: white;
+  text-shadow: 1px 1px 4px $grey-on-grey;
+}

--- a/lineman/app/components/membership_requests_page/membership_requests_page.haml
+++ b/lineman/app/components/membership_requests_page/membership_requests_page.haml
@@ -1,5 +1,7 @@
-.container.main-container
-  %main.membership-requests-page{ng-if: 'membershipRequestsPage.group'}
+.loading-wrapper.container.main-container
+  %loading{ng-if: '!membershipRequestsPage.group'}
+  %main.memberships-request-page.main-container{ng-if: 'membershipRequestsPage.group'}
+    %group_theme{group: 'membershipRequestsPage.group'}
     .membership-requests-page__pending-requests
       %h2.lmo-h2{translate: 'membership_requests_page.heading'}
       %ul{ng-if: 'membershipRequestsPage.group.hasPendingMembershipRequests()'}

--- a/lineman/app/components/memberships_page/memberships_page.haml
+++ b/lineman/app/components/memberships_page/memberships_page.haml
@@ -1,22 +1,12 @@
 .loading-wrapper.container.main-container
   %loading{ng-if: '!membershipsPage.group'}
-  .group-page__cover{style:'background-image:url({{membershipsPage.group.coverUrl()}})'}
   %main.memberships-page.main-container{ng-if: 'membershipsPage.group'}
-    %section.group-page__header{aria-label: "{{ 'group_page.header.aria_label' | translate }}"}
-      .group-page__logo{style:'background-image:url({{membershipsPage.group.logoUrl()}})', alt: "{{ 'group_page.group_logo' | translate }}"}
-      .group-page__name-and-actions
-        .group-page__name
-          %h1.lmo-h1
-            %a{lmo-href-for: 'membershipsPage.group.parent()', ng-show: 'membershipsPage.group.parentId'}
-              {{membershipsPage.group.parentName()}}
-            %span{ng_show: 'membershipsPage.group.parentId'}> \-
-            %a{lmo-href-for: 'membershipsPage.group'}
-              {{membershipsPage.group.name}}
-      .memberships-page__memberships
-        %h2.lmo-h2{translate: 'memberships_page.members'}
-        .memberships-page__search-filter
-          %input.membership-page__search-filter.form-control{ng-model: 'membershipsPage.fragment', ng-model-options: '{debounce: 300}', ng-change: 'membershipsPage.fetchMemberships()', placeholder: '{{"memberships_page.fragment_placeholder" | translate}}'}
-          %i.fa.fa-lg.fa-search
-        %admin_memberships_panel{ng-if: 'membershipsPage.canAdministerGroup()', memberships: 'membershipsPage.memberships', group: 'membershipsPage.group'}
-        %memberships_panel{ng-if: '!membershipsPage.canAdministerGroup()', memberships: 'membershipsPage.memberships', group: 'membershipsPage.group'}
-      %pending_invitations_card{group: 'membershipsPage.group'}
+    %group_theme{group: 'membershipsPage.group'}
+    .memberships-page__memberships
+      %h2.lmo-h2{translate: 'memberships_page.members'}
+      .memberships-page__search-filter
+        %input.membership-page__search-filter.form-control{ng-model: 'membershipsPage.fragment', ng-model-options: '{debounce: 300}', ng-change: 'membershipsPage.fetchMemberships()', placeholder: '{{"memberships_page.fragment_placeholder" | translate}}'}
+        %i.fa.fa-lg.fa-search
+      %admin_memberships_panel{ng-if: 'membershipsPage.canAdministerGroup()', memberships: 'membershipsPage.memberships', group: 'membershipsPage.group'}
+      %memberships_panel{ng-if: '!membershipsPage.canAdministerGroup()', memberships: 'membershipsPage.memberships', group: 'membershipsPage.group'}
+    %pending_invitations_card{group: 'membershipsPage.group'}

--- a/lineman/app/components/memberships_page/memberships_page.scss
+++ b/lineman/app/components/memberships_page/memberships_page.scss
@@ -23,8 +23,6 @@
   @include card;
   padding-top: 10px;
   clear: both;
-  position: relative;
-  top: 25px;
 }
 
 .memberships-page__member-info {

--- a/lineman/app/components/thread_page/thread_page.haml
+++ b/lineman/app/components/thread_page/thread_page.haml
@@ -1,16 +1,7 @@
 .loading-wrapper.container.main-container
   %loading{ng-if: '!threadPage.discussion'}
   %main.thread-page{ng-if: 'threadPage.discussion'}
-
-    %section.media.thread-group{aria-label: "{{ 'thread_group.aria_label' | translate }}"}
-      .media-left.thread-group__icon{aria-hidden: 'true'}
-        %img.thread-group-logo{ng-src: "{{threadPage.group().logoUrl()}}"}
-      .media-body.thread-group__name
-        %a{ng_show: 'threadPage.group().parentId', lmo-href-for: 'threadPage.group().parent()'}
-          {{threadPage.group().parentName()}}
-        %span{ng_show: 'threadPage.group().parentId', aria-label: '-'}> >
-        %a{lmo-href-for: 'threadPage.group()'}
-          {{threadPage.group().name}}
+    %group_theme{group: 'threadPage.discussion.group()', compact: 'true'}
 
     %section.thread-context{aria-label: "{{ 'thread_context.aria_label' | translate }}"}
       %h2.lmo-card-heading{aria-hidden: 'true', translate: 'context_card.heading'}

--- a/lineman/spec-e2e/helpers/groups_helper.coffee
+++ b/lineman/spec-e2e/helpers/groups_helper.coffee
@@ -72,7 +72,7 @@ module.exports = new class GroupsHelper
     element(By.css('.group-page')).getText()
 
   groupPageHeader: ->
-    element(By.css('.group-page__name h1'))
+    element(By.css('.group-theme__name h1'))
 
   clickJoinGroupButton: ->
     element(By.css('.join-group-button__join-group')).click()
@@ -133,4 +133,4 @@ module.exports = new class GroupsHelper
     element(By.css('.start-group-form__submit')).click()
 
   groupName: ->
-    element(By.css('.group-page__name')).getText()
+    element(By.css('.group-theme__name')).getText()

--- a/lineman/spec-e2e/helpers/thread_helper.coffee
+++ b/lineman/spec-e2e/helpers/thread_helper.coffee
@@ -144,7 +144,7 @@ module.exports = new class ThreadHelper
     element(By.css('.thread-context__dropdown-options-edit')).click()
 
   groupTitle: ->
-    element(By.css('.thread-group__name')).getText()
+    element(By.css('.group-theme__name--compact')).getText()
 
   discussionTitle: ->
     element(By.css('.thread-context')).getText()


### PR DESCRIPTION
This applies a directive to allow an easy way to put the group theme on new pages.

QUESTIONABLE BONUS:

I put the group theme on the thread page as well, per the mockups here:
https://projects.invisionapp.com/share/MV4B7FARB#/screens/103662393

In action:
![screen shot 2015-10-03 at 10 44 43 am](https://cloud.githubusercontent.com/assets/750477/10262141/c1a2fecc-69bb-11e5-8282-f703fe588cab.png)

I know we're thinking about revamping the thread page layout, but it was a small bit of work and looks quite nice imho. #IterateDontIncinerate