### PR TITLE
Don't skip booting angular UI when visiting /inbox

### DIFF
--- a/app/controllers/inbox_controller.rb
+++ b/app/controllers/inbox_controller.rb
@@ -1,7 +1,7 @@
 class InboxController < BaseController
   include DiscussionIndexCacheHelper
   after_filter :clear_discussion_index_caches, only: :index
-  skip_before_filter :boot_angular_ui
+  skip_before_filter :boot_angular_ui, except: :index
 
   def index
     load_inbox

--- a/app/controllers/inbox_controller.rb
+++ b/app/controllers/inbox_controller.rb
@@ -1,7 +1,7 @@
 class InboxController < BaseController
   include DiscussionIndexCacheHelper
   after_filter :clear_discussion_index_caches, only: :index
-  skip_before_filter :boot_angular_ui, except: :index
+  skip_before_filter :boot_angular_ui, only: :size
 
   def index
     load_inbox


### PR DESCRIPTION
Currently visiting `loomio.org/inbox` renders a weird half-baked version of the old beta interface, even if you're on angular.

This is what the protractor tests are complaining about... not sure when this broke?