### PR TITLE
repatriate navbar orphans

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -122,6 +122,7 @@ en:
     groups_title: 'View your groups'
     start_thread: 'Start a new thread'
     notifications: 'Notifications panel'
+    user_actions: 'User actions'
     user_options:
       label: 'User options'
       contact_us: 'Contact us'

--- a/lineman/app/components/navbar/navbar.haml
+++ b/lineman/app/components/navbar/navbar.haml
@@ -1,5 +1,5 @@
-%header.lmo-navbar{role: 'navigation'}
-  .lmo-navbar-item-container.lmo-navbar-item-container--left
+%header.lmo-navbar{role: 'banner'}
+  %section.lmo-navbar-item-container.lmo-navbar-item-container--left{role: 'navigation'}
     .lmo-navbar__item{ng-class: '{"lmo-navbar__item--selected": selected == "dashboardPage"}'}
       %a.btn.lmo-navbar__btn.lmo-navbar__btn-icon.lmo-navbar__recent{lmo-href: '/dashboard', title: "{{ 'navbar.recent_title' | translate }}", tabindex: 1, ng-click: 'homePageClicked()'}
         %i.fa.fa-lg.fa-clock-o>
@@ -17,10 +17,10 @@
     .lmo-navbar__item.lmo-navbar__logo
       %img{src: 'img/logo.png'}
   .lmo-navbar-item-container.lmo-navbar-item-container--right
-    .lmo-navbar-item-container__sub.lmo-navbar-item-container__sub--left
-      .lmo-navbar__item{role: 'search'}
+    %section.lmo-navbar-item-container__sub.lmo-navbar-item-container__sub--left{role: 'search'}
+      .lmo-navbar__item
         %navbar_search
-    .lmo-navbar-item-container__sub.lmo-navbar-item-container__sub--right
+    %section.lmo-navbar-item-container__sub.lmo-navbar-item-container__sub--right{aria-label: "{{ 'navbar.user_actions' | translate }}"}
       .lmo-navbar__item.lmo-navbar__item--notifications
         %notifications
       .lmo-navbar__item.lmo-navbar__item--user


### PR DESCRIPTION
FYI there are a small number of predefined ["Landmark" roles](http://mcdlr.com/wai-aria-cheatsheet/), like banner, search, main, navigation, etc. 

When we have a region that doesn't make sense to be identified with a Landmark role, then we just use aria-label and call it whatever we like. 

That's why there's `role: 'banner'` and `aria-label: 'user-actions'` in this pull request.