### PR TITLE
align search dropdown with search input on desktop

### DIFF
--- a/lineman/app/components/navbar/navbar_search.scss
+++ b/lineman/app/components/navbar/navbar_search.scss
@@ -36,6 +36,7 @@
 
   width: 100%;
   top: $navbar-height;
+  right: 93px; /*overridden on small screens by media query below*/
   text-align: left;
   max-width: 320px;
   margin-top: 2px;


### PR DESCRIPTION
Fixes search results dropdown on desktop. Mobile unaffected.

**Before**

![image](https://cloud.githubusercontent.com/assets/970124/10323422/6c93a8ec-6cdf-11e5-9cca-60ca7661cde6.png)

**After**

![image](https://cloud.githubusercontent.com/assets/970124/10323389/30ec6194-6cdf-11e5-9a1d-8f853c04d30b.png)
