### PR TITLE
add help links and tidy up group page cards

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -21,6 +21,7 @@ en:
       thisweek: 'This Week'
       thismonth: 'This Month'
       older: 'Older'
+    more_help: 'More help'
     models:
       proposal: 'Proposal'
     action:
@@ -426,7 +427,8 @@ en:
 
   membership_requests_card:
     heading: 'Membership Requests'
-    manage_requests: Manage requests ({{count}})
+    manage_requests: Manage requests
+    manage_requests_with_count: Manage requests ({{count}})
 
   group_help_card:
     title: Help

--- a/lineman/app/components/group_page/group_help_card/group_help_card.haml
+++ b/lineman/app/components/group_page/group_help_card/group_help_card.haml
@@ -15,3 +15,5 @@
       .media-body
         %a.group-help-card__article-title{href: 'http://blog.loomio.org/2015/09/18/9-ways-to-use-a-loomio-proposal-to-turn-a-conversation-into-action/', title: '9 ways to use a Loomio proposal to turn a conversation into action'}
           %strong{translate: 'group_help_card.nine_ways_to_use_proposals'}
+  %a.group-help-card__more-help.lmo-card-minor-action{lmo-href: 'https://help.loomio.org', target: '_blank'}
+    %span{translate: 'common.more_help'}

--- a/lineman/app/components/group_page/group_previous_proposals_card/group_previous_proposals_card.haml
+++ b/lineman/app/components/group_page/group_previous_proposals_card/group_previous_proposals_card.haml
@@ -4,7 +4,8 @@
     %ul.group-previous-proposals-card__previous_proposals
       %li.group-previous-proposals-card__previous_proposal{ng-repeat: 'proposal in group.closedProposals() | limitTo: 3 track by proposal.id'}
         %pie_with_position.pull-left{proposal: 'proposal'}
-        .group-previous-proposals-card__title
-          {{proposal.name}}
-    %a.group-previous-proposals-card__link{lmo-href-for: 'group', lmo-href-action: 'previous_proposals'}
+        %a{lmo-href-for: 'group', lmo-href-action: 'previous_proposals'}
+          .group-previous-proposals-card__proposal-title
+            {{proposal.name}}
+    %a.group-previous-proposals-card__link.lmo-card-minor-action{lmo-href-for: 'group', lmo-href-action: 'previous_proposals'}
       %span{translate: 'group_previous_proposals_card.see_more'}

--- a/lineman/app/components/group_page/group_previous_proposals_card/group_previous_proposals_card.scss
+++ b/lineman/app/components/group_page/group_previous_proposals_card/group_previous_proposals_card.scss
@@ -11,6 +11,7 @@
   margin-bottom: 10px;
 }
 
-.group-previous-proposals-card__title {
+.group-previous-proposals-card__proposal-title {
   margin-left: 10px;
+  color: $primary-text-color;
 }

--- a/lineman/app/components/group_page/group_theme/group_theme.scss
+++ b/lineman/app/components/group_page/group_theme/group_theme.scss
@@ -2,10 +2,6 @@
   max-width: $large-max-width;
   margin: 0 auto;
   padding-top: 48px;
-  /* over-riding bootstrap */
-  .media:first-child{
-    margin-top: 10px;
-  }
 }
 
 .group-theme__cover{

--- a/lineman/app/components/group_page/members_card/members_card.haml
+++ b/lineman/app/components/group_page/members_card/members_card.haml
@@ -9,6 +9,5 @@
       %a.btn.btn-success.btn-block.lmo-btn-icon{href: '', ng_click: 'invitePeople()'}
         %i.fa.fa-lg.fa-plus>
         %span{translate: 'group_page.invite_people' }
-    .members-card__manage-members.card-minor-action
-      %a{lmo-href-for: 'group', lmo-href-action: 'memberships'}
-        %span{translate: 'group_page.all_members', translate-value-count: '{{group.membershipsCount}}'}
+    %a.members-card__manage-members.lmo-card-minor-action{lmo-href-for: 'group', lmo-href-action: 'memberships'}
+      %span{translate: 'group_page.all_members', translate-value-count: '{{group.membershipsCount}}'}

--- a/lineman/app/components/group_page/membership_requests_card/membership_requests_card.haml
+++ b/lineman/app/components/group_page/membership_requests_card/membership_requests_card.haml
@@ -3,10 +3,11 @@
     %h2.lmo-card-heading{translate: 'membership_requests_card.heading'}
     %ul.membership-requests-card__pending-requests
       %li.media{ng-repeat: 'membershipRequest in group.pendingMembershipRequests() | orderBy: ["-createdAt"] | limitTo: 5 track by membershipRequest.id'}
-        .media-left
-          %user_avatar{user: 'membershipRequest.actor()', size: 'medium'}
-        .media-body
-          %span.membership-requests-card__requestor-name {{membershipRequest.actor().name}}
-          .lmo-truncate.membership-requests-card__requestor-introduction {{membershipRequest.introduction}}
-    %a.membership-requests-card__link{lmo-href-for: 'group', lmo-href-action: 'membership_requests'}
-      %span{translate: 'membership_requests_card.manage_requests', translate-value-count: '{{group.pendingMembershipRequests().length}}'}
+        %a{lmo-href-for: 'group', lmo-href-action: 'membership_requests', title: "{{ 'membership_requests_card.manage_requests' | translate }}"}
+          .media-left
+            %user_avatar{user: 'membershipRequest.actor()', size: 'medium'}
+          .media-body
+            %span.membership-requests-card__requestor-name {{membershipRequest.actor().name}}
+            .lmo-truncate.membership-requests-card__requestor-introduction {{membershipRequest.introduction}}
+    %a.membership-requests-card__link.lmo-card-minor-action{lmo-href-for: 'group', lmo-href-action: 'membership_requests'}
+      %span{translate: 'membership_requests_card.manage_requests_with_count', translate-value-count: '{{group.pendingMembershipRequests().length}}'}

--- a/lineman/app/components/group_page/membership_requests_card/membership_requests_card.scss
+++ b/lineman/app/components/group_page/membership_requests_card/membership_requests_card.scss
@@ -8,11 +8,18 @@
 }
 
 .membership-requests-card__requestor-name{
-  font-weight: 600;
-  font-size: 12px;
+  @include fontSmall;
+  @include fontHelveticaBold;
+  color: $primary-text-color;
 }
 
 .membership-requests-card__requestor-introduction{
+  @include fontSmall;
   color: $grey-on-white;
-  font-size: 12px;
+}
+.membership-requests-card__pending-requests a{
+  color: $grey-on-white;
+}
+.membership-requests-card__pending-requests a:hover{
+  text-decoration: none;
 }

--- a/lineman/app/components/group_page/subgroups_card/subgroups_card.haml
+++ b/lineman/app/components/group_page/subgroups_card/subgroups_card.haml
@@ -9,7 +9,5 @@
         %a{lmo-href-for: 'subgroup'} {{ subgroup.name }}
       .subgroups-card__list-item-description {{ subgroup.description | words:10 }}
 
-  .card-minor-action{ng-if: 'canCreateSubgroups()'}
-    %a.subgroups-card__add-subgroup-link{href: '', ng-click: 'startSubgroup()'}
-      %span{aria-hidden:'true'}>+
-      %span{ translate: 'common.action.add_subgroup' }
+  %a.subgroups-card__add-subgroup-link.lmo-card-minor-action{href: '', ng-click: 'startSubgroup()', ng-if: 'canCreateSubgroups()'}
+    %span{ translate: 'common.action.add_subgroup' }

--- a/lineman/app/components/mixins.scss
+++ b/lineman/app/components/mixins.scss
@@ -135,10 +135,6 @@ $boxLargeSize: 80px;
   background: #fff;
   margin-bottom: 8px;
   i{ color: $grey-on-white; }
-  .card-minor-action{
-    margin: 10px 0 0 0;
-    clear: both;
-  }
 }
 
 $thinPaddingSize: 10px;

--- a/lineman/app/components/navbar/navbar.scss
+++ b/lineman/app/components/navbar/navbar.scss
@@ -70,9 +70,6 @@
   .lmo-navbar__btn{
     padding: 7px 6px;
   }
-  .dropdown i.fa {
-    width: 24px;
-  }
 }
 
 .lmo-navbar__btn{

--- a/lineman/app/components/navbar/navbar_user_options.haml
+++ b/lineman/app/components/navbar/navbar_user_options.haml
@@ -13,9 +13,13 @@
           %a.navbar-user-options__email-settings-link{lmo-href: '/email_preferences'}
             %i.fa.fa-envelope>
             %span{translate: 'navbar.user_options.email_settings'}
+        %li.dropdown-menu-item
+          %a.navbar-user-options__help-link{lmo-href: 'https://help.loomio.org', target: '_blank'}
+            %i.fa.fa-info-circle>
+            %span{translate: 'navbar.user_options.help'}
         %li.dropdown-menu-item{ng-if: 'showContactUs()'}
-          %a.navbar-user-options__email-settings-link{ng-click: 'contactUs()'}
-            %i.fa.fa-question>
+          %a.navbar-user-options__contact-us-link{ng-click: 'contactUs()'}
+            %i.fa.fa-question-circle>
             %span{translate: 'navbar.user_options.contact_us'}
         %li.dropdown-menu-item
           %a.navbar-user-options__sign-out-link{href: '', ng-click: 'signOut()'}

--- a/lineman/app/components/utilities.scss
+++ b/lineman/app/components/utilities.scss
@@ -347,3 +347,15 @@ label.label-with-details{
   line-height: 35px;
   text-decoration: underline;
 }
+
+.lmo-card-minor-action{
+  @include fontHelveticaLight;
+  color: $grey-on-white;
+  text-decoration: underline;
+  margin: 10px 0 0 0;
+  display: block;
+}
+
+.dropdown-menu i.fa {
+  width: 30px;
+}


### PR DESCRIPTION
# Changes

* add help link to user dropdown
* add help link to group page help card
* make group page previous proposals list items link to previous proposals page
* make group page membership requests list items link to membership requests page
* standardise all the lmo-card-minor-action links on the group page cards

# Before

![before](https://cloud.githubusercontent.com/assets/970124/10327073/ac97cf8e-6cff-11e5-98e5-5f95cb846f67.png)

# After 

![after](https://cloud.githubusercontent.com/assets/970124/10327080/ba0a37ba-6cff-11e5-9fca-94c220a6cedd.png)