### PR TITLE
reinstate threads card

### DIFF
--- a/lineman/app/components/group_page/discussions_card/discussions_card.haml
+++ b/lineman/app/components/group_page/discussions_card/discussions_card.haml
@@ -1,16 +1,16 @@
 %section.discussions-card{aria-labelledby: 'threads-card-title'}
-  .lmo-card-padding
-    %a.discussions-card__new-thread-button.btn.btn-success.lmo-btn-icon{ng-if: 'isMemberOfGroup()', href: '', ng_click: 'openDiscussionForm()', title: "{{ 'navbar.start_thread' | translate }}"}
-      %i.fa.fa-plus{aria-hidden: 'true'}>
-      %span{translate: 'navbar.start_thread'}
 
-    %h2#threads-card-title.lmo-card-heading{ translate: 'group_page.discussions'}
-    .lmo-placeholder{translate: 'group_page.discussions_placeholder', ng-if: 'showThreadsPlaceholder()' }
+  %a.discussions-card__new-thread-button.btn.btn-success.lmo-btn-icon{ng-if: 'isMemberOfGroup()', href: '', ng_click: 'openDiscussionForm()', title: "{{ 'navbar.start_thread' | translate }}"}
+    %i.fa.fa-plus{aria-hidden: 'true'}>
+    %span{translate: 'navbar.start_thread'}
 
-    .discussions-card__list--empty{ng-if: '!loadMoreExecuting && !discussions.any()'}
-      .discussions-card__list-empty-reason{translate: 'group_page.thread_list.empty.{{whyImEmpty()}}'}
-      .discussions-card__how-to-gain-access{ng-if: 'howToGainAccess()'}
-        %span{translate: 'group_page.thread_list.empty.{{howToGainAccess()}}'}
+  %h2#threads-card-title.lmo-card-heading{ translate: 'group_page.discussions'}
+  .lmo-placeholder{translate: 'group_page.discussions_placeholder', ng-if: 'showThreadsPlaceholder()' }
+
+  .discussions-card__list--empty{ng-if: '!loadMoreExecuting && !discussions.any()'}
+    .discussions-card__list-empty-reason{translate: 'group_page.thread_list.empty.{{whyImEmpty()}}'}
+    .discussions-card__how-to-gain-access{ng-if: 'howToGainAccess()'}
+      %span{translate: 'group_page.thread_list.empty.{{howToGainAccess()}}'}
 
   .discussions-card__list
     %section.thread-preview-collection__container{ng-if: 'discussions.any()'}

--- a/lineman/app/components/group_page/discussions_card/discussions_card.haml
+++ b/lineman/app/components/group_page/discussions_card/discussions_card.haml
@@ -1,11 +1,11 @@
 %section.discussions-card{aria-labelledby: 'threads-card-title'}
+  .discussions-card__header
+    %a.discussions-card__new-thread-button.btn.btn-success.lmo-btn-icon{ng-if: 'isMemberOfGroup()', href: '', ng_click: 'openDiscussionForm()', title: "{{ 'navbar.start_thread' | translate }}"}
+      %i.fa.fa-plus{aria-hidden: 'true'}>
+      %span{translate: 'navbar.start_thread'}
 
-  %a.discussions-card__new-thread-button.btn.btn-success.lmo-btn-icon{ng-if: 'isMemberOfGroup()', href: '', ng_click: 'openDiscussionForm()', title: "{{ 'navbar.start_thread' | translate }}"}
-    %i.fa.fa-plus{aria-hidden: 'true'}>
-    %span{translate: 'navbar.start_thread'}
-
-  %h2#threads-card-title.lmo-card-heading{ translate: 'group_page.discussions'}
-  .lmo-placeholder{translate: 'group_page.discussions_placeholder', ng-if: 'showThreadsPlaceholder()' }
+    %h2#threads-card-title.lmo-card-heading{ translate: 'group_page.discussions'}
+    .lmo-placeholder{translate: 'group_page.discussions_placeholder', ng-if: 'showThreadsPlaceholder()' }
 
   .discussions-card__list--empty{ng-if: '!loadMoreExecuting && !discussions.any()'}
     .discussions-card__list-empty-reason{translate: 'group_page.thread_list.empty.{{whyImEmpty()}}'}

--- a/lineman/app/components/group_page/discussions_card/discussions_card.scss
+++ b/lineman/app/components/group_page/discussions_card/discussions_card.scss
@@ -1,3 +1,7 @@
+.discussions-card{
+  @include card;
+}
+
 .discussions-card__new-thread-button{
   @include fontSmall;
   float: right;

--- a/lineman/app/components/group_page/discussions_card/discussions_card.scss
+++ b/lineman/app/components/group_page/discussions_card/discussions_card.scss
@@ -1,5 +1,9 @@
 .discussions-card{
-  @include card;
+  @include cardNoPadding;
+}
+
+.discussions-card__header{
+  margin: $cardPaddingSize;
 }
 
 .discussions-card__new-thread-button{

--- a/lineman/app/components/thread_preview_collection/thread_preview_collection.scss
+++ b/lineman/app/components/thread_preview_collection/thread_preview_collection.scss
@@ -3,3 +3,10 @@
   margin-bottom: $cardPaddingSize;
   margin-top: $thinPaddingSize;
 }
+
+.discussions-card__list .thread-previews-container{
+  @include cardNoPadding;
+  margin: $thinPaddingSize (-1 * $cardPaddingSize);
+  border-width: 1px 0 0 0;
+  box-shadow: none;
+}

--- a/lineman/app/components/thread_preview_collection/thread_preview_collection.scss
+++ b/lineman/app/components/thread_preview_collection/thread_preview_collection.scss
@@ -1,12 +1,5 @@
-.thread-previews-container {
+.inbox-page__groups .thread-previews-container, .dashboard-page__collections .thread-previews-container {
   @include cardNoPadding;
   margin-bottom: $cardPaddingSize;
   margin-top: $thinPaddingSize;
-}
-
-.discussions-card__list .thread-previews-container{
-  @include cardNoPadding;
-  margin: $thinPaddingSize (-1 * $cardPaddingSize);
-  border-width: 1px 0 0 0;
-  box-shadow: none;
 }


### PR DESCRIPTION
Possibly not the best approach to this? it is a bit tricky because the threads list on Dashboard is it's own card, but the threads list on the Group page is inside a card. This works at least. Good enough to merge?

## Before

![screen shot 2015-10-07 at 5 07 06 pm](https://cloud.githubusercontent.com/assets/970124/10328868/1e5d0f38-6d16-11e5-943c-64632c83a496.png)

## After

![screen shot 2015-10-07 at 5 07 38 pm](https://cloud.githubusercontent.com/assets/970124/10328867/1e5a5162-6d16-11e5-930d-0117ea62cc15.png)