### PR TITLE
Simplify my_votes endpoint

### DIFF
--- a/app/controllers/api/votes_controller.rb
+++ b/app/controllers/api/votes_controller.rb
@@ -4,15 +4,7 @@ class API::VotesController < API::RestfulController
   alias :update :create
 
   def my_votes
-    @votes = if params[:discussion_id]
-      load_and_authorize :discussion
-      @discussion.votes.includes({motion: [:author, :outcome_author]}, :user).for_user(current_user).most_recent
-    elsif params[:proposal_ids]
-      ids = params[:proposal_ids].split(',').map(&:to_i)
-      current_user.votes.where(motion_id: ids)
-    else
-      current_user.votes.most_recent.since(3.months.ago).most_recent
-    end
+    @votes = current_user.votes.includes(:motion, :user).where(motion_id: motion_ids).most_recent
     respond_with_collection
   end
 
@@ -21,6 +13,10 @@ class API::VotesController < API::RestfulController
   def visible_records
     load_and_authorize :motion
     @motion.votes.most_recent.order(:created_at)
+  end
+
+  def motion_ids
+    params[:proposal_ids].split(',').map(&:to_i) if params[:proposal_ids]
   end
 
 end

--- a/app/serializers/discussion_serializer.rb
+++ b/app/serializers/discussion_serializer.rb
@@ -44,26 +44,26 @@ class DiscussionSerializer < ActiveModel::Serializer
   has_one :author, serializer: UserSerializer, root: 'users'
   has_one :group, serializer: GroupSerializer, root: 'groups'
   has_one :active_proposal, serializer: MotionSerializer, root: 'proposals'
+  has_one :active_proposal_vote, serializer: VoteSerializer, root: 'votes'
 
-  def author
-    object.author
+  def include_active_proposal_vote?
+    reader.present? && active_proposal.present?
+  end
+
+  def active_proposal_vote
+    active_proposal.votes.find_by(user_id: reader.user_id)
   end
 
   def active_proposal
-    object.current_motion
-  end
-
-  def filter(keys)
-    keys.delete(:active_proposal) unless object.current_motion.present?
-    keys
-  end
-
-  def scope
-    super || {}
+    @active_proposal ||= object.current_motion
   end
 
   def reader
     @reader ||= scope[:reader_cache].get_for(object) if scope[:reader_cache]
+  end
+
+  def scope
+    super || {}
   end
 
 end

--- a/lineman/app/components/dashboard_page/dashboard_page_controller.coffee
+++ b/lineman/app/components/dashboard_page/dashboard_page_controller.coffee
@@ -3,8 +3,6 @@ angular.module('loomioApp').controller 'DashboardPageController', ($rootScope, $
   $rootScope.$broadcast('setTitle', 'Dashboard')
   $rootScope.$broadcast('analyticsClearGroup')
 
-  Records.votes.fetchMyRecentVotes()
-
   @perPage = 50
   @loaded =
     show_all:           0

--- a/lineman/app/components/group_page/group_previous_proposals_card/group_previous_proposals_card.coffee
+++ b/lineman/app/components/group_page/group_previous_proposals_card/group_previous_proposals_card.coffee
@@ -6,12 +6,10 @@ angular.module('loomioApp').directive 'groupPreviousProposalsCard', ->
   controller: ($scope, CurrentUser, Records, AbilityService) ->
     if AbilityService.canViewPreviousProposals($scope.group)
       Records.proposals.fetchClosedByGroup($scope.group.key).then ->
-        Records.votes.fetchMyVotesByProposals($scope.group.closedProposals())
+        Records.votes.fetchMyVotes($scope.group.closedProposals())
 
     $scope.showPreviousProposals = ->
       AbilityService.canViewPreviousProposals($scope.group) and $scope.group.hasPreviousProposals()
 
     $scope.lastVoteByCurrentUser = (proposal) ->
       proposal.lastVoteByUser(CurrentUser)
-
-

--- a/lineman/app/components/previous_proposals_page/previous_proposals_page.coffee
+++ b/lineman/app/components/previous_proposals_page/previous_proposals_page.coffee
@@ -5,7 +5,7 @@ angular.module('loomioApp').controller 'PreviousProposalsPageController', ($scop
     Records.groups.findOrFetchById($routeParams.key).then (group) =>
       @group = group
       Records.proposals.fetchClosedByGroup($routeParams.key).then =>
-        Records.votes.fetchMyVotesByProposals(@group.closedProposals())
+        Records.votes.fetchMyVotes(@group.closedProposals())
 
   $scope.$on 'currentUserMembershipsLoaded', init
   init()

--- a/lineman/app/components/thread_page/previous_proposals_card/previous_proposals_card.coffee
+++ b/lineman/app/components/thread_page/previous_proposals_card/previous_proposals_card.coffee
@@ -5,7 +5,7 @@ angular.module('loomioApp').directive 'previousProposalsCard', ->
   replace: true
   controller: ($scope, $rootScope, $location, Records, ProposalFormService) ->
 
-    Records.votes.fetchMyVotesByDiscussion($scope.discussion)
+    Records.votes.fetchMyVotes($scope.discussion.closedProposals())
     Records.proposals.fetchByDiscussion($scope.discussion).then ->
       if proposal = Records.proposals.find($location.search().proposal)
         $scope.selectProposal(proposal)

--- a/lineman/app/components/thread_page/proposals_card/proposals_card.coffee
+++ b/lineman/app/components/thread_page/proposals_card/proposals_card.coffee
@@ -7,7 +7,7 @@ angular.module('loomioApp').directive 'proposalsCard', ->
   controllerAs: 'proposalsCard'
   controller: (Records, ProposalFormService, CurrentUser) ->
     Records.proposals.fetchByDiscussion @discussion
-    Records.votes.fetchMyVotesByDiscussion @discussion
+    Records.votes.fetchMyVotes @discussion.closedProposals()
 
     @isExpanded = (proposal) ->
       if @selectedProposal?

--- a/lineman/app/models/vote_records_interface.coffee
+++ b/lineman/app/models/vote_records_interface.coffee
@@ -2,19 +2,7 @@ angular.module('loomioApp').factory 'VoteRecordsInterface', (BaseRecordsInterfac
   class VoteRecordsInterface extends BaseRecordsInterface
     model: VoteModel
 
-    fetchMyRecentVotes: ->
-      @fetch
-        path: 'my_votes'
-        cacheKey: 'myVotes'
-
-    fetchMyVotesByDiscussion: (discussion) ->
-      @fetch
-        path: 'my_votes'
-        params:
-          discussion_key: discussion.key
-        cacheKey: "myVotesFor#{discussion.key}" 
-
-    fetchMyVotesByProposals: (proposals) ->
+    fetchMyVotes: (proposals) ->
       proposalIds = _.map proposals, (proposal) -> proposal.id
       @fetch
         path: 'my_votes'
@@ -25,4 +13,3 @@ angular.module('loomioApp').factory 'VoteRecordsInterface', (BaseRecordsInterfac
       @fetch
         params:
           motion_id: proposal.id
-        cacheKey: "votesFor#{proposal.key}"

--- a/spec/controllers/api/votes_controller_spec.rb
+++ b/spec/controllers/api/votes_controller_spec.rb
@@ -57,18 +57,25 @@ describe API::VotesController do
     end
 
     context 'success' do
-      it 'returns votes filtered by discussion and current user' do
-        get :my_votes, discussion_id: discussion.id, format: :json
+
+      let(:other_discussion)         { create :discussion, group: group }
+      let(:other_discussion_motion)  { create :motion, discussion: other_discussion }
+      let(:my_other_discussion_vote) { create :vote, motion: other_discussion_motion }
+
+      it 'returns votes filtered by proposal id and current user' do
+        my_other_discussion_vote
+        get :my_votes, proposal_ids: discussion.motion_ids.join(','), format: :json
         json = JSON.parse(response.body)
         expect(json.keys).to include *(%w[votes])
         motions = json['votes'].map { |v| v['id'] }
         expect(motions).to include my_vote.id
         expect(motions).to include my_other_vote.id
         expect(motions).to_not include other_guys_vote.id
+        expect(motions).to_not include my_other_discussion_vote.id
       end
 
       it 'returns only the most recent vote' do
-        get :my_votes, discussion_id: discussion.id, format: :json
+        get :my_votes, proposal_ids: discussion.motion_ids.join(','), format: :json
         json = JSON.parse(response.body)
         expect(json.keys).to include *(%w[votes])
         motions = json['votes'].map { |v| v['id'] }


### PR DESCRIPTION
Hey @robguthrie I'd be interested in hearing your thoughts on this, as it relates to side loading records we need from the store.

Here I'm loading up the current user's vote when the discussion a) is being loaded with a reader, and b) has a current proposal, but I wonder if there's a better way?

(This should, btw, fix the weird bug where people's votes aren't being loaded correctly on the dashboard sometimes... basically I don't trust the `my_votes` endpoint very much at the moment.)

(Also don't merge me; I'm just pushing this up now to see how the tests fare)