### PR TITLE
New flow ui tweaks

### DIFF
--- a/app/extras/example_content.rb
+++ b/app/extras/example_content.rb
@@ -14,7 +14,7 @@ class ExampleContent
   end
 
   def helper_bot
-    email = ENV['HELPER_BOT_EMAIL'] || 'helperbot@example.com'
+    email = ENV['HELPER_BOT_EMAIL'] || 'contact@loomio.org'
     bot = User.find_by_email(email)
     unless bot
       bot = User.new
@@ -22,6 +22,7 @@ class ExampleContent
       bot.email = email
       bot.password = SecureRandom.hex(20)
       bot.uses_markdown = true
+      bot.avatar_kind = 'gravatar'
       bot.save!
     end
     bot

--- a/app/extras/example_content.rb
+++ b/app/extras/example_content.rb
@@ -5,9 +5,9 @@ class ExampleContent
     example_content = self.new
     bot = example_content.helper_bot
     bot_membership = group.add_member! bot
-    example_content.introduction_thread(group)
+    introduction_thread = example_content.introduction_thread(group)
     how_it_works_thread = example_content.how_it_works_thread(group)
-    example_content.first_comment(how_it_works_thread)
+    example_content.first_comment(how_it_works_thread, introduction_thread)
     first_proposal = example_content.first_proposal(how_it_works_thread)
     first_vote = example_content.first_vote(first_proposal)
     bot_membership.destroy
@@ -78,11 +78,11 @@ class ExampleContent
     thread
   end
 
-  def first_comment(thread)
+  def first_comment(how_it_works_thread, introduction_thread)
     comment = Comment.new(body: I18n.t('first_comment.body',
-                                        thread_url: discussion_url(thread),
-                                        group_name: thread.group.name),
-                          discussion: thread)
+                                        thread_url: discussion_url(introduction_thread),
+                                        group_name: how_it_works_thread.group.name),
+                          discussion: how_it_works_thread)
     CommentService.create(comment: comment, actor: helper_bot)
     comment
   end

--- a/app/extras/example_content.rb
+++ b/app/extras/example_content.rb
@@ -15,17 +15,12 @@ class ExampleContent
 
   def helper_bot
     email = ENV['HELPER_BOT_EMAIL'] || 'contact@loomio.org'
-    bot = User.find_by_email(email)
-    unless bot
-      bot = User.new
-      bot.name = 'Loomio Helper Bot'
-      bot.email = email
-      bot.password = SecureRandom.hex(20)
-      bot.uses_markdown = true
-      bot.avatar_kind = 'gravatar'
-      bot.save!
-    end
-    bot
+    bot = User.find_by(email: email) ||
+          User.create!(email: email,
+                       name: 'Loomio Helper Bot',
+                       password: SecureRandom.hex(20),
+                       uses_markdown: true,
+                       avatar_kind: 'gravatar')
   end
 
   def introduction_thread_content(group)

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -394,7 +394,7 @@ en:
 
   confirm_gift_plan_modal:
     heading: Gift plan selected
-    body: "If your group doesn't have the budget to pay for software, you don't need to pay a subscription. Your group members will see a card like this one when they visit your group:"
+    body: "If your group doesn't have the budget to pay for software, you don't need to pay a subscription. Your group members will periodically be invited to make a voluntary donation."
     got_it: "Ok, got it!"
 
   gift_card:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1041,7 +1041,7 @@ en:
 
       - Set your [profile photo](https://www.loomio.org/profile)
       - Configure your [email settings](https://www.loomio.org/email_preferences)
-      - Introduce yourself to the group in the [Welcome to '%{group_name}' thread]('%{thread_url}')
+      - Introduce yourself to the group in the [Welcome to %{group_name} thread](%{thread_url})
 
       If you’ve got any questions, the first place to check is the [Loomio help manual](http://help.loomio.org).
 

--- a/lineman/app/components/group_page/trial_card/confirm_gift_plan_modal/confirm_gift_plan_modal.haml
+++ b/lineman/app/components/group_page/trial_card/confirm_gift_plan_modal/confirm_gift_plan_modal.haml
@@ -8,8 +8,6 @@
   .modal-body
     .confirm-gift-plan-modal__body
       %span{translate: 'confirm_gift_plan_modal.body'}
-      .confirm-gift-plan-modal__gift-plan-card
-        %gift_card{group: 'group'}
 
   .modal-footer.lmo-clearfix
     %button.confirm-gift-plan-modal__cancel-button.btn.btn-warning{type: 'button', ng-click: '$close()', translate: 'common.action.cancel'}

--- a/lineman/app/components/group_page/trial_card/confirm_gift_plan_modal/confirm_gift_plan_modal.scss
+++ b/lineman/app/components/group_page/trial_card/confirm_gift_plan_modal/confirm_gift_plan_modal.scss
@@ -3,20 +3,6 @@
   width: auto;
 }
 
-.confirm-gift-plan-modal__gift-plan-card {
-  max-width: 310px;
-  margin: 20px auto;
-}
-
-.confirm-gift-plan-modal__confirm-button {
-  color: #fff;
-  background-color: #4185DE;
-  color: #fff;
-  i.fa { color: #fff; }
-  &:hover { color: #fff; }
-  &:focus { color: #fff; }
-}
-
 .confirm-gift-plan-modal__cancel-button {
   float: left;
 }


### PR DESCRIPTION
Addresses/fixes:
- On the Confirm Gift Plan modal, remove %gift_card and replace the text with "If your group doesn't have the budget to pay for software, you don't need to pay a subscription. Your group members will periodically be invited to make a voluntary donation."
- In the How To Use Loomio thread, the link to the Introductions thread is broken
- Loomio Helper Bot should use the contact@loomio.org gravatar