### PR TITLE
fix up dom order for float:right buttons for a11y

### DIFF
--- a/lineman/app/components/flash/flash.scss
+++ b/lineman/app/components/flash/flash.scss
@@ -25,7 +25,7 @@
   padding-left: 10px;
   border-left: 2px solid white;
   font-weight: bold;
-  font-variant: small-caps;
+  text-transform: uppercase;
   word-break: keep-all;
 }
 

--- a/lineman/app/components/group_page/discussions_card/discussions_card.haml
+++ b/lineman/app/components/group_page/discussions_card/discussions_card.haml
@@ -1,10 +1,10 @@
 %section.discussions-card{aria-labelledby: 'threads-card-title'}
   .discussions-card__header
+    %h2#threads-card-title.lmo-card-heading{ translate: 'group_page.discussions'}
     %a.discussions-card__new-thread-button.btn.btn-success.lmo-btn-icon{ng-if: 'isMemberOfGroup()', href: '', ng_click: 'openDiscussionForm()', title: "{{ 'navbar.start_thread' | translate }}"}
       %i.fa.fa-plus>
       %span{translate: 'navbar.start_thread'}
 
-    %h2#threads-card-title.lmo-card-heading{ translate: 'group_page.discussions'}
     .lmo-placeholder{translate: 'group_page.discussions_placeholder', ng-if: 'showThreadsPlaceholder()' }
 
   .discussions-card__list--empty{ng-if: '!loadMoreExecuting && !discussions.any()'}

--- a/lineman/app/components/thread_preview/thread_preview.haml
+++ b/lineman/app/components/thread_preview/thread_preview.haml
@@ -1,19 +1,4 @@
 .thread-preview
-  .thread-preview__star
-    %star_toggle{thread: 'thread'}
-
-  .thread-preview__actions.hidden-xs
-    %button.btn.btn-default.btn-sm.thread-preview__mark-as-read{ng-click: 'thread.markAsRead()', ng-class: '{disabled: !thread.isUnread()}'}>
-      %i.fa.fa-check>
-      %span{translate: 'dashboard_page.mark_as_read'}
-    %button.btn.btn-default.btn-sm.thread-preview__mute{ng-click: 'changeVolume("mute")', ng-show: '!thread.isMuted()'}>
-      %i.fa.fa-volume-off
-      %i.fa.fa-times>
-      %span{translate: 'volume_levels.mute'}
-    %button.btn.btn-default.btn-sm.thread-preview__mute{ng-click: 'changeVolume("normal")', ng-show: 'thread.isMuted()'}>
-      %i.fa.fa-volume-down>
-      %span{translate: 'volume_levels.unmute'}
-
   %a.thread-preview__link{lmo-href-for: 'thread'}
     .thread-preview__icon
       %user_avatar{ng-if: '!thread.activeProposal()', user: 'thread.author()', size: 'medium'}
@@ -46,3 +31,15 @@
         .thread-preview__group-name
           {{ thread.group().fullName }} ·
           %smart_time{time: 'thread.lastActivityAt'}>
+
+  .thread-preview__star
+    %star_toggle{thread: 'thread'}
+
+  .thread-preview__actions.hidden-xs
+    %button.btn.btn-default.btn-sm.thread-preview__mark-as-read{ng-click: 'thread.markAsRead()', ng-class: '{disabled: !thread.isUnread()}', title: "{{'dashboard_page.mark_as_read' | translate }}"}>
+      %i.fa.fa-check>
+    %button.btn.btn-default.btn-sm.thread-preview__mute{ng-click: 'changeVolume("mute")', ng-show: '!thread.isMuted()', title: "{{ 'volume_levels.mute' | translate }}" }>
+      %i.fa.fa-volume-off
+      %i.fa.fa-times>
+    %button.btn.btn-default.btn-sm.thread-preview__mute{ng-click: 'changeVolume("normal")', ng-show: 'thread.isMuted()', title: "{{ 'volume_levels.unmute' | translate }}"}>
+      %i.fa.fa-volume-down>

--- a/lineman/app/components/thread_preview/thread_preview.scss
+++ b/lineman/app/components/thread_preview/thread_preview.scss
@@ -9,14 +9,18 @@
 }
 
 .thread-preview__star{
-  float: right;
+  position: absolute;
+  right: 0;
+  top: 0;
   margin-right: $cardPaddingSize;
   margin-top: $thinPaddingSize;
 }
 
 .thread-preview__actions{
+  position: absolute;
+  right: 40px;
+  top: -4px;
   display: none;
-  float: right;
   margin-right: $thinPaddingSize;
   margin-top: $thinPaddingSize;
 }
@@ -126,13 +130,12 @@
   text-align: center;
 }
 
-
-.thread-preview__mark-as-read{
-  margin-right: 5px;
+.thread-preview__actions .btn-sm {
+  width: 40px;
 }
 
 .thread-preview__mute{
-  margin-right: 5px;
+  margin-left: 5px;
   .fa-volume-off{
     padding-right: 9px;
   }


### PR DESCRIPTION
* Reorder DOM so that the buttons come after the thing they modify. 
* remove labels from mute and mark as ready buttons so they don't look so ugly

![image](https://cloud.githubusercontent.com/assets/970124/10444110/291e8afc-71bf-11e5-83c5-0af95f2f382b.png)
