### PR TITLE
Notification links

### DIFF
--- a/lineman/app/components/navbar/navbar_search.coffee
+++ b/lineman/app/components/navbar/navbar_search.coffee
@@ -29,10 +29,10 @@ angular.module('loomioApp').directive 'navbarSearch', ->
 
     $scope.updateHighlighted = (index) ->
       $scope.highlighted = index
-      _.map highlightables(), (element) -> element.classList.remove("is-active")
+      _.map highlightables(), (element) -> element.classList.remove("lmo-active")
       if $scope.highlightedSelection()?
         $scope.highlightedSelection().firstChild.focus()
-        $scope.highlightedSelection().classList.add("is-active")
+        $scope.highlightedSelection().classList.add("lmo-active")
         # scroll to newly highlighted element?
 
     $scope.searchField = ->

--- a/lineman/app/components/notifications/comment_liked.haml
+++ b/lineman/app/components/notifications/comment_liked.haml
@@ -1,5 +1,4 @@
-%a.selector-list-item-link{href: '{{link()}}', ng-controller: 'NotificationController'}
-  .media-left
-    %user_avatar{user: "actor", size: 'small'}
-  .media-body
-    %span{translate: 'notifications.comment_liked', translate-value-name: '{{actor.name}}', translate-value-discussion: '{{event.discussion().title}}' }
+.media-left
+  %user_avatar{user: "notification.actor()", size: 'small'}
+.media-body
+  %span{translate: 'notifications.comment_liked', translate-value-name: '{{notification.actor().name}}', translate-value-discussion: '{{notification.event().discussion().title}}' }

--- a/lineman/app/components/notifications/comment_replied_to.haml
+++ b/lineman/app/components/notifications/comment_replied_to.haml
@@ -1,5 +1,4 @@
-%a.selector-list-item-link{ng-href: '{{link()}}', ng-controller: 'NotificationController'}
-  .media-left
-    %user_avatar{user: "actor", size: 'small'}
-  .media-body
-    %span{translate: 'notifications.comment_replied_to', translate-value-name: '{{actor.name}}', translate-value-discussion: '{{event.discussion().title}}' }
+.media-left
+  %user_avatar{user: "notification.actor()", size: 'small'}
+.media-body
+  %span{translate: 'notifications.comment_replied_to', translate-value-name: '{{notification.actor().name}}', translate-value-discussion: '{{notification.event().discussion().title}}' }

--- a/lineman/app/components/notifications/membership_request_approved.haml
+++ b/lineman/app/components/notifications/membership_request_approved.haml
@@ -1,5 +1,4 @@
-%a.selector-list-item-link{ng-href: '{{link()}}', ng-controller: 'NotificationController'}
-  .media-left
-    %user_avatar{user: "actor", size: 'small'}
-  .media-body
-    %span{translate: 'notifications.membership_request_approved', translate-value-name: '{{actor.name}}', translate-value-group: '{{event.membership().group().fullName}}' }
+.media-left
+  %user_avatar{user: "notification.actor()", size: 'small'}
+.media-body
+  %span{translate: 'notifications.membership_request_approved', translate-value-name: '{{notification.actor().name}}', translate-value-group: '{{notification.event().membership().group().fullName}}' }

--- a/lineman/app/components/notifications/membership_requested.haml
+++ b/lineman/app/components/notifications/membership_requested.haml
@@ -1,12 +1,11 @@
-%a.selector-list-item-link{ng-href: '{{link()}}', ng-controller: 'NotificationController'}
-  .media{ng-if: "event.membershipRequest().byExistingUser()"}
-    .media-left
-      %user_avatar{user: "event.membershipRequest().actor()", size: 'small'}
-    .media-body
-      %span{translate: 'notifications.membership_requested', translate-value-name: '{{event.membershipRequest().actor().name}}', translate-value-group: '{{event.membershipRequest().group().fullName}}' }
+.media{ng-if: "notification.event().membershipRequest().byExistingUser()"}
+  .media-left
+    %user_avatar{user: "notification.event().membershipRequest().actor()", size: 'small'}
+  .media-body
+    %span{translate: 'notifications.membership_requested', translate-value-name: '{{notification.event().membershipRequest().actor().name}}', translate-value-group: '{{notification.event().membershipRequest().group().fullName}}' }
 
-  .media{ng-if: "!event.membershipRequest().byExistingUser()"}
-    .media-left
-      %img.lmo-box--small.lmo-rounded-corners{src: "{{event.membershipRequest().group().logoUrl()}}", aria-hidden: 'true'}
-    .media-body
-      %span{translate: 'notifications.membership_requested', translate-value-name: '{{event.membershipRequest().name}}', translate-value-group: '{{event.membershipRequest().group().fullName}}' }
+.media{ng-if: "!notification.event().membershipRequest().byExistingUser()"}
+  .media-left
+    %img.lmo-box--small.lmo-rounded-corners{ng-src: "{{notification.event().membershipRequest().group().logoUrl()}}", aria-hidden: 'true'}
+  .media-body
+    %span{translate: 'notifications.membership_requested', translate-value-name: '{{notification.event().membershipRequest().name}}', translate-value-group: '{{notification.event().membershipRequest().group().fullName}}' }

--- a/lineman/app/components/notifications/motion_closing_soon.haml
+++ b/lineman/app/components/notifications/motion_closing_soon.haml
@@ -1,5 +1,4 @@
-%a.selector-list-item-link{href: '{{link()}}', ng-controller: 'NotificationController'}
-  .media-left
-    .thread-item__proposal-icon
-  .media-body
-    %span{translate: 'notifications.motion_closing_soon', translate-value-proposal: '{{event.proposal().name}}' }
+.media-left
+  .thread-item__proposal-icon
+.media-body
+  %span{translate: 'notifications.motion_closing_soon', translate-value-proposal: '{{notification.relevantRecord().name}}' }

--- a/lineman/app/components/notifications/motion_outcome_created.haml
+++ b/lineman/app/components/notifications/motion_outcome_created.haml
@@ -1,5 +1,4 @@
-%a.selector-list-item-link{ng-href: '{{link()}}', ng-controller: 'NotificationController'}
-  .media-left
-    %user_avatar{user: "actor", size: 'small'}
-  .media-body
-    %span{translate: 'notifications.motion_outcome_created', translate-value-name: '{{actor.name}}', translate-value-proposal: '{{event.proposal().name}}' }
+.media-left
+  %user_avatar{user: "notification.actor()", size: 'small'}
+.media-body
+  %span{translate: 'notifications.motion_outcome_created', translate-value-name: '{{notification.actor().name}}', translate-value-proposal: '{{notification.relevantRecord().name}}' }

--- a/lineman/app/components/notifications/notifications.haml
+++ b/lineman/app/components/notifications/notifications.haml
@@ -1,11 +1,14 @@
 .blank{dropdown: '', on-toggle: 'toggled(open)'}
   %button.btn.lmo-btn-nude.lmo-navbar__btn.lmo-navbar__btn--notifications.lmo-navbar__btn-icon.notifications__button.has-badge{dropdown-toggle: '', tabindex: 4}
     .sr-only{translate: 'navbar.notifications'}
-    %i.fa.fa-lg.fa-fw{aria-hidden: 'true', ng-class: '{"fa-bell": unread(), "fa-bell-o": !unread()}'}
-    %span.badge.notifications__activity{ng-if: 'unread()'}
+    %i.fa.fa-lg.fa-fw{aria-hidden: 'true', ng-class: '{"fa-bell": hasUnread(), "fa-bell-o": !hasUnread()}'}
+    %span.badge.notifications__activity{ng-if: 'hasUnread()'}
       {{unreadCount()}}
   .dropdown-menu.dropdown-menu-right.dropdown-menu-with-selector-list.notifications__dropdown{role: 'menu'}
     .navbar-notifications
       %ul.selector-list
         %li.selector-list-header{translate: "notifications.header", role: 'heading'}
-        %li.selector-list-item.media{ng_repeat: 'notification in notifications() track by notification.id', ng-include: '"generated/components/notifications/" + notification.event().kind + ".html"'}
+        %li.selector-list-item.media{ng-class: '{"lmo-active": !notification.viewed}', ng-repeat: 'notification in notifications() | orderBy: "-createdAt" track by notification.id'}
+          %a.selector-list-item-link{lmo-href-for: 'notification.relevantRecord()'}
+            .blank{ng-include: '"generated/components/notifications/" + notification.kind() + ".html"'}
+      %loading{ng-if: 'loading()'}

--- a/lineman/app/components/notifications/user_added_to_group.haml
+++ b/lineman/app/components/notifications/user_added_to_group.haml
@@ -1,9 +1,8 @@
-%a.selector-list-item-link{ng-href: '{{link()}}', ng-controller: 'NotificationController'}
-  %span{ng-if: 'event.membership().inviter() == null'}
-    %span{translate: 'notifications.user_added_to_group_no_inviter', translate-value-group: '{{event.membership().group().fullName}}' }
+%span{ng-if: 'notification.event().membership().inviter() == null'}
+  %span{translate: 'notifications.user_added_to_group_no_inviter', translate-value-group: '{{notification.event().membership().group().fullName}}' }
 
-  .lmo-wrap{ng-if: 'event.membership().inviter()'}
-    .media-left
-      %user_avatar{user: "event.membership().inviter()", size: 'small'}
-    .media-body
-      %span{translate: 'notifications.user_added_to_group', translate-value-name: '{{event.membership().inviter().name}}', translate-value-group: '{{event.membership().group().fullName}}' }
+.lmo-wrap{ng-if: 'notification.event().membership().inviter()'}
+  .media-left
+    %user_avatar{user: "notification.event().membership().inviter()", size: 'small'}
+  .media-body
+    %span{translate: 'notifications.user_added_to_group', translate-value-name: '{{notification.event().membership().inviter().name}}', translate-value-group: '{{notification.event().membership().group().fullName}}' }

--- a/lineman/app/components/notifications/user_mentioned.haml
+++ b/lineman/app/components/notifications/user_mentioned.haml
@@ -1,5 +1,4 @@
-%a.selector-list-item-link{ng-href: '{{link()}}', ng-controller: 'NotificationController'}
-  .media-left
-    %user_avatar{user: "actor", size: 'small'}
-  .media-body
-    %span{translate: 'notifications.user_mentioned', translate-value-name: '{{actor.name}}', translate-value-title: '{{event.comment().discussion().title}}' }
+.media-left
+  %user_avatar{user: "notification.actor()", size: 'small'}
+.media-body
+  %span{translate: 'notifications.user_mentioned', translate-value-name: '{{notification.actor().name}}', translate-value-title: '{{notification.event().comment().discussion().title}}' }

--- a/lineman/app/components/selector_list/selector_list.scss
+++ b/lineman/app/components/selector_list/selector_list.scss
@@ -51,10 +51,6 @@
 
 .selector-list .media{ margin-top: 0; }
 .selector-list .media-left { margin-right: 8px; }
-.selector-list-item.is-active{
-  background-color: $item-highlight-color;
-  border-left: 4px solid $loomio-orange;
-}
 
 .is-subgroup-true .selector-list-item-link{
   padding-left: 53px;

--- a/lineman/app/components/utilities.scss
+++ b/lineman/app/components/utilities.scss
@@ -388,6 +388,11 @@ label.label-with-details{
   }
 }
 
+.lmo-active {
+  background-color: $item-highlight-color;
+  border-left: 4px solid $loomio-orange;
+}
+
 @media (min-width: 768px) {
   .lmo-column-left {
     width: 59%;

--- a/lineman/app/models/event_model.coffee
+++ b/lineman/app/models/event_model.coffee
@@ -24,7 +24,6 @@ angular.module('loomioApp').factory 'EventModel', (BaseModel) ->
     }
 
     relationships: ->
-      @belongsTo 'group'
       @belongsTo 'membership'
       @belongsTo 'membershipRequest'
       @belongsTo 'discussion'
@@ -34,6 +33,11 @@ angular.module('loomioApp').factory 'EventModel', (BaseModel) ->
       @belongsTo 'actor', from: 'users'
       @belongsTo 'version'
 
+    group: ->
+      return @membership().group()        if @membership()
+      return @membershipRequest().group() if @membershipRequest()
+      return @discussion.group()          if @discussion()
+
     delete: ->
       @deleted = true
 
@@ -42,3 +46,6 @@ angular.module('loomioApp').factory 'EventModel', (BaseModel) ->
 
     relevantRecordType: ->
       @constructor.eventTypeMap[@kind]
+
+    relevantRecord: ->
+      @[@relevantRecordType()]()

--- a/lineman/app/models/notification_model.coffee
+++ b/lineman/app/models/notification_model.coffee
@@ -9,3 +9,12 @@ angular.module('loomioApp').factory 'NotificationModel', (BaseModel) ->
 
     createdAt: ->
       @event().createdAt
+
+    actor: ->
+      @event().actor()
+
+    kind: ->
+      @event().kind
+
+    relevantRecord: ->
+      @event().relevantRecord()

--- a/lineman/app/models/notification_records_interface.coffee
+++ b/lineman/app/models/notification_records_interface.coffee
@@ -11,7 +11,7 @@ angular.module('loomioApp').factory 'NotificationRecordsInterface', (BaseRecords
 
     viewed: ->
       any = false
-      _.each @collection.find({viewed: false}), (n) =>
+      _.each @collection.find(viewed: { $ne: true}), (n) =>
         any = true
         n.update(viewed: true)
 

--- a/lineman/app/services/current_user.coffee
+++ b/lineman/app/services/current_user.coffee
@@ -9,4 +9,9 @@ angular.module('loomioApp').factory 'CurrentUser', ($rootScope, Records, AppConf
     AppConfig.inboxLoaded = true
     $rootScope.$broadcast 'currentUserInboxLoaded'
 
+
+  Records.notifications.fetchMyNotifications().then ->
+    AppConfig.notificationsLoaded = true
+    $rootScope.$broadcast 'notificationsLoaded'
+
   Records.users.find(AppConfig.currentUserId)

--- a/lineman/app/services/lmo_url_service.coffee
+++ b/lineman/app/services/lmo_url_service.coffee
@@ -19,7 +19,7 @@ angular.module('loomioApp').factory 'LmoUrlService', ->
       @buildModelRoute('d', d.key, d.title, params, options)
 
     proposal: (p, params = {}, options = {}) ->
-      @buildModelRoute('m', p.key, p.name, params, options)
+      @discussion p.discussion(), _.merge(params, {proposal: p.key})
 
     comment: (c, params = {}, options = {}) ->
       @discussion c.discussion(), _.merge(params, {comment: c.id})

--- a/lineman/package.json
+++ b/lineman/package.json
@@ -13,7 +13,7 @@
     "angular_record_store": "git://github.com/loomio/angular_record_store.git#2.3.1",
     "bootstrap": "^3.3.5",
     "coffee-script": "^1.8.0",
-    "loomio-angular-router": "0.5.6"
+    "loomio-angular-router": "0.5.9"
   },
   "engines": {
     "node": "~>0.10.5",

--- a/lineman/spec/services/lmo_url_service_spec.coffee
+++ b/lineman/spec/services/lmo_url_service_spec.coffee
@@ -52,10 +52,10 @@ describe 'LmoUrlService', ->
 
     describe 'proposal', ->
       it 'gives a proposal path', ->
-        expect(service.proposal(proposal)).toBe("/m/#{proposal.key}/proposal-name")
+        expect(service.proposal(proposal)).toBe("/d/#{proposal.discussion().key}/discussion-title?proposal=#{proposal.key}")
 
       it 'can pass query parameters', ->
-        expect(service.proposal(proposal, { position: 'yes', utm_medium: 'medium'})).toBe("/m/#{proposal.key}/proposal-name?position=yes&utm_medium=medium")
+        expect(service.proposal(proposal, { position: 'yes', utm_medium: 'medium'})).toBe("/d/#{proposal.discussion().key}/discussion-title?position=yes&utm_medium=medium&proposal=#{proposal.key}")
 
     describe 'comment', ->
       it 'gives a comment path', ->


### PR DESCRIPTION
Giving the notifications a little love.

Notable:
- Added a `relevantRecord()` method to event to allow for easier lmo-hreffing
- Added a loading spinny while notifications are loading
- Pushed a fix to our angular router to allow for query param linking (we should smoke test this)
- Simplified the notifications controller some
- Changed lmo-url-service#proposal to redirect straight to the proposal, rather than through the legacy intermediate page.