### PR TITLE
Expandable comment field

### DIFF
--- a/lineman/app/app.coffee
+++ b/lineman/app/app.coffee
@@ -9,7 +9,8 @@ angular.module('loomioApp', ['ngNewRouter',
                              'angular-inview',
                              'ui.gravatar',
                              'truncate',
-                             'duScroll']).config ($httpProvider, $locationProvider, $translateProvider, markedProvider, $compileProvider) ->
+                             'duScroll',
+                             'monospaced.elastic']).config ($httpProvider, $locationProvider, $translateProvider, markedProvider, $compileProvider) ->
 
   #configure markdown
   renderer = new marked.Renderer()

--- a/lineman/app/components/discussion_form/discussion_form.haml
+++ b/lineman/app/components/discussion_form/discussion_form.haml
@@ -26,7 +26,7 @@
 
       .form-group
         %label{for: 'discussion-context-field', translate: 'discussion_form.context_label'}
-        %textarea.discussion-form__description-input.form-control.lmo-primary-form-input#discussion-context-field{ng-model: 'discussion.description', placeholder: "{{ 'discussion_form.context_placeholder' | translate }}"}
+        %textarea.discussion-form__description-input.form-control.lmo-primary-form-input#discussion-context-field{msd-elastic: 'true', ng-model: 'discussion.description', placeholder: "{{ 'discussion_form.context_placeholder' | translate }}"}
 
       .form-group{ng-show: 'showPrivacyForm()'}
         .privacy-form-option

--- a/lineman/app/components/edit_group_form/edit_group_form.haml
+++ b/lineman/app/components/edit_group_form/edit_group_form.haml
@@ -16,7 +16,7 @@
       %validation_errors{subject: 'group', field: 'name'}
 
       %label{for: 'group-description', translate: 'edit_group_form.profile.description'}
-      %textarea.edit-group-form__description.form-control#group-description{ng-model: 'group.description'}
+      %textarea.edit-group-form__description.form-control#group-description{msd-elastic: 'true', ng-model: 'group.description'}
 
       %h2.lmo-h2{translate: 'edit_group_form.privacy.label'}
 

--- a/lineman/app/components/start_group_form/start_group_form.haml
+++ b/lineman/app/components/start_group_form/start_group_form.haml
@@ -19,7 +19,7 @@
 
     .form-group
       %label{for: 'group-description', translate: 'start_group_form.description_label'}
-      %textarea.start-group-form__description.form-control#group-description{ng-model: 'group.description', placeholder: "{{ 'start_group_form.description_placeholder' | translate }}"}
+      %textarea.start-group-form__description.form-control#group-description{msd-elastic: 'true', ng-model: 'group.description', placeholder: "{{ 'start_group_form.description_placeholder' | translate }}"}
 
     .group-payment-notice{ng-if: 'group.isParent()', translate: 'start_group_form.group_payment_reminder'}
 

--- a/lineman/app/components/thread_page/comment_form/comment_form.haml
+++ b/lineman/app/components/thread_page/comment_form/comment_form.haml
@@ -5,7 +5,7 @@
       %input{type: 'hidden', ng-model: 'comment.usesMarkdown'}
       %h2.lmo-card-heading#comment-form-title{translate: 'comment_form.aria_label'}>
       %span{translate: 'comment_form.in_reply_to', translate-values: "{name: '{{comment.parent().authorName()}}' }", ng-show: 'comment.parent().authorName()'}
-      %textarea.form-control.comment-form__comment-field.lmo-primary-form-input{aria-labelledby: 'comment-form-title', name: 'body', placeholder: "Say something...", ng_model: 'comment.body', mentio: true, mentio-trigger-char: "'@'", mentio_items: 'mentionables', mentio-template-url: 'generated/components/thread_page/comment_form/mentio_menu.html', mentio-search: 'fetchByNameFragment(term)', mentio-id: 'comment-field', ng-focus: 'formInFocus()', ng-blur: 'formLostFocus()', ng-model-options: "{ updateOn: 'default blur', debounce: {'default': 300, 'blur': 0} }"}
+      %textarea.form-control.comment-form__comment-field.lmo-primary-form-input{msd-elastic: 'true', aria-labelledby: 'comment-form-title', name: 'body', placeholder: "Say something...", ng_model: 'comment.body', mentio: true, mentio-trigger-char: "'@'", mentio_items: 'mentionables', mentio-template-url: 'generated/components/thread_page/comment_form/mentio_menu.html', mentio-search: 'fetchByNameFragment(term)', mentio-id: 'comment-field', ng-focus: 'formInFocus()', ng-blur: 'formLostFocus()', ng-model-options: "{ updateOn: 'default blur', debounce: {'default': 300, 'blur': 0} }"}
       .comment-row.comment-attachments{ng_repeat: 'attachment in comment.newAttachments()'}
         %a.attachment-link{ng_href: '{{attachment.location}}', target: '_blank'}>
           {{ attachment.filename }}

--- a/lineman/app/components/utilities.scss
+++ b/lineman/app/components/utilities.scss
@@ -399,3 +399,7 @@ label.label-with-details{
 .align-center {
   text-align: center;
 }
+
+textarea.form-control {
+  max-height: 400px;
+}

--- a/lineman/bower.json
+++ b/lineman/bower.json
@@ -21,7 +21,8 @@
     "ment.io": "~0.9.15",
     "moment": "latest",
     "ng-file-upload": "~3.2.4",
-    "svg.js": "latest"
+    "svg.js": "latest",
+    "angular-elastic": "latest"
   },
   "devDependencies": {
     "angular-mocks": "1.4.0-rc.0"

--- a/lineman/config/files.coffee
+++ b/lineman/config/files.coffee
@@ -38,4 +38,5 @@ module.exports = require(process.env["LINEMAN_MAIN"]).config.extend "files",
              "vendor/bower_components/angular-scroll/angular-scroll.js",
              "vendor/bower_components/svg.js/dist/svg.js",
              "vendor/bower_components/jstimezonedetect/jstz.js",
-             "node_modules/angular_record_store/dist/standalone.js" ]
+             "node_modules/angular_record_store/dist/standalone.js",
+             "vendor/bower_components/angular-elastic/elastic.js"]


### PR DESCRIPTION
Expand comment field automatically for longer comments

Before:
![screen shot 2015-10-14 at 5 10 51 pm](https://cloud.githubusercontent.com/assets/750477/10486219/9cdbd8b4-7296-11e5-8c0e-2c89e6746741.png)

After (at maximum size):
![screen shot 2015-10-14 at 5 10 38 pm](https://cloud.githubusercontent.com/assets/750477/10486224/a285dd8c-7296-11e5-815f-eaca9709c957.png)

(PS I like that this screenshot suggests that spell check eventually gets bored of accusing you of language massacre.)