### PR TITLE
Don't mark discussions without readers as unread

### DIFF
--- a/lineman/app/models/discussion_model.coffee
+++ b/lineman/app/models/discussion_model.coffee
@@ -74,10 +74,7 @@ angular.module('loomioApp').factory 'DiscussionModel', (BaseModel, AppConfig) ->
       proposal.lastVoteAt if proposal?
 
     isUnread: ->
-      if @lastReadAt?
-        @unreadActivityCount() > 0
-      else
-        true
+      @discussionReaderId? and (!@lastReadAt? or @unreadActivityCount() > 0)
 
     isImportant: ->
       @starred or @hasActiveProposal()


### PR DESCRIPTION
Fixes transitioning to a thread from a search result you haven't seen before.