### PR TITLE
clean up dropdowns

### DIFF
--- a/lineman/app/components/dashboard_page/dashboard_page.haml
+++ b/lineman/app/components/dashboard_page/dashboard_page.haml
@@ -9,8 +9,7 @@
                 .sr-only{ translate: 'dashboard_page.filtering.filter_threads_aria_label'}
                 %span{ translate: "dashboard_page.filtering.filter_threads", aria-hidden: 'true'}>
               %i.fa.fa-chevron-down
-            .dropdown-menu.dropdown-menu-with-labels.dropdown-menu-right{role: 'menu'}
-              .dropdown-heading{role: 'heading', translate: 'dashboard_page.filtering.dropdown_heading'}
+            .dropdown-menu.dropdown-menu--with-details{role: 'menu'}
               %ul.dropdown-menu-items.filtering-options
                 %li.dropdown-menu-item.filtering-option.dashboard-page__filter-recent
                   %a{href: '', ng-click: 'dashboardPage.setFilter("show_all")'}

--- a/lineman/app/components/dropdown/dropdown.scss
+++ b/lineman/app/components/dropdown/dropdown.scss
@@ -1,22 +1,49 @@
 .dropdown-menu{
-  min-width: 320px;
   padding: 15px;
-}
-
-.dropdown-menu-with-selector-list{
-  padding: 0;
+  right: 0;
+  left: auto;
 }
 
 .dropdown-menu label {
-  font-weight: normal;
   cursor: pointer;
 }
 
-.dropdown-menu-with-labels a{
+.dropdown-menu--with-selector-list{
+  padding: 0;
+  min-width: 320px;
+}
+
+.dropdown-menu--with-details{
+  min-width: 320px;
+}
+
+.dropdown-menu--with-icons{
+  min-width: 200px;
+  padding: 15px 10px 15px 0;
+}
+
+.dropdown-menu-item a, .dropdown-menu-item label{
+  display: block;
+  margin: -13px;
+  padding: 13px;
   color: $primary-text-color;
 }
 
-.dropdown-menu-with-labels .fa-check{
+.dropdown-menu--with-icons a{
+  margin: -13px -10px -13px 0px;
+}
+
+.dropdown-menu--with-icons i.fa {
+  width: 25px;
+  margin-right: 5px;
+  text-align: center;
+}
+
+.dropdown-menu--with-details a{
+  color: $primary-text-color;
+}
+
+.dropdown-menu--with-details .fa-check{
   margin-left: 5px;
 }
 
@@ -24,6 +51,11 @@
   list-style: none;
   padding: 0;
   margin: 0;
+  @include fontHelveticaMedium;
+}
+.dropdown-menu-item-details{
+  @include fontHelvetica;
+  font-weight: normal;
 }
 
 .dropdown-menu-item{
@@ -39,13 +71,6 @@ form .dropdown-menu-item{
   margin-right: -26px;
 }
 
-.dropdown-menu-item a, .dropdown-menu-item label{
-  display: block;
-  margin: -13px;
-  padding: 13px;
-  color: $primary-text-color;
-}
-
 .dropdown-menu-item a:hover, .dropdown-menu-item label:hover{
   display: block;
   text-decoration: none;
@@ -59,7 +84,6 @@ form .dropdown-menu-item{
   text-align: center;
 }
 
-
 .disabled .dropdown-menu-item{
   cursor: auto;
 }
@@ -69,8 +93,8 @@ form .dropdown-menu-item{
 }
 
 li .dropdown-menu-item-label{
-  font-weight: bold;
   line-height: 24px;
+  white-space: nowrap;
   i{
     font-weight: normal;
     width: 18px;
@@ -93,8 +117,10 @@ li .dropdown-menu-item-label{
   border-bottom: 1px solid $border-color;
 }
 
-.dropdown-menu-right{
-  right: 0;
+.dropdown-menu--with-selector-list .dropdown-heading{
+  margin: 0;
+  padding: 0;
+  border-bottom: none;
 }
 
 .dropdown{

--- a/lineman/app/components/group_page/group_actions_dropdown/group_actions_dropdown.haml
+++ b/lineman/app/components/group_page/group_actions_dropdown/group_actions_dropdown.haml
@@ -3,38 +3,38 @@
     %span{translate: 'group_page.options.label'}>
     %i.fa.fa-lg.fa-angle-down
 
-  .dropdown-menu.dropdown-menu-with-labels.dropdown-menu-right{role: 'menu'}
-    .dropdown-heading{translate: 'group_page.options_label', role: 'heading'}
+  .dropdown-menu.dropdown-menu--with-icons{role: 'menu'}
     %ul.dropdown-menu-items
       %li.dropdown-menu-item{ng-if: 'groupActions.canEditGroup()'}
         %a.group-page-actions__edit-group-link{href: '', ng-click: 'groupActions.editGroup()'}
-          .dropdown-menu-item-label{translate: 'group_page.options.edit_group'}
-          .dropdown-menu-item-details
+          %i.fa.fa-lg.fa-cog>
+          %span{translate: 'group_page.options.edit_group'}
       %li.dropdown-menu-item{ng-if: 'groupActions.canAdministerGroup()'}
         %a.group-page-actions__manage-memberships-link{lmo-href-for: 'group', lmo-href-action: 'memberships'}
-          .dropdown-menu-item-label{translate: 'group_page.options.manage_members'}
-        .dropdown-menu-item-details
+          %i.fa.fa-lg.fa-users>
+          %span{translate: 'group_page.options.manage_members'}
       %li.dropdown-menu-item{ng-if: 'groupActions.canManageGroupSubscription()'}
         %a.group-page-actions__manage-subscription-link{ng-if: 'group.subscriptionKind == "paid"', ng-click: 'groupActions.manageSubscriptions()'}
-          .dropdown-menu-item-label{translate: 'group_page.options.manage_subscription'}
+          %i.fa.fa-lg.fa-calendar-check-o>
+          %span{translate: 'group_page.options.manage_subscription'}
         %a.group-page-actions__manage-subscription-link{ng-if: 'group.subscriptionKind == "gift"', ng-click: 'groupActions.choosePlan()'}
-          .dropdown-menu-item-label{translate: 'group_page.options.manage_subscription'}
-        .dropdown-menu-item-details
+          %i.fa.fa-lg.fa-gift>
+          %span{translate: 'group_page.options.manage_subscription'}
       %li.dropdown-menu-item{ng-if: 'groupActions.canAddSubgroup()'}
         %a.group-page-actions__add-subgroup-link{href: '', ng-click: 'groupActions.addSubgroup()'}
-          .dropdown-menu-item-label{translate: 'group_page.options.add_subgroup'}
-        .dropdown-menu-item-details
+          %i.fa.fa-lg.fa-plus>
+          %span{translate: 'group_page.options.add_subgroup'}
 
       %li.dropdown-menu-item{ng-if: 'groupActions.canChangeVolume()'}
         %a.group-page-actions__change-volume-link{href: '', ng-click: 'groupActions.openChangeVolumeForm()'}
-          .dropdown-menu-item-label{translate: 'group_volume_card.heading'}
-        .dropdown-menu-item-details
+          %i.fa.fa-lg.fa-bell>
+          %span{translate: 'group_volume_card.heading'}
 
       %li.dropdown-menu-item
         %a.group-page-actions__leave-group{href: '', ng-click: 'groupActions.leaveGroup()'}
-          .dropdown-menu-item-label{translate: 'group_page.options.leave_group'}
-        .dropdown-menu-item-details
+          %i.fa.fa-lg.fa-sign-out>
+          %span{translate: 'group_page.options.leave_group'}
       %li.dropdown-menu-item{ng-if: 'groupActions.canArchiveGroup()'}
         %a.group-page-actions__archive-group{href: '', ng-click: 'groupActions.archiveGroup()'}
-          .dropdown-menu-item-label{translate: 'group_page.options.deactivate_group'}
-        .dropdown-menu-item-details
+          %i.fa.fa-lg.fa-ban>
+          %span{translate: 'group_page.options.deactivate_group'}

--- a/lineman/app/components/group_page/group_privacy_dropdown/group_privacy_dropdown.haml
+++ b/lineman/app/components/group_page/group_privacy_dropdown/group_privacy_dropdown.haml
@@ -15,7 +15,7 @@
       .screen-only{aria-hidden:'true'}
         %i.fa.fa-lg.fa-lock>
         %span{translate: 'common.privacy.private'}
-  .dropdown-menu.dropdown-menu-with-labels{role: 'menu', ng-class: '{disabled: !canEditGroup()}'}
+  .dropdown-menu.dropdown-menu--with-details{role: 'menu', ng-class: '{disabled: !canEditGroup()}'}
     .dropdown-heading{translate: 'group_page.visibility_label', role: 'heading'}
     %form{novalidate: ''}
       .lmo-disabled-form{ng-show: '!canEditGroup()'}

--- a/lineman/app/components/navbar/navbar_search.haml
+++ b/lineman/app/components/navbar/navbar_search.haml
@@ -8,7 +8,7 @@
   .navbar-search-results{ng-show: 'focused'}
     %ul.group-selector-list.selector-list
       %li.navbar-search-list-item.selector-list-header{ng-show: 'groups().length > 0'}
-        %h3{translate: "common.groups"}
+        %h3.dropdown-heading{translate: "common.groups"}
       %li.navbar-search-list-item.navbar-search-list-option.selector-list-item.media{ng-repeat: 'group in groups() | orderBy: "fullName" track by group.id', ng-class:'{"selector-list-item-no-bottom-line": (queryEmpty()), "selector-list-item-top-line": (queryEmpty() && group.isParent())}'}
         %a.selector-list-item-link{lmo-href-for: 'group', ng-mousedown: 'closeSearchDropdown($event)', ng-blur: 'handleSearchBlur()'}
           .media-left
@@ -25,7 +25,7 @@
         %loading
       %li.navbar-search-list-item.selector-list-item.no-results-found{ng-show: 'noResultsFound()', translate: 'navbar.search.no_results'}
       %li.navbar-search-list-item.selector-list-header{ng-show: 'searchResults && !(searching || noResultsFound())'}
-        %h3{translate: "navbar.search.discussions"}
+        %h3.dropdown-heading{translate: "navbar.search.discussions"}
       %li.navbar-search-list-item.navbar-search-list-option.selector-list-item.media{ng-show: '!(searching || noResultsFound())', ng-repeat: 'searchResult in searchResults | orderBy: ["-priority", "lastActivityAt"]'}
         %a.search-result.selector-list-item-link{lmo-href-for: 'searchResult.discussion()', ng-mousedown: 'closeSearchDropdown($event)', ng-blur: 'handleSearchBlur()'}
           %search_result{result: 'searchResult'}

--- a/lineman/app/components/navbar/navbar_user_options.haml
+++ b/lineman/app/components/navbar/navbar_user_options.haml
@@ -3,7 +3,7 @@
     %button.btn.lmo-btn-nude.lmo-navbar__btn.lmo-navbar__btn-icon{href: '', tabindex: 5, dropdown-toggle: ''}
       .sr-only{translate: 'navbar.user_options.label'}
       %user_avatar{user: 'currentUser', size: 'small'}
-    .dropdown-menu.dropdown-menu-right.user-options-dropdown.dropdown-menu-with-icons
+    .dropdown-menu.dropdown-menu--with-icons.user-options-dropdown
       %ul.dropdown-menu-items
         %li.dropdown-menu-item
           %a.navbar-user-options__profile-link{lmo-href: '/profile'}

--- a/lineman/app/components/notifications/notifications.haml
+++ b/lineman/app/components/notifications/notifications.haml
@@ -4,7 +4,7 @@
     %i.fa.fa-lg.fa-fw{aria-hidden: 'true', ng-class: '{"fa-bell": hasUnread(), "fa-bell-o": !hasUnread()}'}
     %span.badge.notifications__activity{ng-if: 'hasUnread()'}
       {{unreadCount()}}
-  .dropdown-menu.dropdown-menu-right.dropdown-menu-with-selector-list.notifications__dropdown{role: 'menu'}
+  .dropdown-menu.dropdown-menu--with-selector-list.notifications__dropdown{role: 'menu'}
     .navbar-notifications
       %ul.selector-list
         %li.selector-list-header{translate: "notifications.header", role: 'heading'}

--- a/lineman/app/components/thread_page/activity_card/new_comment.haml
+++ b/lineman/app/components/thread_page/activity_card/new_comment.haml
@@ -3,7 +3,7 @@
     %button.thread-item__dropdown-button.btn.lmo-btn-nude{dropdown-toggle: '', type: 'button'}
       %i.fa.fa-chevron-down
       .sr-only{translate: 'new_comment_item.context_menu.aria_label'}
-    .dropdown-menu.dropdown-menu-right
+    .dropdown-menu
       %ul.dropdown-menu-items
         %li.dropdown-menu-item{ng-if: '::canEditComment()'}
           %a.dropdown-menu-item-label.thread-item__edit-link{href: '', ng-click: 'editComment()', translate: 'new_comment_item.context_menu.edit_comment'}

--- a/lineman/app/components/thread_page/current_proposal_card/proposal_actions_dropdown/proposal_actions_dropdown.haml
+++ b/lineman/app/components/thread_page/current_proposal_card/proposal_actions_dropdown/proposal_actions_dropdown.haml
@@ -1,7 +1,7 @@
 .proposal-actions-dropdown.pull-right{dropdown: ''}
   %button.btn.lmo-btn-nude.proposal-actions-dropdown__btn{href:'', dropdown-toggle: ''}
     %i.fa.fa-chevron-down
-  .dropdown-menu.dropdown-menu-right{role: 'menu'}
+  .dropdown-menu{role: 'menu'}
     %ul.dropdown-menu-items
       %li.dropdown-menu-item{ng-if: 'canEditProposal()'}
         %a.dropdown-menu-item-label.proposal-actions-dropdown__edit-link{ng_click: 'editProposal()'}

--- a/lineman/app/components/thread_page/thread_page.haml
+++ b/lineman/app/components/thread_page/thread_page.haml
@@ -11,7 +11,7 @@
             %button.thread-context__dropdown-button.btn.lmo-btn-nude{dropdown-toggle: ''}
               .sr-only{translate: 'thread_context.thread_options'}
               %i.fa.fa-fw.fa-chevron-down
-            .thread-context__dropdown.dropdown-menu.dropdown-menu-right
+            .thread-context__dropdown.dropdown-menu
               %ul.dropdown-menu-items
                 %li.dropdown-menu-item{ng-if: 'threadPage.canChangeVolume()'}
                   %a.thread-context__dropdown-options-notifications.dropdown-menu-item-label{href: '', ng-click: 'threadPage.openChangeVolumeForm()', translate: 'thread_context.notifications'}

--- a/lineman/app/components/utilities.scss
+++ b/lineman/app/components/utilities.scss
@@ -386,10 +386,6 @@ label.label-with-details{
   clear: both;
 }
 
-.dropdown-menu i.fa {
-  width: 30px;
-}
-
 .timeago{
   @include fontTiny();
   color: $grey-on-white;


### PR DESCRIPTION
Standardise different dropdown versions:

### dropdown-menu

Used for the most simple context menus, e.g. thread context, proposal options, comment options.

---

![image](https://cloud.githubusercontent.com/assets/970124/10567491/d15bbddc-7662-11e5-86b9-b8f125ad6419.png)

---

These are small on desktop and expand out to full width when you are on a tiny screen:

---

![image](https://cloud.githubusercontent.com/assets/970124/10567498/f669e090-7662-11e5-8499-d4071f78516b.png)

---

### dropdown-menu--with-icons

Used when you want to illustrate each option with an icon.

---

![image](https://cloud.githubusercontent.com/assets/970124/10567505/3cdc5530-7663-11e5-8255-e5420bd58b2e.png)

![image](https://cloud.githubusercontent.com/assets/970124/10567507/45f0ae78-7663-11e5-8d78-b19a261cd4e6.png)

---

### dropdown-menu--with-details

Used when you have to explain what the options mean

---

![image](https://cloud.githubusercontent.com/assets/970124/10567510/4f114a12-7663-11e5-928f-632ad8a26599.png)

---

* all of them are aligned right
* Should search and notifications dropdowns use the same pattern? Or is this good enough to merge and we can resolve that when we fix search results.
