### PR TITLE
fix thread queries

### DIFF
--- a/lineman/app/components/dashboard_page/dashboard_page_controller.coffee
+++ b/lineman/app/components/dashboard_page/dashboard_page_controller.coffee
@@ -31,17 +31,17 @@ angular.module('loomioApp').controller 'DashboardPageController', ($rootScope, $
     _.contains ['show_muted'], @filter
 
   @updateQueries = =>
-    @currentBaseQuery = ThreadQueryService.filterQuery(@filter)
+    @currentBaseQuery = ThreadQueryService.filterQuery(['only_threads_in_my_groups', @filter])
     if @displayByGroup()
       _.each @groups(), (group) =>
         @views.groups[group.key] = ThreadQueryService.groupQuery(group, { filter: @filter, queryType: 'all' })
     else
-      @views.recent.proposals = ThreadQueryService.filterQuery ['show_proposals', @filter], queryType: 'important'
-      @views.recent.starred   = ThreadQueryService.filterQuery ['show_starred', 'hide_proposals', @filter], queryType: 'important'
+      @views.recent.proposals = ThreadQueryService.filterQuery ['only_threads_in_my_groups', 'show_not_muted', 'show_proposals', @filter], queryType: 'important'
+      @views.recent.starred   = ThreadQueryService.filterQuery ['show_not_muted', 'show_starred', 'hide_proposals', @filter], queryType: 'important'
       _.each @timeframeNames, (name) =>
         @views.recent[name] = ThreadQueryService.timeframeQuery
           name: name
-          filter: @filter
+          filter: ['only_threads_in_my_groups', 'show_not_muted', @filter]
           timeframe: @timeframes[name]
 
   @loadMore = =>

--- a/lineman/app/components/inbox_page/inbox_page_controller.coffee
+++ b/lineman/app/components/inbox_page/inbox_page_controller.coffee
@@ -3,6 +3,7 @@ angular.module('loomioApp').controller 'InboxPageController', ($scope, $rootScop
   $rootScope.$broadcast('setTitle', 'Inbox')
   $rootScope.$broadcast('analyticsClearGroup')
 
+  filters = ['only_threads_in_my_groups', 'show_unread']
   @threadLimit = 50
   @views =
     groups: {}
@@ -15,13 +16,13 @@ angular.module('loomioApp').controller 'InboxPageController', ($scope, $rootScop
   @init = =>
     return if @loading()
     _.each @groups(), (group) =>
-      @views.groups[group.key] = ThreadQueryService.groupQuery(group)
+      @views.groups[group.key] = ThreadQueryService.groupQuery(group, filter: filters)
   $scope.$on 'currentUserMembershipsLoaded', @init
   $scope.$on 'currentUserInboxLoaded', @init
   @init()
 
   @hasThreads = ->
-    ThreadQueryService.filterQuery('show_unread', queryType: 'inbox').any()
+    ThreadQueryService.filterQuery(filters, queryType: 'inbox').any()
 
   @moreForThisGroup = (group) ->
     @views.groups[group.key].length() > @threadLimit

--- a/lineman/app/components/navbar/navbar.coffee
+++ b/lineman/app/components/navbar/navbar.coffee
@@ -16,7 +16,7 @@ angular.module('loomioApp').directive 'navbar', ->
       $scope.selected = component.page
 
     $scope.unreadThreadCount = ->
-      ThreadQueryService.filterQuery('show_unread', queryType: 'inbox').length()
+      ThreadQueryService.filterQuery(['show_unread', 'only_threads_in_my_groups'], queryType: 'inbox').length()
 
     $scope.homePageClicked = ->
       $rootScope.$broadcast 'homePageClicked'

--- a/lineman/app/models/membership_model.coffee
+++ b/lineman/app/models/membership_model.coffee
@@ -23,3 +23,7 @@ angular.module('loomioApp').factory 'MembershipModel', (BaseModel, AppConfig) ->
     changeVolume: (volume) ->
       @volume = volume
       @save()
+
+    isMuted: ->
+      @volume == 'mute'
+

--- a/lineman/app/models/user_model.coffee
+++ b/lineman/app/models/user_model.coffee
@@ -23,6 +23,18 @@ angular.module('loomioApp').factory 'UserModel', (BaseModel, AppConfig) ->
     groupIds: ->
       _.map(@memberships(), 'groupId')
 
+    mutedMemberships: ->
+      _.select(@memberships(), (membership) -> membership.isMuted())
+
+    notMutedMemberships: ->
+      _.reject(@memberships(), (membership) -> membership.isMuted())
+
+    mutedGroupIds: ->
+      _.map(@mutedMemberships(), 'groupId')
+
+    notMutedGroupIds: ->
+      _.map(@notMutedMemberships(), 'groupId')
+
     groups: ->
       _.filter @recordStore.groups.find(id: { $in: @groupIds() }), (group) -> !group.isArchived()
 


### PR DESCRIPTION
On dashboard, do not show threads that are in groups you don't belong to.

On group page, do not hide muted threads.

@gdpelican  worked pretty hard to fit in with your design, feedback appreciated.