### PR TITLE
lose extra padding on one col pages

### DIFF
--- a/lineman/app/components/dashboard_page/dashboard_page.haml
+++ b/lineman/app/components/dashboard_page/dashboard_page.haml
@@ -1,5 +1,5 @@
 .lmo-one-column-layout
-  %main.dashboard-page.lmo-row
+  %main.dashboard-page
     %section.dashboard-page__options{aria-label: "{{ 'dashboard_page.options.aria_label' | translate }}"}
       .lmo-btn-group.lmo-btn-group-right
         .lmo-btn-wrapper

--- a/lineman/app/components/dashboard_page/dashboard_page.scss
+++ b/lineman/app/components/dashboard_page/dashboard_page.scss
@@ -1,4 +1,5 @@
 .dashboard-page {
+  @include lmoRow;
 }
 
 .dashboard-page__heading{

--- a/lineman/app/components/email_settings_page/email_settings_page.haml
+++ b/lineman/app/components/email_settings_page/email_settings_page.haml
@@ -1,5 +1,5 @@
 .lmo-one-column-layout
-  %main.email-settings-page.lmo-row
+  %main.email-settings-page
     %h1.lmo-h1.lmo-vertical-spacer-lg{translate: 'email_settings_page.header'}
     .email-settings-page__email-settings
       %h3.lmo-h3{translate: 'email_settings_page.email'}

--- a/lineman/app/components/email_settings_page/email_settings_page.scss
+++ b/lineman/app/components/email_settings_page/email_settings_page.scss
@@ -1,4 +1,5 @@
 .email-settings-page {
+  @include lmoRow;
 }
 
 .email-settings-page__email-settings {

--- a/lineman/app/components/group_page/group_page.scss
+++ b/lineman/app/components/group_page/group_page.scss
@@ -1,7 +1,3 @@
-.group-page {
-  padding-top: 48px;
-}
-
 .group-page__description {
   @include card;
 }

--- a/lineman/app/components/group_page/group_page.scss
+++ b/lineman/app/components/group_page/group_page.scss
@@ -1,3 +1,7 @@
+.group-page{
+  @include lmoRow;
+}
+
 .group-page__description {
   @include card;
 }

--- a/lineman/app/components/group_page/group_theme/group_theme.haml
+++ b/lineman/app/components/group_page/group_theme/group_theme.haml
@@ -1,43 +1,42 @@
 .group-theme
-  .lmo-row
-    .group-theme__cover{ng-style:'coverStyle()'}
-      .group-theme__upload-photo{ng-mouseover: 'themeHoverIn()', ng-mouseleave: 'themeHoverOut()'}
-        %button.lmo-btn-link-no-underline{ng-click: 'openUploadCoverForm()', ng-if: 'canUploadPhotos()'}
+  .group-theme__cover{ng-style:'coverStyle()'}
+    .group-theme__upload-photo{ng-mouseover: 'themeHoverIn()', ng-mouseleave: 'themeHoverOut()'}
+      %button.lmo-btn-link-no-underline{ng-click: 'openUploadCoverForm()', ng-if: 'canUploadPhotos()'}
+        %i.fa.fa-lg.fa-camera
+        %span.group-theme__upload-help-text{ng-show: 'themeHover'} new photo
+
+
+  %section.group-theme__header--compact{ng-if: 'compact', aria-label: "{{ 'thread_group.aria_label | translate'}}"}
+    .group-theme__logo--compact{aria-hidden: 'true'}
+      %a{lmo-href-for: 'group'}
+        %img{ng-src: "{{group.logoUrl()}}"}
+    .group-theme__name--compact
+      %a{ng-if: 'group.isSubgroup()', lmo-href-for: 'group.parent()'}
+        {{group.parentName()}}
+      %span{ng-if: 'group.isSubgroup()'}> \-
+      %a{lmo-href-for: 'group'}
+        {{group.name}}
+
+  %section.group-theme__header{ng-if: '!compact', aria-label: "{{ 'group_page.header.aria_label' | translate }}"}
+    .group-theme__logo{ng-style:'logoStyle()', alt: "{{ 'group_page.group_logo' | translate }}"}
+      .group-theme__upload-photo{ng-mouseover: 'logoHoverIn()', ng-mouseleave: 'logoHoverOut()'}
+        %button.lmo-btn-link-no-underline{ng-click: 'openUploadLogoForm()', ng-if: 'canUploadPhotos()'}
           %i.fa.fa-lg.fa-camera
-          %span.group-theme__upload-help-text{ng-show: 'themeHover'} new photo
+          %span.group-theme__upload-help-text{ng-show: 'logoHover'} new photo
 
-
-    %section.group-theme__header--compact{ng-if: 'compact', aria-label: "{{ 'thread_group.aria_label | translate'}}"}
-      .group-theme__logo--compact{aria-hidden: 'true'}
-        %a{lmo-href-for: 'group'}
-          %img{ng-src: "{{group.logoUrl()}}"}
-      .group-theme__name--compact
-        %a{ng-if: 'group.isSubgroup()', lmo-href-for: 'group.parent()'}
-          {{group.parentName()}}
-        %span{ng-if: 'group.isSubgroup()'}> \-
-        %a{lmo-href-for: 'group'}
-          {{group.name}}
-
-    %section.group-theme__header{ng-if: '!compact', aria-label: "{{ 'group_page.header.aria_label' | translate }}"}
-      .group-theme__logo{ng-style:'logoStyle()', alt: "{{ 'group_page.group_logo' | translate }}"}
-        .group-theme__upload-photo{ng-mouseover: 'logoHoverIn()', ng-mouseleave: 'logoHoverOut()'}
-          %button.lmo-btn-link-no-underline{ng-click: 'openUploadLogoForm()', ng-if: 'canUploadPhotos()'}
-            %i.fa.fa-lg.fa-camera
-            %span.group-theme__upload-help-text{ng-show: 'logoHover'} new photo
-
-      .group-theme__name-and-actions
-        .group-theme__name
-          %h1.lmo-h1
-            %a{ng-if: 'group.isSubgroup()', lmo-href-for: 'group.parent()'}
-              {{group.parentName()}}
-            %span{ng-if: 'group.isSubgroup()'}> \-
-            %a{lmo-href-for: 'group'}
-              {{group.name}}
-        .group-theme__actions{ng-if: 'homePage'}
-          .group-theme__member-actions.lmo-btn-group.lmo-btn-group-right{ng-if: 'isMember()'}
-            .lmo-btn-wrapper
-              %group_actions_dropdown{group: 'group'}
-            .lmo-btn-wrapper
-              %group_privacy_dropdown{group: 'group'}
-          %join_group_button{group: 'group'}
-        .clearfix
+    .group-theme__name-and-actions
+      .group-theme__name
+        %h1.lmo-h1
+          %a{ng-if: 'group.isSubgroup()', lmo-href-for: 'group.parent()'}
+            {{group.parentName()}}
+          %span{ng-if: 'group.isSubgroup()'}> \-
+          %a{lmo-href-for: 'group'}
+            {{group.name}}
+      .group-theme__actions{ng-if: 'homePage'}
+        .group-theme__member-actions.lmo-btn-group.lmo-btn-group-right{ng-if: 'isMember()'}
+          .lmo-btn-wrapper
+            %group_actions_dropdown{group: 'group'}
+          .lmo-btn-wrapper
+            %group_privacy_dropdown{group: 'group'}
+        %join_group_button{group: 'group'}
+      .clearfix

--- a/lineman/app/components/group_page/group_theme/group_theme.haml
+++ b/lineman/app/components/group_page/group_theme/group_theme.haml
@@ -1,42 +1,43 @@
-.group-theme.lmo-row
-  .group-theme__cover{ng-style:'coverStyle()'}
-    .group-theme__upload-photo{ng-mouseover: 'themeHoverIn()', ng-mouseleave: 'themeHoverOut()'}
-      %button.lmo-btn-link-no-underline{ng-click: 'openUploadCoverForm()', ng-if: 'canUploadPhotos()'}
-        %i.fa.fa-lg.fa-camera
-        %span.group-theme__upload-help-text{ng-show: 'themeHover'} new photo
-
-
-  %section.group-theme__header--compact{ng-if: 'compact', aria-label: "{{ 'thread_group.aria_label | translate'}}"}
-    .group-theme__logo--compact{aria-hidden: 'true'}
-      %a{lmo-href-for: 'group'}
-        %img{ng-src: "{{group.logoUrl()}}"}
-    .group-theme__name--compact
-      %a{ng-if: 'group.isSubgroup()', lmo-href-for: 'group.parent()'}
-        {{group.parentName()}}
-      %span{ng-if: 'group.isSubgroup()'}> \-
-      %a{lmo-href-for: 'group'}
-        {{group.name}}
-
-  %section.group-theme__header{ng-if: '!compact', aria-label: "{{ 'group_page.header.aria_label' | translate }}"}
-    .group-theme__logo{ng-style:'logoStyle()', alt: "{{ 'group_page.group_logo' | translate }}"}
-      .group-theme__upload-photo{ng-mouseover: 'logoHoverIn()', ng-mouseleave: 'logoHoverOut()'}
-        %button.lmo-btn-link-no-underline{ng-click: 'openUploadLogoForm()', ng-if: 'canUploadPhotos()'}
+.group-theme
+  .lmo-row
+    .group-theme__cover{ng-style:'coverStyle()'}
+      .group-theme__upload-photo{ng-mouseover: 'themeHoverIn()', ng-mouseleave: 'themeHoverOut()'}
+        %button.lmo-btn-link-no-underline{ng-click: 'openUploadCoverForm()', ng-if: 'canUploadPhotos()'}
           %i.fa.fa-lg.fa-camera
-          %span.group-theme__upload-help-text{ng-show: 'logoHover'} new photo
+          %span.group-theme__upload-help-text{ng-show: 'themeHover'} new photo
 
-    .group-theme__name-and-actions
-      .group-theme__name
-        %h1.lmo-h1
-          %a{ng-if: 'group.isSubgroup()', lmo-href-for: 'group.parent()'}
-            {{group.parentName()}}
-          %span{ng-if: 'group.isSubgroup()'}> \-
-          %a{lmo-href-for: 'group'}
-            {{group.name}}
-      .group-theme__actions{ng-if: 'homePage'}
-        .group-theme__member-actions.lmo-btn-group.lmo-btn-group-right{ng-if: 'isMember()'}
-          .lmo-btn-wrapper
-            %group_actions_dropdown{group: 'group'}
-          .lmo-btn-wrapper
-            %group_privacy_dropdown{group: 'group'}
-        %join_group_button{group: 'group'}
-      .clearfix
+
+    %section.group-theme__header--compact{ng-if: 'compact', aria-label: "{{ 'thread_group.aria_label | translate'}}"}
+      .group-theme__logo--compact{aria-hidden: 'true'}
+        %a{lmo-href-for: 'group'}
+          %img{ng-src: "{{group.logoUrl()}}"}
+      .group-theme__name--compact
+        %a{ng-if: 'group.isSubgroup()', lmo-href-for: 'group.parent()'}
+          {{group.parentName()}}
+        %span{ng-if: 'group.isSubgroup()'}> \-
+        %a{lmo-href-for: 'group'}
+          {{group.name}}
+
+    %section.group-theme__header{ng-if: '!compact', aria-label: "{{ 'group_page.header.aria_label' | translate }}"}
+      .group-theme__logo{ng-style:'logoStyle()', alt: "{{ 'group_page.group_logo' | translate }}"}
+        .group-theme__upload-photo{ng-mouseover: 'logoHoverIn()', ng-mouseleave: 'logoHoverOut()'}
+          %button.lmo-btn-link-no-underline{ng-click: 'openUploadLogoForm()', ng-if: 'canUploadPhotos()'}
+            %i.fa.fa-lg.fa-camera
+            %span.group-theme__upload-help-text{ng-show: 'logoHover'} new photo
+
+      .group-theme__name-and-actions
+        .group-theme__name
+          %h1.lmo-h1
+            %a{ng-if: 'group.isSubgroup()', lmo-href-for: 'group.parent()'}
+              {{group.parentName()}}
+            %span{ng-if: 'group.isSubgroup()'}> \-
+            %a{lmo-href-for: 'group'}
+              {{group.name}}
+        .group-theme__actions{ng-if: 'homePage'}
+          .group-theme__member-actions.lmo-btn-group.lmo-btn-group-right{ng-if: 'isMember()'}
+            .lmo-btn-wrapper
+              %group_actions_dropdown{group: 'group'}
+            .lmo-btn-wrapper
+              %group_privacy_dropdown{group: 'group'}
+          %join_group_button{group: 'group'}
+        .clearfix

--- a/lineman/app/components/group_page/group_theme/group_theme.scss
+++ b/lineman/app/components/group_page/group_theme/group_theme.scss
@@ -1,4 +1,5 @@
 .group-theme{
+  @include lmoRow;
   padding-top: 48px;
 }
 

--- a/lineman/app/components/group_page/group_theme/group_theme.scss
+++ b/lineman/app/components/group_page/group_theme/group_theme.scss
@@ -1,3 +1,7 @@
+.group-theme{
+  padding-top: 48px;
+}
+
 .group-theme__cover{
   position: absolute;
   top: $navbar-height;

--- a/lineman/app/components/groups_page/groups_page.haml
+++ b/lineman/app/components/groups_page/groups_page.haml
@@ -1,5 +1,5 @@
 .lmo-one-column-layout
-  %main.groups-page.lmo-row
+  %main.groups-page
     .row.groups-page__heading
       %h1.lmo-h1-medium{translate: 'groups_page.page_header'}
       %a.btn.btn-success.groups-page__new-group{ng-click: 'groupsPage.startGroup()', href: '#'}

--- a/lineman/app/components/groups_page/groups_page.scss
+++ b/lineman/app/components/groups_page/groups_page.scss
@@ -1,4 +1,5 @@
 .groups-page{
+  @include lmoRow;
 }
 
 .groups-page__heading{

--- a/lineman/app/components/inbox_page/inbox_page.haml
+++ b/lineman/app/components/inbox_page/inbox_page.haml
@@ -1,5 +1,5 @@
 .lmo-one-column-layout
-  %main.inbox-page.lmo-row
+  %main.inbox-page
     .thread-preview-collection__container
       %h1.lmo-h1-medium.inbox-page__heading{translate: 'inbox_page.unread_threads'}
       %loading{ng-if: 'inboxPage.loading()'}

--- a/lineman/app/components/inbox_page/inbox_page.scss
+++ b/lineman/app/components/inbox_page/inbox_page.scss
@@ -1,4 +1,5 @@
 .inbox-page{
+  @include lmoRow;
 }
 
 .inbox-page__group {

--- a/lineman/app/components/layout.scss
+++ b/lineman/app/components/layout.scss
@@ -1,7 +1,7 @@
 .lmo-one-column-layout{
   margin: auto;
   max-width: $small-max-px;
-  padding-top: 96px;
+  padding-top: 48px;
   z-index: 0;
   min-width: 320px;
 }

--- a/lineman/app/components/layout.scss
+++ b/lineman/app/components/layout.scss
@@ -13,6 +13,10 @@
   min-width: 320px;
 }
 
+.lmo-row{
+  @include lmoRow;
+}
+
 @media (max-width: $tiny-max-px){
   /* applied to tiny phone screens */
 
@@ -65,9 +69,7 @@
 
 @media (min-width: $tiny-max-px){
   /* applied to everything bigger than a tiny screen */
-  .lmo-row{
-    padding: 0 10px;
-  }
+
 }
 
 @media (max-width: $small-max-px){

--- a/lineman/app/components/membership_requests_page/membership_requests_page.haml
+++ b/lineman/app/components/membership_requests_page/membership_requests_page.haml
@@ -1,6 +1,6 @@
 .loading-wrapper.lmo-one-column-layout
   %loading{ng-if: '!membershipRequestsPage.group'}
-  %main.membership-requests-page.lmo-row{ng-if: 'membershipRequestsPage.group'}
+  %main.membership-requests-page{ng-if: 'membershipRequestsPage.group'}
     %group_theme{group: 'membershipRequestsPage.group'}
     .membership-requests-page__pending-requests
       %h2.lmo-h2{translate: 'membership_requests_page.heading'}

--- a/lineman/app/components/membership_requests_page/membership_requests_page.scss
+++ b/lineman/app/components/membership_requests_page/membership_requests_page.scss
@@ -1,4 +1,5 @@
 .membership-requests-page {
+  @include lmoRow;
 }
 
 .membership-requests-page__pending-requests,

--- a/lineman/app/components/mixins.scss
+++ b/lineman/app/components/mixins.scss
@@ -187,6 +187,14 @@ $cardPaddingSize: 15px;
   display: -webkit-flex;
 }
 
+@mixin lmoRow {
+  @media (min-width: $tiny-max-px){
+    /* outer padding on all but tiny screens */
+    padding-left: 10px;
+    padding-right: 10px;
+  }
+}
+
 
 #angular-feedback-card {
   @include fontSmall;

--- a/lineman/app/components/previous_proposals_page/previous_proposals_page.haml
+++ b/lineman/app/components/previous_proposals_page/previous_proposals_page.haml
@@ -1,6 +1,6 @@
 .loading-wrapper.lmo-one-column-layout
   %loading{ng-if: '!previousProposalsPage.group'}
-  %main.previous-proposals-page.lmo-row{ng-if: 'previousProposalsPage.group'}
+  %main.previous-proposals-page{ng-if: 'previousProposalsPage.group'}
     %group_theme{group: 'previousProposalsPage.group'}
     .previous-proposals-page__previous-proposals
       .lmo-card-left-right-padding

--- a/lineman/app/components/previous_proposals_page/previous_proposals_page.scss
+++ b/lineman/app/components/previous_proposals_page/previous_proposals_page.scss
@@ -1,4 +1,5 @@
 .previous-proposals-page {
+  @include lmoRow;
 }
 
 .previous-proposals-page__previous-proposals {

--- a/lineman/app/components/profile_page/profile_page.haml
+++ b/lineman/app/components/profile_page/profile_page.haml
@@ -1,6 +1,6 @@
 .loading-wrapper.lmo-one-column-layout
   %loading{ng-if: '!profilePage.user'}
-  %main.profile-page.lmo-row{ng-if: 'profilePage.user'}
+  %main.profile-page{ng-if: 'profilePage.user'}
     %h1.lmo-h1.lmo-vertical-spacer-lg{translate: 'profile_page.profile'}
     .profile-page-card
       .lmo-disabled-form{ng-show: 'profilePage.isDisabled'}

--- a/lineman/app/components/profile_page/profile_page.scss
+++ b/lineman/app/components/profile_page/profile_page.scss
@@ -1,4 +1,5 @@
 .profile-page {
+  @include lmoRow;
 }
 
 .profile-page-card {

--- a/lineman/app/components/thread_lintel/thread_lintel.scss
+++ b/lineman/app/components/thread_lintel/thread_lintel.scss
@@ -19,6 +19,7 @@
 }
 
 .thread-lintel__wrapper {
+  @include lmoRow;
   @include fontMedium;
   position: fixed;
   top: $navbar-height;

--- a/lineman/app/components/thread_page/thread_page.haml
+++ b/lineman/app/components/thread_page/thread_page.haml
@@ -54,5 +54,5 @@
       %activity_card{discussion: 'threadPage.discussion'}
       %comment_form{discussion: 'threadPage.discussion'}
 
-    %thread_lintel.lmo-row
+    %thread_lintel
     .clearfix


### PR DESCRIPTION
This fixes the 48px extra padding seen on the dashboard and inbox pages. `.group-theme` and `.lmo-row` were overwriting each other so I nested one inside the other. 
