### PR TITLE
Remove extra forward-slash in url

### DIFF
--- a/lineman/app/components/memberships_page/pending_invitations_card/pending_invitations_card.haml
+++ b/lineman/app/components/memberships_page/pending_invitations_card/pending_invitations_card.haml
@@ -12,7 +12,7 @@
           %td.pending-invitations-card__recipient-email
             {{invitation.recipientEmail}}
           %td.pending-invitations-card__invitation-url
-            {{baseUrl}}/invitations/{{invitation.token}}
+            {{baseUrl}}invitations/{{invitation.token}}
           %td.align-center
             %a.pending-invitations-card__cancel-link{href: '', ng-click: 'openCancelForm(invitation)'}
               %i.fa.fa-lg.fa-times-circle


### PR DESCRIPTION
[Trello card](https://trello.com/c/lfc3e5HO/933-pending-invitation-link-is-wrong-has-a-double-slash)