### PR TITLE
One more padding fix

### DIFF
--- a/lineman/app/components/thread_preview/thread_preview.scss
+++ b/lineman/app/components/thread_preview/thread_preview.scss
@@ -61,6 +61,7 @@
 .thread-preview__proposal-name{
   font-size: 93%;
   padding-left: $thinPaddingSize;
+  padding-right: 5px;
   @include truncateText;
 }
 


### PR DESCRIPTION
I'm sorry.

Before
====
![image](https://cloud.githubusercontent.com/assets/1380991/10776003/7711c53a-7d72-11e5-909c-febcdddc3cbe.png)

After
===
![image](https://cloud.githubusercontent.com/assets/1380991/10776023/ac2c21d4-7d72-11e5-83dd-5ceeaf2c2b2a.png)
