### PR TITLE
Add group to start thread modal launched from group page

### DIFF
--- a/lineman/app/components/discussion_form/discussion_form.coffee
+++ b/lineman/app/components/discussion_form/discussion_form.coffee
@@ -3,7 +3,7 @@ angular.module('loomioApp').factory 'DiscussionForm', ->
   controller: ($scope, $controller, $location, discussion, CurrentUser, Records, AbilityService, FormService, KeyEventService) ->
     $scope.discussion = discussion.clone()
 
-    if $scope.discussion.isNew() and !$scope.discussion.groupId?
+    if $scope.discussion.isNew()
       $scope.showGroupSelect = true
 
     $scope.$on 'modal.closing', (event) ->


### PR DESCRIPTION
[Trello card](https://trello.com/c/xbJCPPNB/846-when-i-open-the-start-thread-modal-from-the-group-page-i-want-to-see-the-group-name-so-i-am-confident-it-is-going-to-start-in-th)