### PR TITLE
put submit button before cancel button for keyboard users

### DIFF
--- a/lineman/app/components/archive_group_form/archive_group_form.haml
+++ b/lineman/app/components/archive_group_form/archive_group_form.haml
@@ -7,5 +7,5 @@
   .modal-body
     %span{translate: 'group_page.deactivate_group.question'}
   .modal-footer
-    %button.lmo-btn--cancel{ng-click: '$close()', type: 'button', translate: 'common.action.cancel'}
     %button.lmo-btn--submit.archive-group-form__submit{type: 'submit', translate: 'group_page.deactivate_group.submit'}
+    %button.lmo-btn--cancel{ng-click: '$close()', type: 'button', translate: 'common.action.cancel'}

--- a/lineman/app/components/change_password_form/change_password_form.haml
+++ b/lineman/app/components/change_password_form/change_password_form.haml
@@ -19,5 +19,5 @@
     %validation_errors{subject: 'user', field: 'confirmPassword'}
 
   .modal-footer
-    %button.lmo-btn--cancel{ng-click: '$close()', type: 'button', translate: 'common.action.cancel'}
     %button.lmo-btn--submit{type: 'submit', translate: 'profile_page.change_password.submit'}
+    %button.lmo-btn--cancel{ng-click: '$close()', type: 'button', translate: 'common.action.cancel'}

--- a/lineman/app/components/change_volume_form/change_volume_form.haml
+++ b/lineman/app/components/change_volume_form/change_volume_form.haml
@@ -12,5 +12,5 @@
             %strong{translate: '{{translateRoot}}.{{level}}_label'}
             %p.change-volume-form__description{translate: '{{translateRoot}}.{{level}}_description'}
     .modal-footer
-      %button.change-volume-form__cancel{type: 'button', translate: 'common.action.cancel', ng-click: '$close()'}
       %button.change-volume-form__submit{type: 'submit', ng-disabled: 'isDisabled', translate: 'common.action.update'}
+      %button.change-volume-form__cancel{type: 'button', translate: 'common.action.cancel', ng-click: '$close()'}

--- a/lineman/app/components/deactivate_user_form/deactivate_user_form.haml
+++ b/lineman/app/components/deactivate_user_form/deactivate_user_form.haml
@@ -8,5 +8,5 @@
     %h4.lmo-h4{translate: 'profile_page.deactivate_user.question'}
     %textarea.form-control{ng-model: 'user.deactivationResponse', placeholder: "{{ 'profile_page.deactivate_user.placeholder' | translate }}"}
   .modal-footer
-    %button.lmo-btn--cancel{ng-click: '$close()', type: 'button', translate: 'common.action.cancel'}
     %button.lmo-btn--danger{type: 'submit', translate: 'profile_page.deactivate_user.submit'}
+    %button.lmo-btn--cancel{ng-click: '$close()', type: 'button', translate: 'common.action.cancel'}

--- a/lineman/app/components/delete_thread_form/delete_thread_form.haml
+++ b/lineman/app/components/delete_thread_form/delete_thread_form.haml
@@ -8,5 +8,5 @@
     .modal-body
       %span{translate: 'delete_thread_form.body'}
     .modal-footer
-      %button.lmo-btn--cancel{ng-click: '$close()', type: 'button', translate: 'common.action.cancel'}
       %button.lmo-btn--danger.delete_thread_form__submit{type: 'submit', translate: 'delete_thread_form.confirm'}
+      %button.lmo-btn--cancel{ng-click: '$close()', type: 'button', translate: 'common.action.cancel'}

--- a/lineman/app/components/discussion_form/discussion_form.haml
+++ b/lineman/app/components/discussion_form/discussion_form.haml
@@ -52,6 +52,6 @@
           %span.label-with-details-details{ng_show: 'discussion.group().isVisibleToParentMembers', translate: 'discussion_form.privacy.will_be_private_to_parent_group', translate-value-group-name: '{{::discussion.groupName()}}', translate-value-parent-group-name: '{{discussion.group().parentName()}}'}
           %span.label-with-details-details{ng_hide: 'discussion.group().isVisibleToParentMembers', translate: 'discussion_form.privacy.will_be_private_to_group', translate-value-group-name: '{{discussion.groupName()}}'}
   .modal-footer
-    %button.lmo-btn--cancel.discussion-form__cancel{type: 'button', ng-click: '$close()', translate: 'common.action.cancel'}
     %button.lmo-btn--submit.discussion-form__submit{type: 'submit', translate: 'discussion_form.new_discussion_submit', ng_show: 'discussion.isNew()' }
     %button.lmo-btn--primary.discussion-form__update{type: 'submit', translate: 'discussion_form.edit_discussion_submit', ng_hide: 'discussion.isNew()' }
+    %button.lmo-btn--cancel.discussion-form__cancel{type: 'button', ng-click: '$close()', translate: 'common.action.cancel'}

--- a/lineman/app/components/edit_group_form/edit_group_form.haml
+++ b/lineman/app/components/edit_group_form/edit_group_form.haml
@@ -75,5 +75,5 @@
           %span{translate: 'edit_group_form.permissions.members_can_vote'}
 
     .modal-footer
-      %button.lmo-btn--cancel{ng-click: '$close()', type: 'button', translate: 'common.action.cancel'}
       %button.lmo-btn--submit.edit-group-form__submit-button{type: 'submit', translate: 'edit_group_form.submit'}
+      %button.lmo-btn--cancel{ng-click: '$close()', type: 'button', translate: 'common.action.cancel'}

--- a/lineman/app/components/group_page/membership_request_form/membership_request_form.haml
+++ b/lineman/app/components/group_page/membership_request_form/membership_request_form.haml
@@ -18,5 +18,5 @@
         %textarea.membership-request-form__introduction.form-control#membership-request-introduction{ng-model: 'membershipRequest.introduction', ng-required: 'false'}
 
   .modal-footer
-    %button.membership-request-form__cancel-btn{ng-click: '$close()', type: 'button', translate: 'common.action.cancel'}
     %button.membership-request-form__submit-btn{type: 'submit', translate: 'membership_request_form.submit_button'}
+    %button.membership-request-form__cancel-btn{ng-click: '$close()', type: 'button', translate: 'common.action.cancel'}

--- a/lineman/app/components/group_page/trial_card/confirm_gift_plan_modal/confirm_gift_plan_modal.haml
+++ b/lineman/app/components/group_page/trial_card/confirm_gift_plan_modal/confirm_gift_plan_modal.haml
@@ -8,6 +8,6 @@
       %span{translate: 'confirm_gift_plan_modal.body'}
 
   .modal-footer.lmo-clearfix
-    %button.confirm-gift-plan-modal__cancel-button{type: 'button', ng-click: '$close()', translate: 'common.action.cancel'}
     %button.confirm-gift-plan-modal__submit-button{type: 'button', ng-click: 'submit()', translate: 'confirm_gift_plan_modal.got_it'}
+    %button.confirm-gift-plan-modal__cancel-button{type: 'button', ng-click: '$close()', translate: 'common.action.cancel'}
 

--- a/lineman/app/components/invitation_form/invitation_form.haml
+++ b/lineman/app/components/invitation_form/invitation_form.haml
@@ -28,5 +28,5 @@
         %textarea.form-control#message_input{ng-model: 'message'}
 
   .modal-footer
-    %button.lmo-btn--cancel{ng-click: '$close()', translate: 'common.action.cancel'}
     %button.invitation-form__submit.lmo-btn--submit{ng-click: 'submit()', ng-disabled: 'isDisabled', ng-show: 'hasInvitations()', translate: 'invitation.send_invite', translate-value-count: '{{invitationsCount()}}'}
+    %button.lmo-btn--cancel{ng-click: '$close()', translate: 'common.action.cancel'}

--- a/lineman/app/components/leave_group_form/leave_group_form.haml
+++ b/lineman/app/components/leave_group_form/leave_group_form.haml
@@ -9,7 +9,7 @@
       %span{ng-if: 'canLeaveGroup()', translate: 'group_page.leave_group.question'}
       %span{ng-if: '!canLeaveGroup()', translate: 'group_page.leave_group.cannot_leave_group'}
     .modal-footer
-      %button.lmo-btn--cancel{ng-click: '$close()', type: 'button', translate: 'common.action.cancel'}
       %button.lmo-btn--submit.leave-group-form__submit{ng-if: 'canLeaveGroup()', type: 'submit', translate: 'group_page.leave_group.submit'}
       %a.lmo-btn--primary.leave-group-form__add-coordinator{ng-if: '!canLeaveGroup()', lmo-href-for: 'group', lmo-href-action: 'memberships', ng-click: '$close()'}
         %span{translate: 'group_page.leave_group.add_coordinator'}
+      %button.lmo-btn--cancel{ng-click: '$close()', type: 'button', translate: 'common.action.cancel'}

--- a/lineman/app/components/memberships_page/cancel_invitation_form/cancel_invitation_form.haml
+++ b/lineman/app/components/memberships_page/cancel_invitation_form/cancel_invitation_form.haml
@@ -6,5 +6,5 @@
   .modal-body
     %span{translate: 'cancel_invitation_form.question'}
   .modal-footer
-    %button.lmo-btn--cancel{ng-click: '$close()', type: 'button', translate: 'cancel_invitation_form.cancel'}
     %button.lmo-btn--danger.cancel-invitation-form__submit{type: 'submit', translate: 'cancel_invitation_form.submit'}
+    %button.lmo-btn--cancel{ng-click: '$close()', type: 'button', translate: 'cancel_invitation_form.cancel'}

--- a/lineman/app/components/move_thread_form/move_thread_form.haml
+++ b/lineman/app/components/move_thread_form/move_thread_form.haml
@@ -10,5 +10,5 @@
       %select.move-thread-form__group-dropdown.form-control#group-dropdown{ng-model: 'discussion.groupId', ng-required: true, ng-options: 'group.id as group.fullName for group in availableGroups() | orderBy: "fullName"'}
 
     .modal-footer
-      %button.lmo-btn--cancel{ng-click: '$close()', type: 'button', translate: 'common.action.cancel'}
       %button.lmo-btn--submit.move-thread-form__submit{type: 'submit', translate: 'move_thread_form.confirm'}
+      %button.lmo-btn--cancel{ng-click: '$close()', type: 'button', translate: 'common.action.cancel'}

--- a/lineman/app/components/proposal_form/proposal_form.haml
+++ b/lineman/app/components/proposal_form/proposal_form.haml
@@ -24,6 +24,6 @@
       %closing_at_field{proposal: 'proposal'}
 
   .modal-footer
-    %button.lmo-btn--cancel.proposal-form__cancel-btn{ng-click: '$close($event)', type: 'button', translate: 'common.action.cancel'}
     %button.lmo-btn--submit.proposal-form__start-btn{ng-if: 'proposal.isNew()', type: 'submit', translate: 'proposal_form.start_proposal'}
     %button.lmo-btn--submit.proposal-form__save-changes-btn{ng-if: '!proposal.isNew()', type: 'submit', translate: 'common.action.save_changes'}
+    %button.lmo-btn--cancel.proposal-form__cancel-btn{ng-click: '$close($event)', type: 'button', translate: 'common.action.cancel'}

--- a/lineman/app/components/remove_membership_form/remove_membership_form.haml
+++ b/lineman/app/components/remove_membership_form/remove_membership_form.haml
@@ -6,5 +6,5 @@
   .modal-body
     %span{translate: 'memberships_page.remove_membership.question', translate-value-name: '{{membership.userName()}}', translate-value-group: '{{membership.group().name}}'}
   .modal-footer
-    %button.lmo-btn--cancel{ng-click: '$close()', type: 'button', translate: 'common.action.cancel'}
     %button.lmo-btn--danger.memberships-page__remove-membership-confirm{type: 'submit', translate: 'memberships_page.remove_membership.submit'}
+    %button.lmo-btn--cancel{ng-click: '$close()', type: 'button', translate: 'common.action.cancel'}

--- a/lineman/app/components/start_group_form/start_group_form.haml
+++ b/lineman/app/components/start_group_form/start_group_form.haml
@@ -22,5 +22,5 @@
     .group-payment-notice{ng-if: 'group.isParent()', translate: 'start_group_form.group_payment_reminder'}
 
   .modal-footer
-    %button.lmo-btn--cancel{type: 'button', ng-click: '$close()', translate: 'common.action.cancel'}
     %button.lmo-btn--submit.start-group-form__submit{type: 'submit', translate: 'start_group_form.submit'}
+    %button.lmo-btn--cancel{type: 'button', ng-click: '$close()', translate: 'common.action.cancel'}

--- a/lineman/app/components/thread_page/close_proposal_form/close_proposal_form.haml
+++ b/lineman/app/components/thread_page/close_proposal_form/close_proposal_form.haml
@@ -8,5 +8,5 @@
     %span{translate: 'close_proposal_form.helptext'}
 
   .modal-footer
-    %button.lmo-btn--cancel{type: 'button', ng-click: '$close()', translate: 'common.action.cancel'}
     %button.lmo-btn--submit.close-proposal-form__submit-btn{type: 'submit', translate: 'close_proposal_form.close_proposal_submit'}
+    %button.lmo-btn--cancel{type: 'button', ng-click: '$close()', translate: 'common.action.cancel'}

--- a/lineman/app/components/thread_page/comment/delete_comment.haml
+++ b/lineman/app/components/thread_page/comment/delete_comment.haml
@@ -7,5 +7,5 @@
   %span{translate: 'delete_comment_dialog.question'}
 
 .modal-footer
-  %button.lmo-btn--cancel{ng-click: 'cancel($event)', translate: 'common.action.cancel'}
   %button.lmo-btn--danger{ng-click: 'submit()', translate: 'delete_comment_dialog.confirm'}
+  %button.lmo-btn--cancel{ng-click: 'cancel($event)', translate: 'common.action.cancel'}

--- a/lineman/app/components/thread_page/comment_form/delete_comment_form.haml
+++ b/lineman/app/components/thread_page/comment_form/delete_comment_form.haml
@@ -6,5 +6,5 @@
     .modal-body
       .comment-form-delete-message{translate: 'comment_form.confirm_delete_message'}
     .modal-footer
-      %button.lmo-btn--cancel{type: 'button', ng-click: '$close()', translate: 'common.action.cancel'}
       %button.lmo-btn--danger.delete-comment-form__delete-button{type: 'submit', translate: 'comment_form.confirm_delete'}
+      %button.lmo-btn--cancel{type: 'button', ng-click: '$close()', translate: 'common.action.cancel'}

--- a/lineman/app/components/thread_page/comment_form/edit_comment_form.haml
+++ b/lineman/app/components/thread_page/comment_form/edit_comment_form.haml
@@ -6,5 +6,5 @@
     .modal-body
       %textarea.form-control.edit-comment-form__comment-field{name: 'body', ng_model: 'comment.body', mentio: true, mentio-trigger-char: "'@'", mentio_items: 'mentionables', mentio-template-url: 'generated/components/thread_page/comment_form/mentio_menu.html', mentio-search: 'fetchByNameFragment(term)', mentio-id: 'comment-field', ng-model-options: "{ updateOn: 'default blur', debounce: {'default': 300, 'blur': 0} }"}
     .modal-footer
-      %button.lmo-btn--cancel{type: 'button', ng-click: '$close()', translate: 'common.action.cancel'}
       %button.lmo-btn--submit.comment-form__submit-btn{type: 'submit', translate: 'common.action.save_changes'}>
+      %button.lmo-btn--cancel{type: 'button', ng-click: '$close()', translate: 'common.action.cancel'}

--- a/lineman/app/components/thread_page/extend_proposal_form/extend_proposal_form.haml
+++ b/lineman/app/components/thread_page/extend_proposal_form/extend_proposal_form.haml
@@ -7,5 +7,5 @@
     %closing_at_field{proposal: 'proposal'}
 
   .modal-footer
-    %button.lmo-btn--cancel{type: 'button', ng-click: 'cancel($event)', translate: 'common.action.cancel'}
     %button.lmo-btn--submit.cuke-extend-proposal-btn{type: 'submit', translate: 'extend_proposal_form.submit'}
+    %button.lmo-btn--cancel{type: 'button', ng-click: 'cancel($event)', translate: 'common.action.cancel'}

--- a/lineman/app/components/thread_page/proposal_outcome_form/proposal_outcome_form.haml
+++ b/lineman/app/components/thread_page/proposal_outcome_form/proposal_outcome_form.haml
@@ -15,5 +15,5 @@
         %textarea.proposal-form__outcome-field.form-control#proposal-outcome-field{placeholder: "{{ 'proposal_outcome_form.outcome_placeholder' | translate }}", ng-model: 'proposal.outcome', ng-required: 'true'}
 
   .modal-footer
-    %button.lmo-btn--cancel.proposal-outcome-form__cancel-btn{ng-click: '$close()', type: 'button', translate: 'common.action.cancel'}
     %button.lmo-btn--submit.proposal-outcome-form__publish-outcome-btn{type: 'submit', translate: 'proposal_outcome_form.publish_outcome'}
+    %button.lmo-btn--cancel.proposal-outcome-form__cancel-btn{ng-click: '$close()', type: 'button', translate: 'common.action.cancel'}

--- a/lineman/app/components/thread_page/vote_form/vote_form.haml
+++ b/lineman/app/components/thread_page/vote_form/vote_form.haml
@@ -19,5 +19,5 @@
             {{ vote.charsLeft() }}
 
     .modal-footer
-      %button.lmo-btn--cancel{type: 'button', ng-click: '$close()', translate: 'common.action.cancel'}
       %button.lmo-btn--submit.vote-form__submit-btn{type: 'submit', translate: 'vote_form.submit_position'}>
+      %button.lmo-btn--cancel{type: 'button', ng-click: '$close()', translate: 'common.action.cancel'}


### PR DESCRIPTION
This makes no visual change to the ui (due to the float: left on the cancel button), but it means the first button you hit when you tab out of the form is Submit.