### PR TITLE
remove twitter autolink from comment serializer

### DIFF
--- a/app/serializers/comment_serializer.rb
+++ b/app/serializers/comment_serializer.rb
@@ -1,6 +1,4 @@
 class CommentSerializer < ActiveModel::Serializer
-  include Twitter::Autolink
-
   embed :ids, include: true
   attributes :id, :body, :mentioned_usernames, :created_at, :updated_at, :parent_id, :parent_author_name
 


### PR DESCRIPTION
i don't think we use this now. 