### PR TITLE
Soft drafts

### DIFF
--- a/app/controllers/api/drafts_controller.rb
+++ b/app/controllers/api/drafts_controller.rb
@@ -1,0 +1,19 @@
+class API::DraftsController < API::RestfulController
+  before_filter :load_resource
+
+  private
+
+  def load_resource
+    self.resource = Draft.find_or_initialize_by(user: current_user, draftable: draftable)
+  end
+
+  def draftable
+    return unless ['user', 'group', 'discussion', 'motion'].include? params[:draftable_type]
+    @draftable ||= params[:draftable_type].classify.constantize.find(params[:draftable_id])
+  end
+
+  def resource_params
+    params.require(:draft).slice(:payload)
+  end
+
+end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -70,7 +70,7 @@ class Ability
       (user_is_admin_of?(group.id) && group.enabled_beta_features.include?('export'))
     end
 
-    can [:members_autocomplete, :set_volume, :see_members, :move_discussions_to, :view_previous_proposals], Group do |group|
+    can [:members_autocomplete, :set_volume, :make_draft, :see_members, :move_discussions_to, :view_previous_proposals], Group do |group|
       user_is_member_of?(group.id)
     end
 
@@ -134,7 +134,7 @@ class Ability
       not user_to_deactivate.adminable_groups.published.any? { |g| g.admins.count == 1 }
     end
 
-    can [:update, :see_notifications_for], User do |user|
+    can [:update, :see_notifications_for, :make_draft], User do |user|
       @user == user
     end
 
@@ -212,7 +212,7 @@ class Ability
       user_is_member_of?(comment.group.id)
     end
 
-    can :add_comment, Discussion do |discussion|
+    can [:add_comment, :make_draft], Discussion do |discussion|
       user_is_member_of?(discussion.group_id)
     end
 
@@ -232,7 +232,7 @@ class Ability
         user_is_admin_of?(discussion.group_id) )
     end
 
-    can [:vote], Motion do |motion|
+    can [:vote, :make_draft], Motion do |motion|
       discussion = motion.discussion
       motion.voting? &&
       ((discussion.group.members_can_vote? && user_is_member_of?(discussion.group_id)) ||
@@ -275,6 +275,11 @@ class Ability
 
     can [:show], Vote do |vote|
       can?(:show, vote.motion)
+    end
+
+    can :update, Draft do |draft|
+      draft.user_id == @user.id &&
+      can?(:make_draft, draft.draftable)
     end
 
   end

--- a/app/models/draft.rb
+++ b/app/models/draft.rb
@@ -1,0 +1,19 @@
+class Draft < ActiveRecord::Base
+  belongs_to :user
+  belongs_to :draftable, polymorphic: true
+
+  validates :user, presence: true
+  validates :draftable, presence: true
+
+  class << self
+    def purge(user:, draftable:, field:)
+      find_or_initialize_by(user: user, draftable: draftable).purge(field)
+    end
+    handle_asynchronously :purge
+  end
+
+  def purge(field)
+    self.payload[field] = {}
+    self.tap(&:save)
+  end
+end

--- a/app/models/permitted_params.rb
+++ b/app/models/permitted_params.rb
@@ -2,7 +2,7 @@ class PermittedParams < Struct.new(:params)
 
   %w[user vote subscription motion membership_request membership
    invitation group_request group discussion discussion_reader comment
-   attachment contact_message theme user_deactivation_response network_membership_request].each do |kind|
+   attachment contact_message theme user_deactivation_response network_membership_request draft].each do |kind|
     define_method(kind) do
       permitted_attributes = self.send("#{kind}_attributes")
       params.require(kind).permit(*permitted_attributes)
@@ -89,5 +89,9 @@ class PermittedParams < Struct.new(:params)
 
   def user_deactivation_response_attributes
     [:body]
+  end
+
+  def draft_attributes
+    [:payload]
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -97,6 +97,7 @@ class User < ActiveRecord::Base
   has_many :notifications, dependent: :destroy
   has_many :comments, dependent: :destroy
   has_many :attachments, dependent: :destroy
+  has_many :drafts, dependent: :destroy
 
   has_one :deactivation_response,
           class_name: 'UserDeactivationResponse',

--- a/app/serializers/draft_serializer.rb
+++ b/app/serializers/draft_serializer.rb
@@ -1,0 +1,4 @@
+class DraftSerializer < ActiveModel::Serializer
+  embed :ids, include: true
+  attributes :id, :draftable_type, :draftable_id, :payload
+end

--- a/app/services/comment_service.rb
+++ b/app/services/comment_service.rb
@@ -33,6 +33,7 @@ class CommentService
     comment.save!
     comment.discussion.update_attribute(:last_comment_at, comment.created_at)
 
+    Draft.purge(user: actor, draftable: comment.discussion, field: :comment)
     SearchVector.index! comment.discussion_id
 
     event = Events::NewComment.publish!(comment)

--- a/app/services/discussion_service.rb
+++ b/app/services/discussion_service.rb
@@ -30,6 +30,7 @@ class DiscussionService
 
     actor.ability.authorize! :create, discussion
     discussion.save!
+    Draft.purge(user: actor, draftable: discussion.group, field: :discussion)
     SearchVector.index! discussion.id
     Events::NewDiscussion.publish!(discussion)
   end

--- a/app/services/draft_service.rb
+++ b/app/services/draft_service.rb
@@ -1,0 +1,8 @@
+class DraftService
+
+  def self.update(draft:, params:, actor:)
+    actor.ability.authorize! :update, draft
+    draft.update(payload: params[:payload], user: actor)
+  end
+
+end

--- a/app/services/motion_service.rb
+++ b/app/services/motion_service.rb
@@ -4,6 +4,8 @@ class MotionService
     actor.ability.authorize! :create, motion
     return false unless motion.valid?
     motion.save!
+
+    Draft.purge(user: actor, draftable: motion.discussion, field: :motion)
     SearchVector.index! motion.discussion_id
 
     event = Events::NewMotion.publish!(motion)

--- a/app/services/vote_service.rb
+++ b/app/services/vote_service.rb
@@ -5,6 +5,8 @@ class VoteService
     actor.ability.authorize! :create, vote
     vote.save!
 
+    Draft.purge(user: actor, draftable: vote.motion, field: :vote)
+
     event = Events::NewVote.publish!(vote)
     DiscussionReader.for(discussion: vote.motion.discussion, user: actor).author_thread_item!(vote.created_at)
     event

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -80,6 +80,13 @@ Loomio::Application.routes.draw do
     end
 
     resources :events, only: :index
+    resources :drafts do
+      collection do
+        get    '/:draftable_type/:draftable_id', action: :show
+        post   '/:draftable_type/:draftable_id', action: :update
+        patch  '/:draftable_type/:draftable_id', action: :update
+      end
+    end
 
     resources :discussions, only: [:show, :index, :create, :update, :destroy] do
       patch :mark_as_read, on: :member

--- a/db/migrate/20151103094050_add_soft_drafts.rb
+++ b/db/migrate/20151103094050_add_soft_drafts.rb
@@ -1,0 +1,9 @@
+class AddSoftDrafts < ActiveRecord::Migration
+  def change
+    create_table :drafts do |t|
+      t.belongs_to :user
+      t.belongs_to :draftable, polymorphic: true
+      t.json :payload, default: {}, null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -274,6 +274,13 @@ ActiveRecord::Schema.define(version: 20151118022605) do
   add_index "discussions", ["last_activity_at"], name: "index_discussions_on_last_activity_at", order: {"last_activity_at"=>:desc}, using: :btree
   add_index "discussions", ["private"], name: "index_discussions_on_private", using: :btree
 
+  create_table "drafts", force: :cascade do |t|
+    t.integer "user_id"
+    t.integer "draftable_id"
+    t.string  "draftable_type"
+    t.json    "payload",        default: {}, null: false
+  end
+
   create_table "events", force: :cascade do |t|
     t.string   "kind",           limit: 255
     t.datetime "created_at"

--- a/lineman/app/components/discussion_form/discussion_form.coffee
+++ b/lineman/app/components/discussion_form/discussion_form.coffee
@@ -6,13 +6,11 @@ angular.module('loomioApp').factory 'DiscussionForm', ->
     if $scope.discussion.isNew()
       $scope.showGroupSelect = true
 
-    $scope.$on 'modal.closing', (event) ->
-      FormService.confirmDiscardChanges(event, $scope.discussion)
-
     actionName = if $scope.discussion.isNew() then 'created' else 'updated'
 
     $scope.submit = FormService.submit $scope, $scope.discussion,
       flashSuccess: "discussion_form.messages.#{actionName}"
+      allowDrafts: true
       successCallback: (response) =>
         $location.path "/d/#{response.discussions[0].key}" if actionName == 'created'
 

--- a/lineman/app/components/discussion_form/discussion_form.haml
+++ b/lineman/app/components/discussion_form/discussion_form.haml
@@ -13,18 +13,18 @@
 
     .lmo-form-group{ng-show: 'showGroupSelect'}
       %label{for: 'discussion-group-field', translate: 'discussion_form.group_label'}
-      %select.form-control#discussion-group-field{ng-model: 'discussion.groupId', ng-required: 'true' ng-options: 'group.id as group.fullName for group in availableGroups() | orderBy: "fullName"', ng-change: 'setCurrentPrivacy()'}
+      %select.form-control#discussion-group-field{ng-model: 'discussion.groupId', ng-required: 'true' ng-options: 'group.id as group.fullName for group in availableGroups() | orderBy: "fullName"', ng-change: 'restoreRemoteDraft()'}
         %option{value: '', translate: 'discussion_form.group_placeholder' }
 
     .discussion-group-selected{ng_if: 'discussion.groupId'}
       .lmo-form-group
         %label{for: 'discussion-title', translate: 'discussion_form.title_label'}
-        %input.discussion-form__title-input.form-control.lmo-primary-form-input#discussion-title{placeholder: "{{ 'discussion_form.title_placeholder' | translate }}", ng-model: 'discussion.title', ng-required: 'true', maxlength: '255'}
+        %input.discussion-form__title-input.form-control.lmo-primary-form-input#discussion-title{placeholder: "{{ 'discussion_form.title_placeholder' | translate }}", ng-model: 'discussion.title', ng-model-options: '{debounce: 600}', ng-change: 'storeDraft()', ng-required: 'true', maxlength: '255'}
         %validation_errors{subject: 'discussion', field: 'title'}
 
       .lmo-form-group
         %label{for: 'discussion-context', translate: 'discussion_form.context_label'}
-        %textarea.discussion-form__description-input.form-control.lmo-primary-form-input#discussion-context{msd-elastic: 'true', ng-model: 'discussion.description', placeholder: "{{ 'discussion_form.context_placeholder' | translate }}"}
+        %textarea.discussion-form__description-input.form-control.lmo-primary-form-input#discussion-context{msd-elastic: 'true', ng-model: 'discussion.description', , ng-model-options: '{debounce: 600}', ng-change: 'storeDraft()',placeholder: "{{ 'discussion_form.context_placeholder' | translate }}"}
 
       .lmo-form-group{ng-show: 'showPrivacyForm()'}
         %label.lmo-form-labelled-input.discussion-form__public

--- a/lineman/app/components/group_form/group_form.coffee
+++ b/lineman/app/components/group_form/group_form.coffee
@@ -3,30 +3,25 @@ angular.module('loomioApp').factory 'GroupForm', ->
   controller: ($scope, $rootScope, $location, group, FormService, Records, $translate, PrivacyString) ->
     $scope.group = group.clone()
 
-    $scope.$on 'modal.closing', (event) ->
-      FormService.confirmDiscardChanges(event, $scope.group)
-
     $scope.i18n = do ->
-      h = {}
+      groupMessaging = {}
       if $scope.group.isParent()
-        h.group_name = 'group_form.group_name'
+        groupMessaging.group_name = 'group_form.group_name'
         if $scope.group.isNew()
-          h.heading = 'group_form.start_group_heading'
-          h.submit = 'group_form.submit_start_group'
+          groupMessaging.heading = 'group_form.start_group_heading'
+          groupMessaging.submit = 'group_form.submit_start_group'
         else
-          h.heading = 'group_form.edit_group_heading'
-          h.submit = 'common.action.update_settings'
+          groupMessaging.heading = 'group_form.edit_group_heading'
+          groupMessaging.submit = 'common.action.update_settings'
       else
-        h.group_name = 'group_form.subgroup_name'
+        groupMessaging.group_name = 'group_form.subgroup_name'
         if $scope.group.isNew()
-          h.heading = 'group_form.start_subgroup_heading'
-          h.submit = 'group_form.submit_start_subgroup'
+          groupMessaging.heading = 'group_form.start_subgroup_heading'
+          groupMessaging.submit = 'group_form.submit_start_subgroup'
         else
-          h.heading = 'group_form.edit_subgroup_heading'
-          h.submit = 'common.action.update_settings'
-      h
-
-
+          groupMessaging.heading = 'group_form.edit_subgroup_heading'
+          groupMessaging.submit = 'common.action.update_settings'
+      groupMessaging
 
     successMessage = ->
       if $scope.group.isNew()
@@ -35,6 +30,7 @@ angular.module('loomioApp').factory 'GroupForm', ->
         'group_form.messages.group_updated'
 
     submitForm = FormService.submit $scope, $scope.group,
+      allowDrafts: true
       flashSuccess: successMessage()
       successCallback: (response) ->
         if $scope.group.isNew()

--- a/lineman/app/components/group_form/group_form.haml
+++ b/lineman/app/components/group_form/group_form.haml
@@ -9,12 +9,12 @@
       .group-form__basic
         .group-form__name
           %label{for: 'group-name', translate: '{{i18n.group_name}}'}
-          %input.form-control#group-name{ng-required: true, ng-model: 'group.name', maxlength: '255'}
+          %input.form-control#group-name{ng-required: true, ng-model: 'group.name', ng-model-options: '{debounce: 600}', ng-change: 'storeDraft()', maxlength: '255'}
           %validation_errors{subject: 'group', field: 'name'}
 
         .group-form__description
           %label{for: 'group-description', translate: 'group_form.description'}
-          %textarea.form-control#group-description{msd-elastic: 'true', ng-model: 'group.description'}
+          %textarea.form-control#group-description{msd-elastic: 'true', ng-model: 'group.description', ng-model-options: '{debounce: 600}', ng-change: 'storeDraft()'}
 
         .group-form__privacy-statement
           {{privacyStatement()}}

--- a/lineman/app/components/group_page/group_page_controller.coffee
+++ b/lineman/app/components/group_page/group_page_controller.coffee
@@ -9,6 +9,7 @@ angular.module('loomioApp').controller 'GroupPageController', ($rootScope, $loca
     $rootScope.$broadcast 'analyticsSetGroup', @group
     $rootScope.$broadcast 'trialIsOverdue', @group if @group.trialIsOverdue()
     MessageChannelService.subscribeToGroup(@group)
+    Records.drafts.fetchFor(@group)
     @handleSubscriptionSuccess()
     @handleWelcomeModal()
   , (error) ->

--- a/lineman/app/components/start_group_form/start_group_form.coffee
+++ b/lineman/app/components/start_group_form/start_group_form.coffee
@@ -1,0 +1,18 @@
+angular.module('loomioApp').factory 'StartGroupForm', ->
+  templateUrl: 'generated/components/start_group_form/start_group_form.html'
+  controller: ($scope, $rootScope, $location, group, Records, FormService, ModalService, GroupWelcomeModal, KeyEventService) ->
+    $scope.group = group
+
+    $scope.submit = FormService.submit $scope, $scope.group,
+      if $scope.group.isSubgroup()
+        allowDrafts: true
+        flashSuccess: 'start_group_form.messages.success_when_subgroup'
+        successCallback: (response) ->
+          $location.path "/g/#{response.groups[0].key}"
+      else
+        allowDrafts: true
+        successCallback: (response) ->
+          $location.path "/g/#{response.groups[0].key}"
+          ModalService.open GroupWelcomeModal
+
+    KeyEventService.submitOnEnter $scope

--- a/lineman/app/components/start_group_form/start_group_form.haml
+++ b/lineman/app/components/start_group_form/start_group_form.haml
@@ -1,0 +1,26 @@
+%form.start-group-form{name: 'startGroupForm', ng_submit: 'submit()', ng-disabled: 'group.processing'}
+  .lmo-disabled-form{ng-show: 'isDisabled'}
+  .modal-header
+    %modal_header_cancel_button
+    %h1.lmo-h1.modal-title{ng-if: 'group.isParent()', translate: 'start_group_form.heading'}
+    %h1.lmo-h1.modal-title{ng-if: 'group.isSubgroup()', translate: 'start_group_form.heading_when_subgroup'}
+
+  .modal-body
+    %form_errors{record: 'group'}
+
+    .group-helptext{ng-if: 'group.isParent()', translate: 'start_group_form.group_helptext'}
+
+    .lmo-form-group
+      %label{for: 'group-name', ng-if: 'group.isParent()', translate: 'start_group_form.name_label'}
+      %label{for: 'group-name', ng-if: 'group.isSubgroup()', translate: 'start_group_form.subgroup_name_label'}
+      %input.start-group-form__name.lmo-primary-form-input.form-control#group-name{ng-model: 'group.name', ng-model-options: '{debounce: 600}', ng-change: 'storeDraft()', ng-required: 'true'}
+
+    .lmo-form-group
+      %label{for: 'group-description', translate: 'start_group_form.description_label'}
+      %textarea.start-group-form__description.lmo-primary-form-input.form-control#group-description{msd-elastic: 'true', ng-model: 'group.description', ng-model-options: '{debounce: 600}', ng-change: 'storeDraft()', placeholder: "{{ 'start_group_form.description_placeholder' | translate }}"}
+
+    .group-payment-notice{ng-if: 'group.isParent()', translate: 'start_group_form.group_payment_reminder'}
+
+  .modal-footer
+    %button.lmo-btn--submit.start-group-form__submit{type: 'submit', translate: 'start_group_form.submit'}
+    %button.lmo-btn--cancel{type: 'button', ng-click: '$close()', translate: 'common.action.cancel'}

--- a/lineman/app/components/thread_page/comment_form/comment_form.coffee
+++ b/lineman/app/components/thread_page/comment_form/comment_form.coffee
@@ -29,6 +29,7 @@ angular.module('loomioApp').directive 'commentForm', ->
     $scope.init = ->
       $scope.comment = Records.comments.build(discussionId: $scope.discussion.id)
       $scope.submit = FormService.submit $scope, $scope.comment,
+        allowDrafts: true
         submitFn: $scope.comment.save
         flashSuccess: successMessage
         flashOptions:

--- a/lineman/app/components/thread_page/comment_form/comment_form.haml
+++ b/lineman/app/components/thread_page/comment_form/comment_form.haml
@@ -5,7 +5,7 @@
       %input{type: 'hidden', ng-model: 'comment.usesMarkdown'}
       %h2.lmo-card-heading#comment-form-title{translate: 'comment_form.aria_label'}>
       %span{translate: 'comment_form.in_reply_to', translate-values: "{name: '{{comment.parent().authorName()}}' }", ng-show: 'comment.parent().authorName()'}
-      %textarea.form-control.comment-form__comment-field.lmo-primary-form-input{msd-elastic: 'true', aria-labelledby: 'comment-form-title', name: 'body', placeholder: "Say something...", ng_model: 'comment.body', mentio: true, mentio-trigger-char: "'@'", mentio_items: 'mentionables', mentio-template-url: 'generated/components/thread_page/comment_form/mentio_menu.html', mentio-search: 'fetchByNameFragment(term)', mentio-id: 'comment-field', ng-model-options: "{ updateOn: 'default blur', debounce: {'default': 300, 'blur': 0} }"}
+      %textarea.form-control.comment-form__comment-field.lmo-primary-form-input{msd-elastic: 'true', ng-change: 'storeDraft()', ng-model-options: '{debounce: 600}', aria-labelledby: 'comment-form-title', name: 'body', placeholder: "Say something...", ng_model: 'comment.body', mentio: true, mentio-trigger-char: "'@'", mentio_items: 'mentionables', mentio-template-url: 'generated/components/thread_page/comment_form/mentio_menu.html', mentio-search: 'fetchByNameFragment(term)', mentio-id: 'comment-field', ng-focus: 'formInFocus()', ng-blur: 'formLostFocus()', ng-model-options: "{ updateOn: 'default blur', debounce: {'default': 300, 'blur': 0} }"}
       .comment-row.comment-attachments{ng_repeat: 'attachment in comment.newAttachments()'}
         %a.attachment-link{ng_href: '{{attachment.location}}', target: '_blank'}>
           {{ attachment.filename }}

--- a/lineman/app/models/comment_model.coffee
+++ b/lineman/app/models/comment_model.coffee
@@ -1,9 +1,10 @@
-angular.module('loomioApp').factory 'CommentModel', (BaseModel, AppConfig) ->
-  class CommentModel extends BaseModel
+angular.module('loomioApp').factory 'CommentModel', (DraftableModel, AppConfig) ->
+  class CommentModel extends DraftableModel
     @singular: 'comment'
     @plural: 'comments'
     @indices: ['discussionId', 'authorId']
     @serializableAttributes: AppConfig.permittedParams.comment
+    @draftParent: 'discussion'
 
     defaultValues: ->
       usesMarkdown: true

--- a/lineman/app/models/discussion_model.coffee
+++ b/lineman/app/models/discussion_model.coffee
@@ -1,9 +1,10 @@
-angular.module('loomioApp').factory 'DiscussionModel', (BaseModel, AppConfig) ->
-  class DiscussionModel extends BaseModel
+angular.module('loomioApp').factory 'DiscussionModel', (DraftableModel, AppConfig) ->
+  class DiscussionModel extends DraftableModel
     @singular: 'discussion'
     @plural: 'discussions'
     @uniqueIndices: ['id', 'key']
     @indices: ['groupId', 'authorId']
+    @draftParent: 'group'
     @serializableAttributes: AppConfig.permittedParams.discussion
 
     afterConstruction: ->

--- a/lineman/app/models/draft_model.coffee
+++ b/lineman/app/models/draft_model.coffee
@@ -1,0 +1,14 @@
+angular.module('loomioApp').factory 'DraftModel', (BaseModel, AppConfig) ->
+  class DraftModel extends BaseModel
+    @singular: 'draft'
+    @plural: 'drafts'
+    @uniqueIndices: ['id']
+    @serializableAttributes: AppConfig.permittedParams.draft
+
+    afterConstruction: ->
+      draftPath = => "#{@remote.apiPrefix}/#{@constructor.plural}/#{@draftableType.toLowerCase()}/#{@draftableId}"
+      @remote.collectionPath = @remote.memberPath = draftPath
+
+    updateFrom: (model) ->
+      @payload[model.constructor.singular] = model.serialize()[model.constructor.singular]
+      @save()

--- a/lineman/app/models/draft_records_interface.coffee
+++ b/lineman/app/models/draft_records_interface.coffee
@@ -1,0 +1,10 @@
+angular.module('loomioApp').factory 'DraftRecordsInterface', (BaseRecordsInterface, DraftModel) ->
+  class DraftRecordsInterface extends BaseRecordsInterface
+    model: DraftModel
+
+    findOrBuildFor: (model) ->
+      _.first(@find(draftableType: _.capitalize(model.constructor.singular), draftableId: model.id)) or
+      @build(draftableType: _.capitalize(model.constructor.singular), draftableId: model.id, payload: {})
+
+    fetchFor: (model) ->
+      @remote.get "#{model.constructor.singular}/#{model.id}"

--- a/lineman/app/models/draftable_model.coffee
+++ b/lineman/app/models/draftable_model.coffee
@@ -1,0 +1,18 @@
+angular.module('loomioApp').factory 'DraftableModel', (BaseModel) ->
+  class DraftableModel extends BaseModel
+    @draftParent: 'undefined'
+
+    draft: ->
+      @recordStore.drafts.findOrBuildFor(@[@constructor.draftParent]())
+
+    fetchDraft: =>
+      @recordStore.drafts.fetchFor(@[@constructor.draftParent]())
+
+    restoreDraft: ->
+      @update @draft().payload[@constructor.singular]
+
+    resetDraft: ->
+      @draft().updateFrom(@recordStore[@constructor.plural].build())
+
+    updateDraft: ->
+      @draft().updateFrom(@)

--- a/lineman/app/models/group_model.coffee
+++ b/lineman/app/models/group_model.coffee
@@ -1,10 +1,14 @@
-angular.module('loomioApp').factory 'GroupModel', (BaseModel, AppConfig) ->
-  class GroupModel extends BaseModel
+angular.module('loomioApp').factory 'GroupModel', (DraftableModel, AppConfig) ->
+  class GroupModel extends DraftableModel
     @singular: 'group'
     @plural: 'groups'
     @uniqueIndices: ['id', 'key']
     @indices: ['parentId']
     @serializableAttributes: AppConfig.permittedParams.group
+    @draftParent: 'draftParent'
+
+    draftParent: ->
+      @parent() or @recordStore.users.find(AppConfig.currentUserId)
 
     defaultValues: ->
       parentId: null

--- a/lineman/app/models/records.coffee
+++ b/lineman/app/models/records.coffee
@@ -15,7 +15,8 @@ angular.module('loomioApp').factory 'Records', (RecordStore,
                                                 SearchResultRecordsInterface,
                                                 ContactRecordsInterface,
                                                 InvitationRecordsInterface,
-                                                VersionRecordsInterface) ->
+                                                VersionRecordsInterface,
+                                                DraftRecordsInterface) ->
   db = new loki(RecordStoreDatabaseName)
   recordStore = new RecordStore(db)
   recordStore.addRecordsInterface(AttachmentRecordsInterface)
@@ -34,4 +35,5 @@ angular.module('loomioApp').factory 'Records', (RecordStore,
   recordStore.addRecordsInterface(ContactRecordsInterface)
   recordStore.addRecordsInterface(InvitationRecordsInterface)
   recordStore.addRecordsInterface(VersionRecordsInterface)
+  recordStore.addRecordsInterface(DraftRecordsInterface)
   recordStore

--- a/lineman/app/services/draft_service.coffee
+++ b/lineman/app/services/draft_service.coffee
@@ -1,0 +1,16 @@
+angular.module('loomioApp').factory 'DraftService', ->
+  new class DraftService
+
+    applyDrafting: (scope, model) ->
+      draftMode = ->
+        model[model.constructor.draftParent]() && model.isNew()
+
+      scope.storeDraft = ->
+        model.updateDraft() if draftMode()
+
+      scope.restoreDraft = ->
+        model.restoreDraft() if draftMode()
+      scope.restoreDraft()
+
+      scope.restoreRemoteDraft = ->
+        model.fetchDraft().then(scope.restoreDraft) if draftMode()

--- a/lineman/app/services/form_service.coffee
+++ b/lineman/app/services/form_service.coffee
@@ -1,4 +1,4 @@
-angular.module('loomioApp').factory 'FormService', ($rootScope, FlashService, $filter) ->
+angular.module('loomioApp').factory 'FormService', ($rootScope, FlashService, DraftService, $filter) ->
   new class FormService
 
     confirmDiscardChanges: (event, record) ->
@@ -22,6 +22,7 @@ angular.module('loomioApp').factory 'FormService', ($rootScope, FlashService, $f
     success = (scope, model, options) ->
       (response) ->
         FlashService.dismiss()
+        model.resetDraft() if options.allowDrafts
         if options.flashSuccess?
           options.flashSuccess = options.flashSuccess() if typeof options.flashSuccess is 'function'
           FlashService.success options.flashSuccess, calculateFlashOptions(options.flashOptions)
@@ -41,6 +42,7 @@ angular.module('loomioApp').factory 'FormService', ($rootScope, FlashService, $f
         scope.isDisabled = false
 
     submit: (scope, model, options = {}) ->
+      DraftService.applyDrafting(scope, model) if options.allowDrafts
       submitFn = options.submitFn or model.save
       (prepareArgs) ->
         prepare(scope, model, options, prepareArgs)

--- a/lineman/spec-e2e/discussion_spec.coffee
+++ b/lineman/spec-e2e/discussion_spec.coffee
@@ -17,25 +17,16 @@ describe 'Discussion Page', ->
       expect(threadPage.discussionTitle()).toContain('better title')
       expect(threadPage.discussionTitle()).toContain("improved description")
 
-    it 'lets you accidentally cancel then save', ->
-      threadPage.openEditThreadForm()
-      discussionForm.fillInTitle('even better title')
-      discussionForm.fillInDescription("more improved description")
-      discussionForm.clickCancel()
-      alert = browser.switchTo().alert()
-      alert.dismiss()
-      discussionForm.clickUpdate()
-      expect(threadPage.discussionTitle()).toContain('even better title')
-      expect(threadPage.discussionTitle()).toContain("more improved description")
-
-    it 'confirms you really want to cancel', ->
+    it 'does not store cancelled thread info', ->
       threadPage.openEditThreadForm()
       discussionForm.fillInTitle('dumb title')
       discussionForm.fillInDescription("rubbish description")
       discussionForm.clickCancel()
-      alert = browser.switchTo().alert()
-      alert.accept()
-      expect(threadPage.discussionTitle()).toContain('What star sign are you?')
+      threadPage.openEditThreadForm()
+      expect(discussionForm.titleField().getText()).not.toContain('dumb title')
+      expect(discussionForm.descriptionField().getText()).not.toContain('rubbish description')
+      expect(discussionForm.titleField().getText()).not.toContain('dumb title')
+      expect(discussionForm.descriptionField().getText()).not.toContain('rubbish description')
 
   describe 'move thread', ->
     it 'lets you move a thread', ->

--- a/lineman/spec-e2e/group_spec.coffee
+++ b/lineman/spec-e2e/group_spec.coffee
@@ -39,13 +39,14 @@ describe 'Group Page', ->
       page.expectText('.thread-context', 'Nobody puts baby in a corner' )
       page.expectText('.thread-context', "I've had the time of my life" )
 
-    it 'confirms you want to discard your unsaved work', ->
-      page.click('.discussions-card__new-thread-button')
+    it 'automatically saves drafts', ->
+      groupsHelper.clickStartThreadButton()
       page.fillIn('#discussion-title', 'Nobody puts baby in a corner')
+      page.fillIn('#discussion-context', "I've had the time of my life")
       page.click('.discussion-form__cancel')
-      page.cancelConfirmDialog()
-      page.click('.discussion-form__submit')
-      page.expectText('.thread-context', 'Nobody puts baby in a corner' )
+      groupsHelper.clickStartThreadButton()
+      page.expectText('#discussion-title', 'Nobody puts baby in a corner' )
+      page.expectText('#discussion-context', "I've had the time of my life" )
 
   describe 'starting a subgroup', ->
     beforeEach ->

--- a/lineman/spec-e2e/helpers/discussion_form_helper.coffee
+++ b/lineman/spec-e2e/helpers/discussion_form_helper.coffee
@@ -1,11 +1,17 @@
 module.exports = new class DiscussionFormHelper
   fillInTitle: (title)->
-    element(By.css('.discussion-form__title-input')).clear()
-    element(By.css('.discussion-form__title-input')).sendKeys(title)
+    @titleField().clear()
+    @titleField().sendKeys(title)
 
   fillInDescription: (description) ->
-    element(By.css('.discussion-form__description-input')).clear()
-    element(By.css('.discussion-form__description-input')).sendKeys(description)
+    @descriptionField().clear()
+    @descriptionField().sendKeys(description)
+
+  titleField: ->
+    element(By.css('.discussion-form__title-input'))
+
+  descriptionField: ->
+    element(By.css('.discussion-form__description-input'))
 
   clickSubmit: ->
     element.all(By.css('.discussion-form__submit')).first().click()
@@ -15,4 +21,3 @@ module.exports = new class DiscussionFormHelper
 
   clickCancel: ->
     element.all(By.css('.discussion-form__cancel')).first().click()
-

--- a/spec/controllers/api/drafts_controller_spec.rb
+++ b/spec/controllers/api/drafts_controller_spec.rb
@@ -1,0 +1,187 @@
+require 'rails_helper'
+describe API::DraftsController do
+
+  let(:user) { create :user }
+  let(:another_user) { create :user }
+  let(:group) { create :group }
+  let(:another_group) { create :group }
+  let(:discussion) { create :discussion, group: group }
+  let(:motion) { create :motion, discussion: discussion }
+
+  let(:user_draft) { create :draft, user: user, draftable: user }
+  let(:group_draft) { create :draft, user: user, draftable: group }
+  let(:discussion_draft) { create :draft, user: user, draftable: discussion }
+  let(:motion_draft) { create :draft, user: user, draftable: motion }
+
+  let(:user_draft_params) {{
+    payload: {
+      group: {
+        name: 'Draft group name',
+        description: 'Draft group description'
+      }
+    }
+  }}
+
+  let(:group_draft_params) {{
+    payload: {
+      discussion: {
+        title: 'Draft discussion title',
+        description: 'Draft discussion description'
+      }
+    }
+  }}
+  let(:discussion_draft_params) {{
+    payload: {
+      motion: {
+        name: 'Draft motion name',
+        description: 'Draft motion description'
+      },
+      comment: {
+        body: 'Draft comment body'
+      }
+    }
+  }}
+  let(:motion_draft_params) {{
+    payload: {
+      vote: {
+        statement: 'Draft vote statement'
+      }
+    }
+  }}
+
+  before do
+    sign_in user
+    group.members << user
+  end
+
+  describe 'create' do
+    it 'creates a new user draft' do
+      post :update, draft: user_draft_params, draftable_type: 'user', draftable_id: user.id
+      expect(response.status).to eq 200
+
+      draft = Draft.last
+      expect(draft.draftable).to eq user
+      expect(draft.user).to eq user
+      expect(draft.payload['group']['name']).to eq user_draft_params[:payload][:group][:name]
+      expect(draft.payload['group']['description']).to eq user_draft_params[:payload][:group][:description]
+
+      json = JSON.parse(response.body)
+      expect(json['drafts'][0]['payload']['group']['name']).to eq user_draft_params[:payload][:group][:name]
+      expect(json['drafts'][0]['payload']['group']['description']).to eq user_draft_params[:payload][:group][:description]
+    end
+
+    it 'creates a new group draft' do
+      post :update, draft: group_draft_params, draftable_type: 'group', draftable_id: group.id
+      expect(response.status).to eq 200
+
+      draft = Draft.last
+      expect(draft.draftable).to eq group
+      expect(draft.user).to eq user
+      expect(draft.payload['discussion']['title']).to eq group_draft_params[:payload][:discussion][:title]
+      expect(draft.payload['discussion']['description']).to eq group_draft_params[:payload][:discussion][:description]
+
+      json = JSON.parse(response.body)
+      expect(json['drafts'][0]['payload']['discussion']['title']).to eq group_draft_params[:payload][:discussion][:title]
+      expect(json['drafts'][0]['payload']['discussion']['description']).to eq group_draft_params[:payload][:discussion][:description]
+    end
+
+    it 'creates a new discussion draft' do
+      post :update, draft: discussion_draft_params, draftable_type: 'discussion', draftable_id: discussion.id
+      expect(response.status).to eq 200
+
+      draft = Draft.last
+      expect(draft.draftable).to eq discussion
+      expect(draft.user).to eq user
+      expect(draft.payload['motion']['name']).to eq discussion_draft_params[:payload][:motion][:name]
+      expect(draft.payload['motion']['description']).to eq discussion_draft_params[:payload][:motion][:description]
+      expect(draft.payload['comment']['body']).to eq discussion_draft_params[:payload][:comment][:body]
+
+      json = JSON.parse(response.body)
+      expect(json['drafts'][0]['payload']['motion']['name']).to eq discussion_draft_params[:payload][:motion][:name]
+      expect(json['drafts'][0]['payload']['motion']['description']).to eq discussion_draft_params[:payload][:motion][:description]
+      expect(json['drafts'][0]['payload']['comment']['body']).to eq discussion_draft_params[:payload][:comment][:body]
+    end
+
+    it 'creates a new motion draft' do
+      post :update, draft: motion_draft_params, draftable_type: 'motion', draftable_id: motion.id
+      expect(response.status).to eq 200
+
+      draft = Draft.last
+      expect(draft.draftable).to eq motion
+      expect(draft.user).to eq user
+      expect(draft.payload['vote']['statement']).to eq motion_draft_params[:payload][:vote][:statement]
+
+      json = JSON.parse(response.body)
+      expect(json['drafts'][0]['payload']['vote']['statement']).to eq motion_draft_params[:payload][:vote][:statement]
+    end
+
+    it 'overwrites a user draft' do
+      user_draft
+      post :update, draft: user_draft_params, draftable_type: 'user', draftable_id: user.id
+      expect(response.status).to eq 200
+
+      user_draft.reload
+      expect(user_draft.draftable).to eq user
+      expect(user_draft.user).to eq user
+      expect(user_draft.payload['group']['name']).to eq user_draft_params[:payload][:group][:name]
+      expect(user_draft.payload['group']['description']).to eq user_draft_params[:payload][:group][:description]
+
+      json = JSON.parse(response.body)
+      expect(json['drafts'][0]['payload']['group']['name']).to eq user_draft_params[:payload][:group][:name]
+      expect(json['drafts'][0]['payload']['group']['description']).to eq user_draft_params[:payload][:group][:description]
+    end
+
+    it 'overwrites a group draft' do
+      group_draft
+      post :update, draft: group_draft_params, draftable_type: 'group', draftable_id: group.id
+      expect(response.status).to eq 200
+
+      group_draft.reload
+      expect(group_draft.draftable).to eq group
+      expect(group_draft.user).to eq user
+      expect(group_draft.payload['discussion']['title']).to eq group_draft_params[:payload][:discussion][:title]
+      expect(group_draft.payload['discussion']['description']).to eq group_draft_params[:payload][:discussion][:description]
+
+      json = JSON.parse(response.body)
+      expect(json['drafts'][0]['payload']['discussion']['title']).to eq group_draft_params[:payload][:discussion][:title]
+      expect(json['drafts'][0]['payload']['discussion']['description']).to eq group_draft_params[:payload][:discussion][:description]
+    end
+
+    it 'overwrites a discussion draft' do
+      discussion_draft
+      post :update, draft: discussion_draft_params, draftable_type: 'discussion', draftable_id: discussion.id
+      expect(response.status).to eq 200
+
+      discussion_draft.reload
+      expect(discussion_draft.draftable).to eq discussion
+      expect(discussion_draft.user).to eq user
+      expect(discussion_draft.payload['motion']['name']).to eq discussion_draft_params[:payload][:motion][:name]
+      expect(discussion_draft.payload['motion']['description']).to eq discussion_draft_params[:payload][:motion][:description]
+      expect(discussion_draft.payload['comment']['body']).to eq discussion_draft_params[:payload][:comment][:body]
+
+      json = JSON.parse(response.body)
+      expect(json['drafts'][0]['payload']['motion']['name']).to eq discussion_draft_params[:payload][:motion][:name]
+      expect(json['drafts'][0]['payload']['motion']['description']).to eq discussion_draft_params[:payload][:motion][:description]
+      expect(json['drafts'][0]['payload']['comment']['body']).to eq discussion_draft_params[:payload][:comment][:body]
+    end
+
+    it 'overwrites a motion draft' do
+      motion_draft
+      post :update, draft: motion_draft_params, draftable_type: 'motion', draftable_id: motion.id
+      expect(response.status).to eq 200
+
+      motion_draft.reload
+      expect(motion_draft.draftable).to eq motion
+      expect(motion_draft.user).to eq user
+      expect(motion_draft.payload['vote']['statement']).to eq motion_draft_params[:payload][:vote][:statement]
+
+      json = JSON.parse(response.body)
+      expect(json['drafts'][0]['payload']['vote']['statement']).to eq motion_draft_params[:payload][:vote][:statement]
+    end
+
+    it 'cannot access a group the user does not have access to' do
+      expect { post :update, draft: group_draft_params, draftable_type: 'group', draftable_id: another_group.id }.not_to change { Draft.count }
+      expect(response.status).to eq 403
+    end
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -217,4 +217,10 @@ FactoryGirl.define do
     kind :trial
   end
 
+  factory :draft do
+    user
+    association :draftable, factory: :discussion
+    payload {{ payload: 'payload' }}
+  end
+
 end

--- a/spec/services/comment_service_spec.rb
+++ b/spec/services/comment_service_spec.rb
@@ -42,6 +42,12 @@ describe 'CommentService' do
       CommentService.create(comment: comment, actor: user)
     end
 
+    it 'clears out the draft' do
+      draft = create(:draft, user: user, draftable: comment.discussion, payload: { comment: { body: 'body draft' } })
+      CommentService.create(comment: comment, actor: user)
+      expect(draft.reload.payload['comment']).to be_blank
+    end
+
     context 'comment is valid' do
       before do
         comment.stub(:valid?).and_return(true)

--- a/spec/services/discussion_service_spec.rb
+++ b/spec/services/discussion_service_spec.rb
@@ -36,6 +36,12 @@ describe 'DiscussionService' do
                                actor: user)
     end
 
+    it 'clears out the draft' do
+      draft = create(:draft, user: user, draftable: discussion.group, payload: { discussion: { name: 'name draft' } })
+      DiscussionService.create(discussion: discussion, actor: user)
+      expect(draft.reload.payload['discussion']).to be_blank
+    end
+
     context 'the discussion is valid' do
       before { discussion.stub(:valid?).and_return(true) }
 

--- a/spec/services/motion_service_spec.rb
+++ b/spec/services/motion_service_spec.rb
@@ -22,6 +22,12 @@ describe 'MotionService' do
       MotionService.create(motion: motion, actor: user)
     end
 
+    it 'clears out the draft' do
+      draft = create(:draft, user: user, draftable: motion.discussion, payload: { motion: { name: 'name draft' } })
+      MotionService.create(motion: motion, actor: user)
+      expect(draft.reload.payload['comment']).to be_blank
+    end
+
     context "motion is valid" do
 
       it "saves the motion" do

--- a/spec/services/vote_service_spec.rb
+++ b/spec/services/vote_service_spec.rb
@@ -26,6 +26,12 @@ describe 'VoteService' do
       VoteService.create(vote: vote, actor: user)
     end
 
+    it 'clears out the draft' do
+      draft = create(:draft, user: user, draftable: vote.motion, payload: { vote: { statement: 'statement draft' } })
+      VoteService.create(vote: vote, actor: user)
+      expect(draft.reload.payload['vote']).to be_blank
+    end
+
     context 'vote is valid' do
       before do
         vote.stub(:valid?).and_return(true)


### PR DESCRIPTION
Here's a PoC for the drafts backend; I haven't touched anything on the frontend yet, but it'd be nice to see this pass the specs anyhow.

Basic idea, we've got a 'Draft' class, which belongs_to a user and polymorphs to a 'draftable', which can be any model (currently, Group, Discussion, Motion). It stores a 'payload' json object, which stores the draft values.

The idea is that we call `$scope.comment.updateFromJSON(draft['comment'])` on the frontend; I don't want to get into the business of storing full-on models and marking them as 'draft' in the backend.

The specs in `drafts_controller_spec` describe the rest of the behaviour pretty well, I think. We're in a weird case where the update and create actions should do the same thing on the controller, so I've currently only got a `create` (read: upsert) action on the controller.