### PR TITLE
move feedback card to footer

### DIFF
--- a/lineman/app/components/angular_feedback_card/angular_feedback_card.coffee
+++ b/lineman/app/components/angular_feedback_card/angular_feedback_card.coffee
@@ -8,6 +8,3 @@ angular.module('loomioApp').directive 'angularFeedbackCard', ->
     $scope.angularUrl = "/angular"
     $scope.version = "v#{AppConfig.version}"
     $scope.versionUrl = "http://www.github.com/loomio/loomio/releases"
-
-    $scope.$on 'hideFeedbackForm', -> $scope.hidden = true
-    $scope.$on 'showFeedbackForm', -> $scope.hidden = false

--- a/lineman/app/components/thread_page/comment_form/comment_form.coffee
+++ b/lineman/app/components/thread_page/comment_form/comment_form.coffee
@@ -8,9 +8,6 @@ angular.module('loomioApp').directive 'commentForm', ->
     $scope.$on 'disableCommentForm', -> $scope.submitIsDisabled = true
     $scope.$on 'enableCommentForm',  -> $scope.submitIsDisabled = false
 
-    $scope.formInFocus = ->   $rootScope.$broadcast 'hideFeedbackForm'
-    $scope.formLostFocus = -> $rootScope.$broadcast 'showFeedbackForm'
-
     $scope.showCommentForm = ->
       AbilityService.canAddComment($scope.discussion)
 

--- a/lineman/app/components/thread_page/comment_form/comment_form.haml
+++ b/lineman/app/components/thread_page/comment_form/comment_form.haml
@@ -5,7 +5,7 @@
       %input{type: 'hidden', ng-model: 'comment.usesMarkdown'}
       %h2.lmo-card-heading#comment-form-title{translate: 'comment_form.aria_label'}>
       %span{translate: 'comment_form.in_reply_to', translate-values: "{name: '{{comment.parent().authorName()}}' }", ng-show: 'comment.parent().authorName()'}
-      %textarea.form-control.comment-form__comment-field.lmo-primary-form-input{msd-elastic: 'true', aria-labelledby: 'comment-form-title', name: 'body', placeholder: "Say something...", ng_model: 'comment.body', mentio: true, mentio-trigger-char: "'@'", mentio_items: 'mentionables', mentio-template-url: 'generated/components/thread_page/comment_form/mentio_menu.html', mentio-search: 'fetchByNameFragment(term)', mentio-id: 'comment-field', ng-focus: 'formInFocus()', ng-blur: 'formLostFocus()', ng-model-options: "{ updateOn: 'default blur', debounce: {'default': 300, 'blur': 0} }"}
+      %textarea.form-control.comment-form__comment-field.lmo-primary-form-input{msd-elastic: 'true', aria-labelledby: 'comment-form-title', name: 'body', placeholder: "Say something...", ng_model: 'comment.body', mentio: true, mentio-trigger-char: "'@'", mentio_items: 'mentionables', mentio-template-url: 'generated/components/thread_page/comment_form/mentio_menu.html', mentio-search: 'fetchByNameFragment(term)', mentio-id: 'comment-field', ng-model-options: "{ updateOn: 'default blur', debounce: {'default': 300, 'blur': 0} }"}
       .comment-row.comment-attachments{ng_repeat: 'attachment in comment.newAttachments()'}
         %a.attachment-link{ng_href: '{{attachment.location}}', target: '_blank'}>
           {{ attachment.filename }}

--- a/lineman/app/css/0_mixins.scss
+++ b/lineman/app/css/0_mixins.scss
@@ -215,19 +215,12 @@ $cardPaddingSize: 15px;
 #angular-feedback-card {
   @include fontSmall;
   z-index: 100;
-  position: fixed;
   left: 11px;
   bottom: 10px;
   width: 120px;
   text-align: center;
   padding: 8px;
-  background-color: white;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.24);
 }
-#angular-feedback-card.ng-hide-add    { animation:0.1s fadeOut ease-in; }
-#angular-feedback-card.ng-hide-remove { animation:0.1s fadeIn ease-in; }
-
-
 
 .lmo-version {
   color: #666;

--- a/lineman/spec-e2e/discussion_spec.coffee
+++ b/lineman/spec-e2e/discussion_spec.coffee
@@ -106,9 +106,3 @@ describe 'Discussion Page', ->
     expect(threadPage.commentForm().isPresent()).toBe(false)
     expect(threadPage.threadOptionsDropdown().isPresent()).toBe(false)
     expect(threadPage.volumeOptions().isPresent()).toBe(false)
-
-  it 'hides the feedback form on comment form focus', ->
-    threadPage.enterCommentText('Hello')
-    expect(threadPage.angularFeedbackCard().isDisplayed()).toBe(false)
-    threadPage.submitComment(' how are you?')
-    expect(threadPage.angularFeedbackCard().isDisplayed()).toBe(true)


### PR DESCRIPTION
This is an urgent fix to get the feedback card out of the way. We are getting lots of messages from people saying it is in the way. Soon this will be in the sidebar but I wanted to get this fix out in a hurry.

![image](https://cloud.githubusercontent.com/assets/970124/11051794/075951dc-87b7-11e5-9c10-20636089d29e.png)
