### PR TITLE
Make subscription success language more appropriate

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -497,11 +497,11 @@ en:
 
   subscription_success_modal:
     heading: Thanks for setting up your subscription!
-    social_mission: 'Your contribution helps us to deliver on our social mission: making it easy for anyone, anywhere to participate in decisions that affect them.'
-    receipt: "If you ever want to change or cancel your subscription, or if you have any other queries,"
-    contact_link: ' please contact us.'
+    receipt: You’ll receive an email with a receipt.
+    change_subscription: "If you ever want to change or cancel your subscription, or if you have any other queries, "
+    contact_link: please contact us.
     sign_off: ❤ from the Loomio team
-    ok_got_it: 'Ok, got it!'
+    ok_got_it: Ok, got it!
 
   edit_group_form:
     title: 'Edit Group Settings'

--- a/lineman/app/components/group_page/subscription_success_modal/subscription_success_modal.haml
+++ b/lineman/app/components/group_page/subscription_success_modal/subscription_success_modal.haml
@@ -6,9 +6,9 @@
   .modal-body
     %img.subscription-success-modal__mascot{src:'img/mascot.png'}
     .subscription-success-modal__message
-      %p{translate: 'subscription_success_modal.social_mission'}
+      %p{translate: 'subscription_success_modal.receipt'}
       %p
-        %span{translate: 'subscription_success_modal.receipt'}
+        %span{translate: 'subscription_success_modal.change_subscription'} 
         %span
           %button.subscription-success-modal__contact-link{translate: 'subscription_success_modal.contact_link', ng-click: 'openIntercom()'}
       %p{translate: 'subscription_success_modal.sign_off'}

--- a/lineman/app/components/group_page/subscription_success_modal/subscription_success_modal.scss
+++ b/lineman/app/components/group_page/subscription_success_modal/subscription_success_modal.scss
@@ -2,7 +2,7 @@
   float: left;
   height: 150px;
   padding: 0 25px 25px 0;
-  margin-bottom: 50px;
+  @media (max-width: 450px) { display: none; }
 }
 
 .subscription-success-modal__message {


### PR DESCRIPTION
I can't figure out how to test this. I think it's right, but it does need testing.