### PR TITLE
Remove create account link from log in page

### DIFF
--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -16,10 +16,6 @@
               - else
                 = t :sign_in
 
-          %h2= t :"common.welcome_back"
-          %p
-            = t(:'dont_have_an_account')
-            = link_to t(:'create_one_now'), new_user_registration_path, id:'create_account'
           .signin_container
             = render "form"
             -unless omniauth_authenticated_and_waiting?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -930,8 +930,6 @@ en:
   or: "or"
   invalid_email: The email address you entered was not recognised. Verify it is entered correctly or try another email address.
   forgot_your_password: "Forgot your password?"
-  dont_have_an_account: "Don't have an account?"
-  create_one_now: "Create one now"
   link_it_up_instead: "Link it up instead"
   sign_up_via: "Sign up via"
   or_fill_in_this_form: "or fill in this form"
@@ -1386,7 +1384,6 @@ en:
 
   common:
     profile: "Profile"
-    welcome_back: "Welcome back!"
     email_settings: "Email settings"
     markdown_help_tooltip: 'Learn the basics of formatting your text with Markdown'
     settings: Settings


### PR DESCRIPTION
I recorded a [2.5 minute screencast](https://youtu.be/ga4rQq9TZSk) to look at what happens when you create an account from the log in page. It's an un-designed flow. It's not welcoming. It makes 'start thread' and 'invite people' non-sensical, but relatively prominent actions. It doesn't validate email addresses. It doesn't set the user's locale. You get no email trail that you set up an account. Also if you are invited to a group, and choose 'If you already have a Loomio account, log in here' it's a bit confusing on the next page seeing the option 'Don't have an account? Create one now'.

Before | After
--- | --- 
![image](https://cloud.githubusercontent.com/assets/1380991/11082900/1f8909be-888e-11e5-9c54-2648a814206e.png) | ![image](https://cloud.githubusercontent.com/assets/1380991/11082907/2c66d652-888e-11e5-8461-72dde18e75af.png)
![image](https://cloud.githubusercontent.com/assets/1380991/11082925/68263444-888e-11e5-9d40-12c3032e9817.png) | ![image](https://cloud.githubusercontent.com/assets/1380991/11082911/3d33a528-888e-11e5-8de2-794380b768ac.png)

What chu reckon e.g. @rdbartlett @robguthrie ?