### PR TITLE
Remove email addresses from memberships page in beta

### DIFF
--- a/app/views/groups/memberships/coordinator_index.html.haml
+++ b/app/views/groups/memberships/coordinator_index.html.haml
@@ -17,7 +17,7 @@
   %thead
     %th.col-md-1= t :photo
     %th= t :name
-    %th= t :"common.email"
+    %th= t :username
     %th= t :coordinator
     %th= t :remove
   %tbody
@@ -28,7 +28,7 @@
         %td
           %div= link_to user.name, user_path(user)
           %div.access-level= t :coordinator if membership.admin?
-        %td=user.email
+        %td= "@#{user.username}"
         %td
           - if membership.admin?
             = link_to t(:remove_coordinator),

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1367,6 +1367,7 @@ en:
   unlike: "Unlike"
   time_until_close: "%{quantity_of_time} until close"
   update: "Update"
+  username: "Username"
   facebook: "Facebook"
   yahoo: "Yahoo"
   google: "Google"


### PR DESCRIPTION
[Trello card](https://trello.com/c/J2WVfhLj/1047-2-remove-email-column-from-group-memberships-page-on-beta)

<img width="954" alt="screen shot 2015-11-17 at 4 21 39 pm" src="https://cloud.githubusercontent.com/assets/2882097/11201911/9361e276-8d47-11e5-9b8d-53fd9345ea21.png">
