### PR TITLE
Don't let forms care about getting their drafts

### DIFF
--- a/lineman/app/components/group_page/group_page_controller.coffee
+++ b/lineman/app/components/group_page/group_page_controller.coffee
@@ -9,7 +9,6 @@ angular.module('loomioApp').controller 'GroupPageController', ($rootScope, $loca
     $rootScope.$broadcast 'analyticsSetGroup', @group
     $rootScope.$broadcast 'trialIsOverdue', @group if @group.trialIsOverdue()
     MessageChannelService.subscribeToGroup(@group)
-    Records.drafts.fetchFor(@group)
     @handleSubscriptionSuccess()
     @handleWelcomeModal()
   , (error) ->

--- a/lineman/app/services/draft_service.coffee
+++ b/lineman/app/services/draft_service.coffee
@@ -10,7 +10,7 @@ angular.module('loomioApp').factory 'DraftService', ->
 
       scope.restoreDraft = ->
         model.restoreDraft() if draftMode()
-      scope.restoreDraft()
 
       scope.restoreRemoteDraft = ->
         model.fetchDraft().then(scope.restoreDraft) if draftMode()
+      scope.restoreRemoteDraft()


### PR DESCRIPTION
Whenever we apply the drafty bits (ie, initialize a form, either via modal or page load), fetch the draft from the server and apply it.