### PR TITLE
Comment drafts fix

### DIFF
--- a/app/models/draft.rb
+++ b/app/models/draft.rb
@@ -5,8 +5,11 @@ class Draft < ActiveRecord::Base
   validates :user, presence: true
   validates :draftable, presence: true
 
-  def self.purge(user:, draftable:, field:)
-    find_or_initialize_by(user: user, draftable: draftable).purge(field)
+  class << self
+    def purge(user:, draftable:, field:)
+      find_or_initialize_by(user: user, draftable: draftable).purge(field)
+    end
+    handle_asynchronously :purge
   end
 
   def purge(field)

--- a/app/models/draft.rb
+++ b/app/models/draft.rb
@@ -5,11 +5,8 @@ class Draft < ActiveRecord::Base
   validates :user, presence: true
   validates :draftable, presence: true
 
-  class << self
-    def purge(user:, draftable:, field:)
-      find_or_initialize_by(user: user, draftable: draftable).purge(field)
-    end
-    handle_asynchronously :purge
+  def self.purge(user:, draftable:, field:)
+    find_or_initialize_by(user: user, draftable: draftable).purge(field)
   end
 
   def purge(field)

--- a/app/services/comment_service.rb
+++ b/app/services/comment_service.rb
@@ -33,7 +33,7 @@ class CommentService
     comment.save!
     comment.discussion.update_attribute(:last_comment_at, comment.created_at)
 
-    Draft.purge(user: actor, draftable: comment.discussion, field: :comment)
+    Draft.purge_without_delay(user: actor, draftable: comment.discussion, field: :comment)
     SearchVector.index! comment.discussion_id
 
     event = Events::NewComment.publish!(comment)

--- a/lineman/app/components/thread_page/comment_form/comment_form.coffee
+++ b/lineman/app/components/thread_page/comment_form/comment_form.coffee
@@ -35,6 +35,7 @@ angular.module('loomioApp').directive 'commentForm', ->
         flashOptions:
           name: successMessageName
         successCallback: $scope.init
+      KeyEventService.submitOnEnter $scope
     $scope.init()
 
     $scope.$on 'replyToCommentClicked', (event, parentComment) ->
@@ -57,5 +58,3 @@ angular.module('loomioApp').directive 'commentForm', ->
       $scope.updateMentionables(fragment)
       Records.memberships.fetchByNameFragment(fragment, $scope.discussion.group().key).then ->
         $scope.updateMentionables(fragment)
-
-    KeyEventService.submitOnEnter $scope

--- a/lineman/app/components/thread_page/comment_form/comment_form.haml
+++ b/lineman/app/components/thread_page/comment_form/comment_form.haml
@@ -6,6 +6,7 @@
       %h2.lmo-card-heading#comment-form-title{translate: 'comment_form.aria_label'}>
       %span{translate: 'comment_form.in_reply_to', translate-values: "{name: '{{comment.parent().authorName()}}' }", ng-show: 'comment.parent().authorName()'}
       %textarea.form-control.comment-form__comment-field.lmo-primary-form-input{msd-elastic: 'true', ng-change: 'storeDraft()', ng-model-options: '{debounce: 600}', aria-labelledby: 'comment-form-title', name: 'body', placeholder: "Say something...", ng_model: 'comment.body', mentio: true, mentio-trigger-char: "'@'", mentio_items: 'mentionables', mentio-template-url: 'generated/components/thread_page/comment_form/mentio_menu.html', mentio-search: 'fetchByNameFragment(term)', mentio-id: 'comment-field', ng-focus: 'formInFocus()', ng-blur: 'formLostFocus()', ng-model-options: "{ updateOn: 'default blur', debounce: {'default': 300, 'blur': 0} }"}
+      %validation_errors{subject: 'comment', field: 'body'}
       .comment-row.comment-attachments{ng_repeat: 'attachment in comment.newAttachments()'}
         %a.attachment-link{ng_href: '{{attachment.location}}', target: '_blank'}>
           {{ attachment.filename }}

--- a/lineman/app/services/key_event_service.coffee
+++ b/lineman/app/services/key_event_service.coffee
@@ -18,6 +18,7 @@ angular.module('loomioApp').factory 'KeyEventService', ($rootScope) ->
 
     registerKeyEvent: (scope, eventCode, execute, shouldExecute) ->
       shouldExecute = shouldExecute or @defaultShouldExecute
+      scope.$$listeners[eventCode] = null
       scope.$on eventCode, (angularEvent, originalEvent, active) ->
         if shouldExecute(active, originalEvent)
           angularEvent.preventDefault() and originalEvent.preventDefault()


### PR DESCRIPTION
This should fix up the race condition for comments (we were deleting drafts asynchronously... normally brilliant, in this case horrible!)

Also a couple bonus fixes:

- Adding a 'comment is blank' message after trying to submit an empty comment
- Refresh the submitOnEnter key action after comment submit (otherwise it'll submit old comments on cmd+enter)