### PR TITLE
Group form tweaking

### DIFF
--- a/lineman/app/components/group_form/group_form.coffee
+++ b/lineman/app/components/group_form/group_form.coffee
@@ -59,3 +59,9 @@ angular.module('loomioApp').factory 'GroupForm', ->
         $scope.group.discussionPrivacyOptions = 'public_or_private'
       else
         $scope.group.discussionPrivacyOptions = 'private_only'
+
+    $scope.groupPrivacyChanged = ->
+      switch $scope.group.groupPrivacy
+        when 'open'   then $scope.group.discussionPrivacyOptions = 'public_only'
+        when 'closed' then $scope.allowPublicThreadsClicked()
+        when 'secret' then $scope.group.discussionPrivacyOptions = 'private_only'

--- a/lineman/app/components/group_form/group_form.haml
+++ b/lineman/app/components/group_form/group_form.haml
@@ -23,21 +23,21 @@
           %label{translate: 'group_form.privacy'}
 
           %label.lmo-form-labelled-input{ng-if: '!group.isSubgroupOfHiddenParent'}
-            %input.group-form__privacy-open{type: 'radio', ng-model: 'group.groupPrivacy', value: 'open', name: 'groupPrivacy'}
+            %input.group-form__privacy-open{type: 'radio', ng-model: 'group.groupPrivacy', ng-change: 'groupPrivacyChanged()', value: 'open', name: 'groupPrivacy'}
             %span
               %strong{translate: 'common.privacy.open'}
               %span.seperator
               {{ privacyStringFor("open") }}
 
           %label.lmo-form-labelled-input
-            %input.group-form__privacy-closed{type: 'radio', ng-model: 'group.groupPrivacy', value: 'closed', name: 'groupPrivacy'}
+            %input.group-form__privacy-closed{type: 'radio', ng-model: 'group.groupPrivacy', ng-change: 'groupPrivacyChanged()', value: 'closed', name: 'groupPrivacy'}
             %span
               %strong{translate: 'common.privacy.closed'}
               %span.seperator
               {{ privacyStringFor("closed") }}
 
           %label.lmo-form-labelled-input
-            %input.group-form__privacy-secret{type: 'radio', ng-model: 'group.groupPrivacy', value: 'secret', name: 'groupPrivacy'}
+            %input.group-form__privacy-secret{type: 'radio', ng-model: 'group.groupPrivacy', ng-change: 'groupPrivacyChanged()', value: 'secret', name: 'groupPrivacy'}
             %span
               %strong{translate: 'common.privacy.secret'}
               %span.seperator

--- a/lineman/app/services/privacy_string_service.coffee
+++ b/lineman/app/services/privacy_string_service.coffee
@@ -15,6 +15,7 @@ angular.module('loomioApp').factory 'PrivacyString', ($translate) ->
         $translate.instant("group_form.privacy_statement.#{key}")
 
     confirmGroupPrivacyChange: (group) ->
+      return if group.isNew()
       key = if group.attributeIsModified('groupPrivacy')
         if group.privacyIsSecret()
           if group.isParent()


### PR DESCRIPTION
Hey @robguthrie let me know what you think of this fix; the current issue as I understand it:

Currently, we can change from say 'closed' to 'open' privacy without updating the underlying 'discussionPrivacyOptions', meaning it's possible to submit a form which has 'open' privacy and 'private_only' discussions, which = 422.