### PR TITLE
Fix AWOL welcome modal

### DIFF
--- a/lineman/app/components/group_page/group_page_controller.coffee
+++ b/lineman/app/components/group_page/group_page_controller.coffee
@@ -35,8 +35,14 @@ angular.module('loomioApp').controller 'GroupPageController', ($rootScope, $loca
       $location.search 'chargify_success', null
       ModalService.open SubscriptionSuccessModal
 
-  @handleWelcomeModal = ->
-    if CurrentUser.isAdminOf(@group) and @group.noInvitationsSent() and !@group.trialIsOverdue() and !GroupWelcomeModal.shownToGroup[@group.id]?
+  @showWelcomeModel = ->
+    AbilityService.isCreatorOf(@group) and
+    @group.noInvitationsSent() and
+    !@group.trialIsOverdue() and
+    !GroupWelcomeModal.shownToGroup[@group.id]
+
+  @handleWelcomeModal = =>
+    if @showWelcomeModel()
       GroupWelcomeModal.shownToGroup[@group.id] = true
       ModalService.open GroupWelcomeModal
 

--- a/lineman/app/services/ability_service.coffee
+++ b/lineman/app/services/ability_service.coffee
@@ -59,6 +59,9 @@ angular.module('loomioApp').factory 'AbilityService', (CurrentUser) ->
     canAdministerGroup: (group) ->
       CurrentUser.isAdminOf(group)
 
+    isCreatorOf: (group) ->
+      CurrentUser.id == group.creatorId
+
     canStartThread: (group) ->
       group.membersCanStartDiscussions or @canAdministerGroup(group)
 


### PR DESCRIPTION
Break out the conditions for the welcome modal to make them a little easier to read, and only show welcome modal to the creator (we don't have memberships loaded at this point, so we don't know that the current user is an admin or not. Also, the welcome modal goes away after anyone's invited to the group, so it's really just the creator that needs to see it.)