### PR TITLE
Restructure CommentService events

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -26,11 +26,13 @@ class CommentsController < BaseController
 
   def like
     CommentService.like(comment: @comment, actor: current_user)
+    @comment.reload
     render template: "comments/comment_likes"
   end
 
   def unlike
     CommentService.unlike(comment: @comment, actor: current_user)
+    @comment.reload
     render template: "comments/comment_likes"
   end
 

--- a/app/extras/event_bus.rb
+++ b/app/extras/event_bus.rb
@@ -1,0 +1,29 @@
+class EventBus
+  include Singleton
+
+  def broadcast(event, *params)
+    listeners[event].each { |listener| listener.call(*params) }
+  end
+
+  def listen(*events, &block)
+    events.each { |event| listeners[event].add(block) }
+  end
+
+  def deafen(*events, &block)
+    events.each { |event| listeners[event].delete(block) }
+  end
+
+  def clear
+    @listeners = nil
+  end
+
+  # allows us to call EventBus.listen, instead of EventBus.instance.listen
+  [:broadcast, :listen, :deafen, :clear].each { |m| define_singleton_method m, ->(*args, &block) { instance.send(m, *args, &block) } }
+
+  private
+
+  def listeners
+    @listeners ||= Hash.new { |hash, key| hash[key] = Set.new }
+  end
+
+end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -85,13 +85,10 @@ class Comment < ActiveRecord::Base
   end
 
   def refresh_liker_ids_and_names!
-    hash = {}
-    comment_votes.each do |cv|
-      hash[cv.user_id] = cv.user.name
-    end
-    self.liker_ids_and_names = hash
+    self.liker_ids_and_names = self.comment_votes.reduce({}) { |hash, vote| hash[vote.user_id] = vote.user.name; hash }
     save!
   end
+  EventBus.listen('comment_like', 'comment_unlike') { |cv| cv.comment.refresh_liker_ids_and_names! }
 
   def mentioned_usernames
     extract_mentioned_screen_names(self.body).uniq
@@ -99,6 +96,14 @@ class Comment < ActiveRecord::Base
 
   def mentioned_group_members
     group.users.where(username: mentioned_usernames).where('users.id != ?', author.id)
+  end
+
+  def new_mentions_in(body)
+    self.class.new(body: body).mentioned_usernames - mentioned_usernames
+  end
+
+  def notified_group_members
+    mentioned_group_members.without(author).without(parent.try(:author))
   end
 
   def likes_count

--- a/app/models/draft.rb
+++ b/app/models/draft.rb
@@ -11,6 +11,7 @@ class Draft < ActiveRecord::Base
     end
     handle_asynchronously :purge
   end
+  EventBus.listen('comment_create') { |comment| purge_without_delay(user: comment.user, draftable: comment.discussion, field: :comment) }
 
   def purge(field)
     self.payload[field] = {}

--- a/app/models/events/comment_liked.rb
+++ b/app/models/events/comment_liked.rb
@@ -3,7 +3,7 @@ class Events::CommentLiked < Event
 
   def self.publish!(comment_vote)
     create!(kind: "comment_liked",
-            eventable: comment_vote)
+            eventable: comment_vote).tap { |e| EventBus.broadcast('comment_liked_event', e) }
   end
 
   def comment_vote

--- a/app/models/events/comment_replied_to.rb
+++ b/app/models/events/comment_replied_to.rb
@@ -1,16 +1,9 @@
 class Events::CommentRepliedTo < Event
   def self.publish!(comment)
-    return unless comment.parent.present?
-    event = create!(kind: 'comment_replied_to',
-                    eventable: comment,
-                    created_at: comment.created_at)
-
-    if comment.parent.author != comment.author
-      ThreadMailer.delay.comment_replied_to(comment.parent.author, event) if comment.parent.author.email_when_mentioned?
-      event.notify! comment.parent.author
-    end
-
-    event
+    return unless comment.parent.present? && comment.parent.author != comment.author
+    create!(kind: 'comment_replied_to',
+            eventable: comment,
+            created_at: comment.created_at).tap { |e| EventBus.broadcast('comment_replied_to_event', comment.parent.author, e) }
   end
 
   def group_key

--- a/app/models/events/new_comment.rb
+++ b/app/models/events/new_comment.rb
@@ -1,22 +1,10 @@
 class Events::NewComment < Event
+
   def self.publish!(comment)
-    event = create!(kind: 'new_comment',
-                    eventable: comment,
-                    discussion: comment.discussion,
-                    created_at: comment.created_at)
-
-    Events::CommentRepliedTo.publish! comment if comment.is_reply?
-
-    comment.mentioned_group_members.
-            without(comment.parent_author).find_each do |mentioned_user|
-      Events::UserMentioned.publish!(comment, mentioned_user)
-    end
-
-    BaseMailer.send_bulk_mail(to: UsersToEmailQuery.new_comment(comment)) do |user|
-      ThreadMailer.delay.new_comment(user, event)
-    end
-
-    event
+    create(kind: 'new_comment',
+           eventable: comment,
+           discussion: comment.discussion,
+           created_at: comment.created_at).tap { |e| EventBus.broadcast('new_comment_event', e) }
   end
 
   def group_key

--- a/app/models/events/user_mentioned.rb
+++ b/app/models/events/user_mentioned.rb
@@ -1,18 +1,9 @@
 class Events::UserMentioned < Event
   def self.publish!(comment, mentioned_user)
-    event = create!(kind: 'user_mentioned',
-                    eventable: comment,
-                    user: comment.author,
-                    created_at: comment.created_at)
-
-
-    if mentioned_user.email_when_mentioned?
-      ThreadMailer.delay.user_mentioned(mentioned_user, event)
-    end
-
-    event.notify!(mentioned_user)
-
-    event
+    create!(kind: 'user_mentioned',
+            eventable: comment,
+            user: comment.author,
+            created_at: comment.created_at).tap { |e| EventBus.broadcast('user_mentioned_event', mentioned_user, e) }
   end
 
   def comment

--- a/app/models/search_vector.rb
+++ b/app/models/search_vector.rb
@@ -49,6 +49,7 @@ class SearchVector < ActiveRecord::Base
     end
     handle_asynchronously :index!
   end
+  EventBus.listen('comment_create', 'comment_update') { |comment| index! comment.discussion_id }
 
   def self.index_everything!
     index_without_delay! Discussion.pluck(:id)

--- a/app/services/comment_service.rb
+++ b/app/services/comment_service.rb
@@ -3,24 +3,18 @@ class CommentService
     return false unless comment.likers.include? actor
     actor.ability.authorize!(:unlike, comment)
 
-    CommentVote.where(user_id: actor.id, comment_id: comment.id).destroy_all
-    comment.refresh_liker_ids_and_names!
+    comment_vote = CommentVote.find_by(comment_id: comment.id, user_id: actor.id)
+    comment_vote.destroy
 
-    Memos::CommentUnliked.publish!(comment: comment, user: actor)
-
+    EventBus.broadcast('comment_unlike', comment_vote)
   end
 
   def self.like(comment:, actor:)
     actor.ability.authorize!(:like, comment)
 
-    comment_vote = CommentVote.find_or_create_by(comment_id: comment.id,
-                                                 user_id: actor.id)
+    comment_vote = CommentVote.find_or_create_by(comment_id: comment.id, user_id: actor.id)
 
-    comment.refresh_liker_ids_and_names!
-
-    DiscussionReader.for(discussion: comment.discussion,
-                         user: actor).set_volume_as_required!
-
+    EventBus.broadcast('comment_like', comment_vote)
     Events::CommentLiked.publish!(comment_vote)
   end
 
@@ -31,37 +25,26 @@ class CommentService
     return false unless comment.valid?
 
     comment.save!
-    comment.discussion.update_attribute(:last_comment_at, comment.created_at)
-
-    Draft.purge_without_delay(user: actor, draftable: comment.discussion, field: :comment)
-    SearchVector.index! comment.discussion_id
-
-    event = Events::NewComment.publish!(comment)
-    DiscussionReader.for(user: actor, discussion: comment.discussion).author_thread_item!(comment.created_at)
-    event
+    EventBus.broadcast('comment_create', comment)
+    Events::NewComment.publish!(comment)
   end
 
   def self.destroy(comment:, actor:)
     actor.ability.authorize!(:destroy, comment)
-    # paranoid destroy_all because comment votes seem to be dangling around.
     comment.comment_votes.destroy_all
     comment.destroy
-    Memos::CommentDestroyed.publish!(comment)
+    EventBus.broadcast('comment_destroy', comment)
   end
 
   def self.update(comment:, params:, actor:)
-    new_mentions = Comment.new(params).mentioned_usernames - comment.mentioned_usernames
-
+    new_mentions = comment.new_mentions_in(params[:body])
     comment.edited_at = Time.zone.now
     comment.body = params[:body]
 
     return false unless comment.valid?
     actor.ability.authorize! :create, comment
-    SearchVector.index! comment.discussion_id
     comment.save!
 
-    User.where(username: new_mentions).each { |user| Events::UserMentioned.publish!(comment, user) } if new_mentions.any?
-    Memos::CommentUpdated.publish!(comment)
-    true
+    EventBus.broadcast('comment_update', comment, new_mentions)
   end
 end

--- a/config/initializers/event_bus_mailers.rb
+++ b/config/initializers/event_bus_mailers.rb
@@ -1,0 +1,9 @@
+
+EventBus.listen('new_comment_event') do |event|
+  BaseMailer.send_bulk_mail(to: UsersToEmailQuery.new_comment(event.comment)) do |user|
+    ThreadMailer.delay.new_comment(user, event)
+  end
+end
+
+EventBus.listen('comment_replied_to_event') { |user, event| ThreadMailer.delay.comment_replied_to(user, event) }
+EventBus.listen('user_mentioned_event')     { |user, event| ThreadMailer.delay.user_mentioned(user, event) }

--- a/config/initializers/event_bus_memos.rb
+++ b/config/initializers/event_bus_memos.rb
@@ -1,0 +1,3 @@
+EventBus.listen('comment_destroy') { |comment| Memos::CommentDestroyed.publish!(comment) }
+EventBus.listen('comment_update')  { |comment| Memos::CommentUpdated.publish!(comment) }
+EventBus.listen('comment_unlike')  { |comment_vote| Memos::CommentUnliked.publish!(comment: comment_vote.comment, user: comment_vote.user) }

--- a/config/initializers/event_bus_notifications.rb
+++ b/config/initializers/event_bus_notifications.rb
@@ -1,0 +1,9 @@
+
+EventBus.listen('comment_create') { |comment| Events::CommentRepliedTo.publish!(comment) if comment.is_reply? }
+EventBus.listen('comment_create') { |comment| comment.notified_group_members.each { |user| Events::UserMentioned.publish!(comment, user) } }
+
+EventBus.listen('comment_update') do |comment, new_mentions|
+  User.where(username: new_mentions).each { |user| Events::UserMentioned.publish!(comment, user) } if new_mentions.present?
+end
+
+EventBus.listen('comment_replied_to_event', 'user_mentioned_event') { |user, event| event.notify!(user) }

--- a/spec/extras/event_bus_spec.rb
+++ b/spec/extras/event_bus_spec.rb
@@ -1,0 +1,73 @@
+require 'rails_helper'
+
+describe EventBus do
+
+  let(:subject) { EventBus.instance }
+  let(:my_proc) { Proc.new { self.inspect } }
+  let(:my_param_proc) { Proc.new { |param| param.is_a? my_param } }
+  let(:my_param) { Object }
+
+  before { @listeners = subject.instance_variable_get(:@listeners); subject.clear }
+  after { subject.instance_variable_set(:@listeners, @listeners) }
+
+  describe 'listen' do
+    it 'activates a listener with an event name' do
+      expect(self).to receive(:inspect)
+      subject.listen('my_event', &my_proc)
+      subject.broadcast('my_event')
+    end
+
+    it 'activates a listener with params' do
+      expect(self).to receive(:is_a?).with(my_param)
+      subject.listen('my_event', &my_param_proc)
+      subject.broadcast('my_event', self)
+    end
+
+    it 'does not activate events with a different event name' do
+      expect(self).to_not receive(:inspect)
+      subject.listen('my_event', &my_proc)
+      subject.broadcast('my_other_event')
+    end
+
+    it 'can accept multiple event names' do
+      expect(self).to receive(:inspect).twice
+      subject.listen('my_event', 'my_other_event', &my_proc)
+      subject.broadcast('my_event')
+      subject.broadcast('my_other_event')
+    end
+  end
+
+  describe 'deafen' do
+    it 'silences listeners with an event name' do
+      expect(self).to_not receive(:inspect)
+      subject.listen('my_event', &my_proc)
+      subject.deafen('my_event', &my_proc)
+      subject.broadcast('my_event')
+    end
+
+    it 'does not silence other events' do
+      expect(self).to receive(:inspect)
+      subject.listen('my_event', &my_proc)
+      subject.deafen('my_other_event', &my_proc)
+      subject.broadcast('my_event')
+    end
+
+    it 'can accept multiple event names' do
+      expect(self).to_not receive(:inspect)
+      subject.listen('my_event', &my_proc)
+      subject.listen('my_other_event', &my_proc)
+      subject.deafen('my_event', 'my_other_event', &my_proc)
+      subject.broadcast('my_event')
+      subject.broadcast('my_other_event')
+    end
+  end
+
+  describe 'clear' do
+    it 'empties the listeners' do
+      expect(self).to_not receive(:inspect)
+      subject.listen('my_event', &my_proc)
+      subject.clear
+      subject.broadcast('my_event')
+    end
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -93,6 +93,11 @@ published_at "2015-11-18 14:28:30"
     end
   end
 
+  factory :comment_vote do
+    comment
+    user
+  end
+
   factory :motion do
     sequence(:name) { Faker::Name.name }
     association :author, factory: :user

--- a/spec/models/events/comment_replied_to_spec.rb
+++ b/spec/models/events/comment_replied_to_spec.rb
@@ -4,39 +4,31 @@ describe Events::CommentRepliedTo do
   let(:discussion) { create :discussion }
   let!(:comment) { create(:comment, discussion: discussion, parent: parent) }
   let!(:parent) { create(:comment, discussion: discussion) }
-  let(:event) { double(notify!: true) }
 
   describe "::publish!" do
 
-    it 'creates an event' do
-      expect(Event).to receive(:create!).with(kind: 'comment_replied_to',
-                                              eventable: comment,
-                                              created_at: comment.created_at).and_return(event)
-      expect(ThreadMailer).to receive(:delay).and_return(double(comment_replied_to: true))
-      Events::CommentRepliedTo.publish!(comment)
+    it 'returns an event' do
+      expect(Events::CommentRepliedTo.publish!(comment)).to be_a(Event)
     end
 
-    it 'returns an event' do
-      expect(Events::CommentRepliedTo.publish!(comment)).to be_a Event
+    it 'creates a comment replied to event' do
+      expect { Events::CommentRepliedTo.publish!(comment) }.to change { Event.count(kind: 'comment_replied_to') }.by(1)
     end
 
     it 'emails the parent author' do
-      expect(Event).to receive(:create!).with(kind: 'comment_replied_to',
-                                              eventable: comment,
-                                              created_at: comment.created_at).and_return(event)
       expect(ThreadMailer).to receive(:delay).and_return(double(comment_replied_to: true))
-      expect(event).to receive(:notify!)
-      Events::CommentRepliedTo.publish!(comment)
+      expect { Events::CommentRepliedTo.publish!(comment) }.to change { Event.count }.by(1)
+    end
+
+    it 'creates a notification' do
+      expect { Events::CommentRepliedTo.publish!(comment) }.to change { Notification.count }.by(1)
     end
 
     it 'does not email when the comment and reply author are the same' do
       parent.update author: comment.author
-      expect(Event).to receive(:create!).with(kind: 'comment_replied_to',
-                                              eventable: comment,
-                                              created_at: comment.created_at).and_return(event)
+      expect(Event).to_not receive(:create!)
       expect(ThreadMailer).to_not receive(:delay)
-      expect(event).to_not receive(:notify!)
-      Events::CommentRepliedTo.publish!(comment)
+      expect { Events::CommentRepliedTo.publish!(comment) }.to_not change { Notification.count }
     end
   end
 end

--- a/spec/models/events/new_comment_spec.rb
+++ b/spec/models/events/new_comment_spec.rb
@@ -8,11 +8,7 @@ describe Events::NewComment do
   describe "::publish!" do
 
     it 'creates an event' do
-      Event.should_receive(:create!).with(kind: 'new_comment',
-                                          eventable: comment,
-                                          discussion: comment.discussion,
-                                          created_at: comment.created_at)
-      Events::NewComment.publish!(comment)
+      expect { Events::NewComment.publish!(comment) }.to change { Event.count(kind: 'new_comment') }.by(1)
     end
 
     it 'returns an event' do
@@ -21,17 +17,6 @@ describe Events::NewComment do
 
     it 'uses its group as the channel to publish to' do
       expect(Events::NewComment.publish!(comment).send(:channel_object)).to eq discussion.group
-    end
-
-    it 'does not publish a comment replied to event if there is no parent' do
-      Events::CommentRepliedTo.should_not_receive(:publish!).with(comment)
-      Events::NewComment.publish! comment
-    end
-
-    it 'publishes a comment replied to event if there is a comment' do
-      comment.parent = create :comment
-      Events::CommentRepliedTo.should_receive(:publish!).with(comment)
-      Events::NewComment.publish! comment
     end
   end
 end


### PR DESCRIPTION
Today's :airplane: treat!

I did this as a thought experiment more than anything else, to decouple the concerns of the Service layer from the various events; this implements changes to the NewComment and UserMentioned events.

Something like this is an important piece towards a flexible, extensible plugin architecture, because it means people can hook into the things going on in the app without having to muck about in the things that are calling them.

Would be cool to hear your thoughts on honing this approach some @robguthrie 

(Hi from Amsterdam!)