### PR TITLE
tool to rename, move translations

### DIFF
--- a/lib/pluck_translations.rb
+++ b/lib/pluck_translations.rb
@@ -1,0 +1,52 @@
+module LoomioI18n
+  # next write spec that confirms some file is translated correctly.
+  # boose:
+  #   some_key: 'ok'
+  # subject:
+  #   thing: 'ues'
+
+  # gives identical destination file
+  # test inserts data
+  # test does not destroy existing keys
+  def self.pluck_translations(en_source_filename: ,
+                             source_key:,
+                             en_destination_filename:,
+                             destination_key:)
+
+    locales_with_filenames(en_source_filename,
+                           en_destination_filename) do |locale, source_filename, destination_filename|
+
+      subject = YAML.load_file(source_filename)[locale][source_key]
+      destination = File.exists?(destination_filename) ? YAML.load_file(destination_filename) : {}
+
+      path_in_hash("#{locale}.#{destination_key}", destination).merge!(subject)
+
+      File.open(destination_filename, 'w') {|f| f.write destination.to_yaml }
+    end
+  end
+
+  # give us the value at en.bar.foo
+  # if foo does not exist, create a hash and return it
+  def self.path_in_hash(path, hash)
+    path.split('.').inject(hash) do |location, key|
+      if location.has_key?(key)
+        location[key]
+      else
+        location[key] = {}
+      end
+    end
+  end
+
+  def self.locales_with_filenames(en_source_filename, en_destination_filename)
+    Dir[en_source_filename.gsub('en', "{#{locales.join(',')}}")].each do |filename|
+      locale = /#{en_source_filename.gsub('en', '(.+)')}/.match(filename)[1]
+      yield(locale,
+            en_source_filename.gsub('en', locale),
+            en_destination_filename.gsub('en', locale))
+    end
+  end
+
+  def self.locales
+    %w[af ar az be bg bn bs ca cs cy da de de-AT de-CH el en en-AU en-CA en-GB en-IE en-IN en-NZ en-US en-ZA eo es es-419 es-AR es-CL es-CO es-CR es-EC es-MX es-PA es-PE es-US es-VE et eu fa fi fr fr-CA fr-CH gl he hi hi-IN hr hu id is it it-CH ja km kn ko lb lo lt lv mk mn mr-IN ms nb ne nl nn or pa pl pt pt-BR rm ro ru sk sl sr sv sw ta th tl tr tt ug uk ur uz vi wo zh-CN zh-HK zh-TW zh-YUE]
+  end
+end

--- a/lib/tasks/locales.rake
+++ b/lib/tasks/locales.rake
@@ -61,7 +61,7 @@ namespace :locales do
 
       keys_with_variables = find_keys_with_variables(source_language_hash).map {|key| key[2..-2] }
       keys_with_html = find_keys_with_html(source_language_hash).map {|key| key[2..-2] } - keys_to_ignore
-      
+
       args[:locales].each do |locale|
         print "#{grey(locale)} "
         transifex_locale = (locale.to_s).gsub('-','_')
@@ -273,4 +273,3 @@ def pad_string_to(string, desired_length)
   (desired_length - printed_length).times { string += ' ' }
   string
 end
-

--- a/lib/tasks/pluck_translations.rake
+++ b/lib/tasks/pluck_translations.rake
@@ -1,0 +1,12 @@
+require_relative '../pluck_translations'
+namespace :loomio do
+  task :pluck_translations => :environment do
+    LoomioI18n.pluck_translations({
+      en_source_filename: ARGV[1],
+      source_key: ARGV[2],
+      en_destination_filename: ARGV[3],
+      destination_key: ARGV[4]
+    })
+    exit 0
+  end
+end

--- a/spec/lib/pluck_translations_spec.rb
+++ b/spec/lib/pluck_translations_spec.rb
@@ -1,0 +1,64 @@
+require_relative '../../lib/pluck_translations'
+
+
+describe "Pluck translations" do
+  let(:translations) {
+    {
+      'en' => {'a' => 'blue', 'b' => {'c' => 'red' }},
+      'es' => {'a' => 'azul', 'b' => {'c' => 'rojo'}},
+    }
+  }
+
+  before do
+    #setup input_en.yml and input_es.yml as simple example
+    translations.each_pair do |locale, pairs|
+      File.open("input.#{locale}.yml", 'w') do |f|
+        f.write({locale => pairs}.to_yaml)
+      end
+    end
+  end
+
+  after do
+    translations.each_pair do |locale, pairs|
+      File.delete("input.#{locale}.yml")
+      File.delete("output.#{locale}.yml")
+    end
+  end
+
+
+  it "copys a set of strings from one place to another" do
+    LoomioI18n.pluck_translations(
+      en_source_filename: 'input.en.yml',
+      source_key: 'b',
+      en_destination_filename: 'output.en.yml',
+      destination_key: 'bb'
+    )
+
+    # read output_en.yml and confirm it has chips
+
+    result = YAML.load_file('output.en.yml')
+    expect(result['en']['bb']).to eq({'c' => 'red'})
+
+    # read output_en.yml and confirm it has chips
+    result = YAML.load_file('output.es.yml')
+    expect(result['es']['bb']).to eq({'c' => 'rojo'})
+  end
+
+  it "copys a set of strings to a nested place" do
+    LoomioI18n.pluck_translations(
+      en_source_filename: 'input.en.yml',
+      source_key: 'b',
+      en_destination_filename: 'output.en.yml',
+      destination_key: 'b.b'
+    )
+
+    # read output_en.yml and confirm it has chips
+
+    result = YAML.load_file('output.en.yml')
+    expect(result['en']['b']['b']).to eq({'c' => 'red'})
+
+    # read output_en.yml and confirm it has chips
+    result = YAML.load_file('output.es.yml')
+    expect(result['es']['b']['b']).to eq({'c' => 'rojo'})
+  end
+end


### PR DESCRIPTION
`rake loomio:pluck_translations config/locales/en.yml email config/locales/emails.en.yml email`

Will move all translations with they key `email` in en.yml es.yml ... etc to the key email in emails.en.yml emails.es.yml etc

IE: We can move translations around without discarding all the work of our translators. I built this so we can break up our main .yml files into way smaller files.