### PR TITLE
Add no activity placeholder

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -774,6 +774,7 @@ en:
 
   discussion:
     activity: 'Activity'
+    activity_placeholder: 'No activity yet!'
     proposals: 'Proposals'
     previous_proposals: 'Previous Proposals'
     load_previous: 'Load earlier activity'

--- a/lineman/app/components/thread_page/activity_card/activity_card.coffee
+++ b/lineman/app/components/thread_page/activity_card/activity_card.coffee
@@ -80,6 +80,8 @@ angular.module('loomioApp').directive 'activityCard', ->
     $scope.events = ->
       _.filter $scope.discussion.events(), (event) -> $scope.safeEvent(event.kind)
 
+    $scope.noEvents = ->
+      !$scope.loadEventsForwardsExecuting and !_.any($scope.events())
 
     $scope.init()
     return

--- a/lineman/app/components/thread_page/activity_card/activity_card.haml
+++ b/lineman/app/components/thread_page/activity_card/activity_card.haml
@@ -4,6 +4,7 @@
     %i.fa.fa-refresh>
     %span{translate: 'discussion.load_previous', translate-value-count: '{{beforeCount()}}'}
   %loading.activity-card__loading.page-loading{ng-show: 'loadEventsBackwardsExecuting'}
+  .activity-card__no-activity.lmo-placeholder.align-center{ng-if: 'noEvents()', translate: 'discussion.activity_placeholder'}
   %ul.activity-card__activity-list
     %li.activity-card__activity-list-item{ng_repeat: 'event in events() track by event.id', in-view: '($inview&&threadItemVisible(event)) || (!$inview&&threadItemHidden(event))', in-view-options: '{debounce: 100}', aria-labelledby: 'event-{{event.id}}'}
       .activity-card__last-item{ng-if: '$last'}


### PR DESCRIPTION
This has been bugging me for a bit.

Before:
![screen shot 2015-12-21 at 9 42 44 am](https://cloud.githubusercontent.com/assets/750477/11926711/49179234-a7c7-11e5-9e44-95bbe1a3cfe5.png)

After:
![screen shot 2015-12-21 at 9 42 19 am](https://cloud.githubusercontent.com/assets/750477/11926710/455ccf74-a7c7-11e5-811c-3b0e1237e43d.png)

Maybe a prompt in the placeholder to enter a comment below? Other option is to hide the activity card when there isn't activity, but having the empty card feels odd to me.