### PR TITLE
Move Intercom widget to avoid covering FAB

### DIFF
--- a/lineman/app/css/1_utilities.scss
+++ b/lineman/app/css/1_utilities.scss
@@ -262,3 +262,7 @@ textarea.form-control {
     opacity: 0;
   }
 }
+
+div#intercom-container div#intercom-launcher {
+    right: 85px;
+}


### PR DESCRIPTION
Can this be tested on an installation that has Intercom?

### Before

![image](https://cloud.githubusercontent.com/assets/1380991/12409393/6a17b46e-bece-11e5-8a1a-9537e1b3e83b.png)

### After (I hope)

![image](https://cloud.githubusercontent.com/assets/1380991/12409401/719b5b50-bece-11e5-89af-3be5d6bfc0f4.png)
