### PR TITLE
Don't serialize out null subscriptions

### DIFF
--- a/app/controllers/api/message_channel_controller.rb
+++ b/app/controllers/api/message_channel_controller.rb
@@ -4,7 +4,7 @@ class API::MessageChannelController < API::RestfulController
   rescue_from(MessageChannelService::UnknownChannelError) { |e| respond_with_standard_error e, 400 }
 
   def subscribe
-    @subscriptions = Array(subscription_models).map { |model| MessageChannelService.subscribe_to(user: current_user, model: model) }
+    @subscriptions = Array(subscription_models).map { |model| MessageChannelService.subscribe_to(user: current_user, model: model) }.compact
     respond_with_subscriptions
   end
 


### PR DESCRIPTION
This fixes a javascript error which happens on development when Faye isn't running :smile: 