### PR TITLE
Fix word-break for CJK users

### DIFF
--- a/app/assets/stylesheets/unstructured/_main.scss
+++ b/app/assets/stylesheets/unstructured/_main.scss
@@ -5,6 +5,7 @@ body {
   background-color: $app-background;
   color: $text-black;
   margin-top: 50px;
+  word-break: keep-all;
 }
 
 body.pages{


### PR DESCRIPTION
`word-break: keep-all;` is same as `word-break: normal;`, except for CJK words.
It will provide better ux for CJK users.

https://developer.mozilla.org/ko/docs/Web/CSS/word-break