### PR TITLE
Add companion PUT route to api PATCH actions

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,6 +39,7 @@ Loomio::Application.routes.draw do
     resources :groups, only: [:show, :create, :update] do
       get :subgroups, on: :member
       patch :archive, on: :member
+      put :archive, on: :member
       post :use_gift_subscription, on: :member
       post 'upload_photo/:kind', on: :member, action: :upload_photo
     end
@@ -88,6 +89,7 @@ Loomio::Application.routes.draw do
         get    '/:draftable_type/:draftable_id', action: :show
         post   '/:draftable_type/:draftable_id', action: :update
         patch  '/:draftable_type/:draftable_id', action: :update
+        put    '/:draftable_type/:draftable_id', action: :update
       end
     end
 
@@ -97,6 +99,11 @@ Loomio::Application.routes.draw do
       patch :star, on: :member
       patch :unstar, on: :member
       patch :move, on: :member
+      put :mark_as_read, on: :member
+      put :set_volume, on: :member
+      put :star, on: :member
+      put :unstar, on: :member
+      put :move, on: :member
       get :dashboard, on: :collection
       get :inbox, on: :collection
     end


### PR DESCRIPTION
Allow PUT action to be used in API where we're using PATCH

To tiptoe around this issue:
https://github.com/sandstorm-io/sandstorm/issues/1218

In reference to the Loomio / Sandstorm discussion happening here:
https://www.loomio.org/d/yw0D8Sc6/help-porting-loomio-to-sandstorm

NB: I've also updated the angular record store in 2.3.4 to add a `putMember` method, which will perform a `PUT` rather than `PATCH` request to the server (although I'd still like Loomio to be doing PATCH requests at the moment, since that's the railsy standard)
https://github.com/loomio/angular_record_store/pull/7
