### PR TITLE
Add maximum height for attached images to avoid them dominating threads

### DIFF
--- a/angular/core/components/attachment_preview/attachment_preview.scss
+++ b/angular/core/components/attachment_preview/attachment_preview.scss
@@ -6,6 +6,7 @@
 .attachment-preview img {
   border-radius: 5px;
   max-width: 100%;
+  max-height: 320px;
   border: 1px solid $border-color;
 }
 


### PR DESCRIPTION
Before | After
--- | ---
<img width="623" alt="screen shot 2016-02-04 at 10 38 00 am" src="https://cloud.githubusercontent.com/assets/1380991/12798224/1bbd09e8-cb2d-11e5-91b8-cd0cc282b4c0.png"> | <img width="631" alt="screen shot 2016-02-04 at 10 37 47 am" src="https://cloud.githubusercontent.com/assets/1380991/12798225/1fb01554-cb2d-11e5-8d00-e22a6db57300.png">

This has Product Owner approval :)

