### PR TITLE
ensure that votestatements are in primary text colour

### DIFF
--- a/angular/core/components/thread_page/activity_card/thread_item.scss
+++ b/angular/core/components/thread_page/activity_card/thread_item.scss
@@ -62,6 +62,7 @@
 }
 
 .thread-item__vote-statement {
+  color: $primary-text-color;
   display: inline-block;
 }
 


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/486367/13059695/efb8a754-d490-11e5-96fc-98834a7405a9.png)

should look more like this:
![image](https://cloud.githubusercontent.com/assets/486367/13059728/2a810016-d491-11e5-9b7e-1020e96dd25c.png)

which is what this line of css does