### PR TITLE
Allow display of up to 1000 pending invitations

### DIFF
--- a/angular/core/components/memberships_page/pending_invitations_card/pending_invitations_card.coffee
+++ b/angular/core/components/memberships_page/pending_invitations_card/pending_invitations_card.coffee
@@ -8,7 +8,7 @@ angular.module('loomioApp').directive 'pendingInvitationsCard', ->
       CurrentUser.isAdminOf($scope.group)
 
     if $scope.canSeeInvitations()
-      Records.invitations.fetchPendingByGroup($scope.group.key)
+      Records.invitations.fetchPendingByGroup($scope.group.key, per: 1000)
 
     $scope.baseUrl = AppConfig.baseUrl
 


### PR DESCRIPTION
To fix: https://github.com/loomio/loomio/issues/2837