### PR TITLE
Fix vertical mobile card headers; broadcast placeholders further

### DIFF
--- a/angular/core/components/group_page/discussions_card/discussions_card.coffee
+++ b/angular/core/components/group_page/discussions_card/discussions_card.coffee
@@ -29,7 +29,7 @@ angular.module('loomioApp').directive 'discussionsCard', ->
                         discussion: -> Records.discussions.build(groupId: $scope.group.id)
 
     $scope.showThreadsPlaceholder = ->
-      AbilityService.canAdministerGroup($scope.group) and $scope.group.discussions().length < 3
+      $scope.group.discussions().length < 4
 
     $scope.whyImEmpty = ->
       if !AbilityService.canViewGroup($scope.group)

--- a/angular/core/components/group_page/discussions_card/discussions_card.scss
+++ b/angular/core/components/group_page/discussions_card/discussions_card.scss
@@ -3,7 +3,12 @@
 }
 
 .discussions-card__header{
-  margin: $cardPaddingSize;
+  margin: $cardPaddingSize $cardPaddingSize 0 $cardPaddingSize;
+  @include displayFlex;
+  -webkit-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-justify-content: space-between;
+  justify-content: space-between;
 }
 
 .discussions-card__new-thread-button{
@@ -11,7 +16,7 @@
   @include lmoBtnIcon;
   @include fontSmall;
   float: right;
-  margin-bottom: 10px;
+  margin-bottom: $cardPaddingSize;
 }
 
 .discussions-card__list--empty {

--- a/angular/core/components/group_page/group_page_controller.coffee
+++ b/angular/core/components/group_page/group_page_controller.coffee
@@ -21,7 +21,7 @@ angular.module('loomioApp').controller 'GroupPageController', ($rootScope, $loca
     $rootScope.$broadcast('pageError', error)
 
   @showDescriptionPlaceholder = ->
-    AbilityService.canAdministerGroup(@group) and !@group.description
+    !@group.description
 
   @canManageMembershipRequests = ->
     AbilityService.canManageMembershipRequests(@group)

--- a/angular/core/css/1_lmo_card.scss
+++ b/angular/core/css/1_lmo_card.scss
@@ -25,7 +25,6 @@
 .lmo-card-heading{
   @include fontHelveticaMedium;
   @include fontSmall;
-  display: inline-block;
   text-transform: uppercase;
   color: $grey-on-white;
   margin-bottom: 10px;

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -408,7 +408,7 @@ en:
     group_logo: 'Group logo'
     new_photo: 'new photo'
     description: 'Group description'
-    description_placeholder: 'Use this place to describe the purpose of the group so your members know why they are here.'
+    description_placeholder: 'Groups coordinators can use this area to describe the group’s purpose, so everyone knows why they are here.'
     discussions: 'Threads'
     discussions_placeholder: 'A thread is where everyone can discuss a topic and make decisions together.'
     members: 'Members'


### PR DESCRIPTION
Resolves #2779 

Before | After
----- | -----
![2016-02-17 17 08 48](https://cloud.githubusercontent.com/assets/1380991/13099662/6cb8386a-d599-11e5-8f1e-592218074010.png) | ![2016-02-17 17 05 08](https://cloud.githubusercontent.com/assets/1380991/13099665/6fab4116-d599-11e5-9ae2-f196aba94198.png)

This is an intermittent bug. Worth testing on clone to be sure I've squashed it and there are no side effects.