### PR TITLE
add engines to package.json and use node 5

### DIFF
--- a/angular/package.json
+++ b/angular/package.json
@@ -3,6 +3,10 @@
   "version": "1.0.0",
   "description": "Assets for Loomio 1.0",
   "main": "gulpfile.coffee",
+  "engines": {
+    "node": "5.5.0",
+    "npm": "3.3.12"
+  },
   "scripts": {
     "test": "gulp test"
   },

--- a/angular/tasks/config/vendor.yml
+++ b/angular/tasks/config/vendor.yml
@@ -11,7 +11,7 @@ js:
   - angular-translate-loader-url/angular-translate-loader-url.js
   - angular-ui-bootstrap/ui-bootstrap.js
   - angular-ui-bootstrap/ui-bootstrap-tpls.js
-  - angular-marked/node_modules/marked/lib/marked.js
+  - marked/lib/marked.js
   - angular-marked/dist/angular-marked.js
   - ng-file-upload/dist/angular-file-upload.js
   - ment.io/dist/mentio.js


### PR DESCRIPTION
I'll note that I've got nvm install which makes switching between node versions easy, and could be worthwhile suggesting in the documentation. https://github.com/creationix/nvm

With that one change to the config file, I had it working fine with node 5.5.0

related to #2992 

using: OS X El Capitan