### PR TITLE
improve email regex

### DIFF
--- a/angular/core/components/invitation_form/invitation_form.coffee
+++ b/angular/core/components/invitation_form/invitation_form.coffee
@@ -24,7 +24,8 @@ angular.module('loomioApp').factory 'InvitationForm', ->
       $scope.addCustomMessageClicked = true
 
     $scope.invitees = ->
-      $scope.form.emails.match(/[^\s<,]+?@[^>,\s]+/g) or []
+      # something@something.something where something does not include ; or , or < or >
+      $scope.form.emails.match(/[^\s,;<>]+?@[^\s,;<>]+\.[^\s,;<>]+/g) or []
 
     $scope.maxInvitations = ->
       $scope.invitees().length > 100

--- a/app/controllers/api/invitations_controller.rb
+++ b/app/controllers/api/invitations_controller.rb
@@ -33,7 +33,7 @@ class API::InvitationsController < API::RestfulController
   end
 
   def email_addresses
-    invitation_form_params[:emails].scan(/[^\s<,]+?@[^>,\s]+/).take(100)
+    invitation_form_params[:emails].scan(/[^\s,;<>]+?@[^\s,;<>]+\.[^\s,;<>]+/).take(100)
   end
 
 end


### PR DESCRIPTION
Email regex now requires some kind of TLD after the @. It also sees ; and , as seperators rather than part of the address