### PR TITLE
Add activity item for when thread privacy is changed

### DIFF
--- a/angular/core/components/thread_page/activity_card/discussion_edited.haml
+++ b/angular/core/components/thread_page/activity_card/discussion_edited.haml
@@ -7,4 +7,5 @@
         %strong
           %a{lmo-href-for: "event.actor()"}> {{ event.actorName() }}
         %span{translate: "discussion_edited_item.{{translationKey}}", translate-value-title: "{{title}}"}
+        %span{ng-if: "onlyPrivacyEdited()", translate: "{{privacyKey()}}"}
         %timeago.timeago--inline{timestamp: "event.createdAt"}

--- a/angular/core/components/thread_page/activity_card/discussion_edited.haml
+++ b/angular/core/components/thread_page/activity_card/discussion_edited.haml
@@ -7,5 +7,6 @@
         %strong
           %a{lmo-href-for: "event.actor()"}> {{ event.actorName() }}
         %span{translate: "discussion_edited_item.{{translationKey}}", translate-value-title: "{{title}}"}
-        %span{ng-if: "onlyPrivacyEdited()", translate: "{{privacyKey()}}"}
+        %span
+          %span{ng-if: "onlyPrivacyEdited()", translate: "{{privacyKey()}}"}
         %timeago.timeago--inline{timestamp: "event.createdAt"}

--- a/angular/core/components/thread_page/activity_card/discussion_edited_item_controller.coffee
+++ b/angular/core/components/thread_page/activity_card/discussion_edited_item_controller.coffee
@@ -7,6 +7,17 @@ angular.module('loomioApp').controller 'DiscussionEditedItemController', ($scope
       version.changes.title[1]
     else
       ''
+  $scope.onlyPrivacyEdited = ->
+    version.attributeEdited('private') and
+    !version.attributeEdited('title') or
+    !version.attributeEdited('description')
+
+  $scope.privacyKey = ->
+    return unless version.changes.private[0] != version.changes.private[1]
+    if version.changes.private[1]
+     'discussion_edited_item.public_to_private'
+    else
+     'discussion_edited_item.private_to_public'
 
   $scope.actorName = $scope.event.actorName()
 

--- a/angular/core/models/version_model.coffee
+++ b/angular/core/models/version_model.coffee
@@ -12,7 +12,7 @@ angular.module('loomioApp').factory 'VersionModel', (BaseModel) ->
 
     editedAttributeNames: ->
       _.filter _.keys(@changes).sort(), (key) ->
-        _.include ['title', 'name', 'description', 'closing_at'], key
+        _.include ['title', 'name', 'description', 'closing_at', 'private'], key
 
     attributeEdited: (name) ->
        _.include(_.keys(@changes), name)

--- a/angular/test/protractor/discussion_spec.coffee
+++ b/angular/test/protractor/discussion_spec.coffee
@@ -17,14 +17,17 @@ describe 'Discussion Page', ->
     beforeEach ->
       page.loadPath('setup_discussion')
 
-    it 'lets you edit title and context', ->
+    it 'lets you edit title, context and privacy', ->
       page.click '.thread-context__dropdown-button',
                  '.thread-context__dropdown-options-edit'
       page.fillIn('.discussion-form__title-input', 'better title')
       page.fillIn('.discussion-form__description-input', 'improved description')
+      page.click('.discussion-form__private')
       page.click('.discussion-form__update')
       page.expectText('.thread-context', 'better title')
-      page.expectText('.thread-context', "improved description")
+      page.expectText('.thread-context', 'improved description')
+      page.expectText('.thread-context', 'Private')
+      page.expectText('.thread-item__title', 'updated the thread title, context and privacy')
 
     it 'does not store cancelled thread info', ->
       page.click '.thread-context__dropdown-button',

--- a/app/models/discussion.rb
+++ b/app/models/discussion.rb
@@ -41,7 +41,7 @@ class Discussion < ActiveRecord::Base
   validate :privacy_is_permitted_by_group
 
   is_translatable on: [:title, :description], load_via: :find_by_key!, id_field: :key
-  has_paper_trail only: [:title, :description]
+  has_paper_trail only: [:title, :description, :private]
 
   belongs_to :group
   belongs_to :author, class_name: 'User'

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -898,9 +898,9 @@ en:
     title: 'updated the thread title: <span>{{title}}</span>'
     description: 'updated the thread context'
     description_title: 'updated the thread title and context'
-    private: 'updated the thread privacy from'
-    public_to_private: 'public to private'
-    private_to_public: 'private to public'
+    private: 'updated the thread privacy to:'
+    public_to_private: 'private'
+    private_to_public: 'public'
     description_private_title: 'updated the thread title, context and privacy'
 
   contact_message_form:

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -898,7 +898,7 @@ en:
     title: 'updated the thread title: <span>{{title}}</span>'
     description: 'updated the thread context'
     description_title: 'updated the thread title and context'
-    private: 'updated the thread privacy to:'
+    private: 'updated the thread privacy to'
     public_to_private: 'private'
     private_to_public: 'public'
     description_private_title: 'updated the thread title, context and privacy'

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -898,6 +898,10 @@ en:
     title: 'updated the thread title: <span>{{title}}</span>'
     description: 'updated the thread context'
     description_title: 'updated the thread title and context'
+    private: 'updated the thread privacy from'
+    public_to_private: 'public to private'
+    private_to_public: 'private to public'
+    description_private_title: 'updated the thread title, context and privacy'
 
   contact_message_form:
     contact_us: 'Contact Us'


### PR DESCRIPTION
[Trello card](https://trello.com/c/LhOfstmI/707-activity-item-for-changing-thread-privacy)

<img width="649" alt="screen shot 2016-02-24 at 5 50 37 pm" src="https://cloud.githubusercontent.com/assets/2882097/13275956/631e1e24-db1f-11e5-9186-c94afa93b4e7.png">