### PR TITLE
Tweaks for production deployment

### DIFF
--- a/app/mailers/base_mailer.rb
+++ b/app/mailers/base_mailer.rb
@@ -8,7 +8,7 @@ class BaseMailer < ActionMailer::Base
 
   add_template_helper(ReadableUnguessableUrlsHelper)
 
-  default :from => "Loomio <notifications@loomio.org>"
+  default :from => "Loomio <notifications@#{ENV['SMTP_DOMAIN']}>"
   before_action :utm_hash
 
   protected
@@ -25,7 +25,7 @@ class BaseMailer < ActionMailer::Base
   end
 
   def from_user_via_loomio(user)
-    "\"#{user.name} (Loomio)\" <notifications@loomio.org>"
+    "\"#{user.name} (Loomio)\" <notifications@#{ENV['SMTP_DOMAIN']}>"
   end
 
   def send_single_mail(locale: , to:, subject_key:, subject_params: {}, **options)

--- a/config/application.rb
+++ b/config/application.rb
@@ -74,20 +74,22 @@ module Loomio
 
     config.active_record.raise_in_transactional_callbacks = true
 
-    def self.fog_credentials
-      env = Rails.application.secrets
-      case env.fog_provider
-      when 'AWS'   then { aws_access_key_id: env.aws_access_key_id, aws_secret_access_key: env.aws_secret_access_key }
-      when 'Local' then { local_root: [Rails.root, 'public'].join('/'), endpoint: env.canonical_host }
-      end.merge(provider: env.fog_provider)
-    end
+    if ENV['FOG_PROVIDER']
+      def self.fog_credentials
+        env = Rails.application.secrets
+        case env.fog_provider
+        when 'AWS'   then { aws_access_key_id: env.aws_access_key_id, aws_secret_access_key: env.aws_secret_access_key }
+        when 'Local' then { local_root: [Rails.root, 'public'].join('/'), endpoint: env.canonical_host }
+        end.merge(provider: env.fog_provider)
+      end
 
-    # Store avatars on Amazon S3
-    config.paperclip_defaults = {
-      storage: :fog,
-      fog_credentials: fog_credentials,
-      fog_directory: Rails.application.secrets.fog_uploads_directory,
-      fog_public: true
-    }
+      # Store avatars on Amazon S3
+      config.paperclip_defaults = {
+        storage: :fog,
+        fog_credentials: fog_credentials,
+        fog_directory: Rails.application.secrets.fog_uploads_directory,
+        fog_public: true
+      }
+    end
   end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -67,16 +67,21 @@ Loomio::Application.configure do
 
   config.action_mailer.perform_deliveries = true
 
-  # Send emails using SMTP service
-  config.action_mailer.delivery_method = :smtp
-  config.action_mailer.smtp_settings = {
-    :address        => ENV['SMTP_SERVER'],
-    :port           => ENV['SMTP_PORT'],
-    :authentication => :plain,
-    :user_name      => ENV['SMTP_USERNAME'],
-    :password       => ENV['SMTP_PASSWORD'],
-    :domain         => ENV['SMTP_DOMAIN']
-  }
+  if ENV['SMTP_SERVER']
+    # Send emails using SMTP service
+    config.action_mailer.delivery_method = :smtp
+    config.action_mailer.smtp_settings = {
+      :address        => ENV['SMTP_SERVER'],
+      :port           => ENV['SMTP_PORT'],
+      :authentication => :plain,
+      :user_name      => ENV['SMTP_USERNAME'],
+      :password       => ENV['SMTP_PASSWORD'],
+      :domain         => ENV['SMTP_DOMAIN']
+    }
+  else
+    # Send emails using local sendmail
+    config.action_mailer.delivery_method = :sendmail
+  end
 
   config.serve_static_files = true
   config.action_mailer.raise_delivery_errors = true

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -4,7 +4,7 @@ Devise.setup do |config|
   # ==> Mailer Configuration
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class with default "from" parameter.
-  config.mailer_sender = "noreply@loomio.org"
+  config.mailer_sender = "noreply@#{ENV['SMTP_DOMAIN']}"
 
   # Configure the class responsible to send e-mails.
   # config.mailer = "Devise::Mailer"


### PR DESCRIPTION
A few tweaks to make S3 and SMTP optional, and avoid using `@loomio.org` when sending mails.