### PR TITLE
Prevent group welcome modal from showing for subgroups

### DIFF
--- a/angular/core/components/group_page/group_page_controller.coffee
+++ b/angular/core/components/group_page/group_page_controller.coffee
@@ -43,6 +43,7 @@ angular.module('loomioApp').controller 'GroupPageController', ($rootScope, $loca
       ModalService.open SubscriptionSuccessModal
 
   @showWelcomeModel = ->
+    @group.isParent() and
     AbilityService.isCreatorOf(@group) and
     @group.noInvitationsSent() and
     !@group.trialIsOverdue() and

--- a/angular/test/protractor/invitations_spec.coffee
+++ b/angular/test/protractor/invitations_spec.coffee
@@ -48,7 +48,6 @@ describe 'Invitations', ->
     page.fillIn '#group-name', 'subgroup for some'
 
     page.click '.group-form__submit-button',
-               '.group-welcome-modal__close-button',
                '.members-card__invite-members-btn',
                '.invitation-form__add-members',
                '.add-members-modal__list-item:first-of-type',


### PR DESCRIPTION
Addresses https://github.com/loomio/loomio/issues/3019