### PR TITLE
Ui tweaks

### DIFF
--- a/angular/core/components/navbar/navbar.scss
+++ b/angular/core/components/navbar/navbar.scss
@@ -108,6 +108,10 @@
   position: relative;
 }
 
+.lmo-navbar__btn.has-badge:hover .badge {
+  border-color: $list-hover-color;
+}
+
 .lmo-navbar__btn.has-badge .badge {
   font-size: 10px;
   position: absolute;

--- a/angular/core/components/start_menu/start_menu.scss
+++ b/angular/core/components/start_menu/start_menu.scss
@@ -34,8 +34,19 @@
   @include box_shadow(2);
   border-radius: 100%;
   cursor: pointer;
+  outline: 0;
   &:hover {
     @include box_shadow(3);
+  }
+  .fa-group {
+    position: relative;
+    bottom: 1px;
+    right: 2px;
+  }
+  .fa-times {
+    position: relative;
+    bottom: 3px;
+    right: 1px;
   }
 }
 

--- a/angular/core/components/thread_preview/thread_preview.scss
+++ b/angular/core/components/thread_preview/thread_preview.scss
@@ -33,11 +33,17 @@
 .thread-preview__mute{
   @include lmoBtnDefault;
   @include lmoBtnSm;
-}
-
-.thread-preview__mute{
-  @include lmoBtnDefault;
-  @include lmoBtnSm;
+  margin-left: 5px;
+  padding: 5px 13px;
+  .fa-volume-off{
+    padding-right: 9px;
+  }
+  .fa-times{
+    font-size: 70%;
+    position: relative;
+    right: 10px;
+    bottom: 1px;
+  }
 }
 
 .thread-preview__link {
@@ -148,17 +154,4 @@
 
 .thread-preview__actions button {
   width: 40px;
-}
-
-.thread-preview__mute{
-  margin-left: 5px;
-  .fa-volume-off{
-    padding-right: 9px;
-  }
-  .fa-times{
-    font-size: 70%;
-    position: relative;
-    right: 10px;
-    bottom: 1px;
-  }
 }

--- a/lib/version/patch.rb
+++ b/lib/version/patch.rb
@@ -1,1 +1,1 @@
-Loomio::Version::PATCH = 78
+Loomio::Version::PATCH = 79


### PR DESCRIPTION
- Don't outline start menu button when selected
- Position 'x' and group icon correctly in start menu
- Remove white outline on inbox hover
- Center mute button on thread preview