### PR TITLE
Add tests for group membership visibility on profile page

### DIFF
--- a/angular/test/protractor/profile_spec.coffee
+++ b/angular/test/protractor/profile_spec.coffee
@@ -2,6 +2,7 @@ describe 'Profile', ->
 
   profileHelper = require './helpers/profile_helper.coffee'
   threadHelper = require './helpers/thread_helper.coffee'
+  page = require './helpers/page_helper.coffee'
 
   beforeEach ->
     threadHelper.load()
@@ -17,8 +18,17 @@ describe 'Profile', ->
       expect(profileHelper.emailInput().getAttribute('value')).toContain('ferris@loomio.org')
 
   describe 'visiting a user profile', ->
-    it 'can display a user and his/her groups', ->
+
+    it 'displays a user and their non-secret groups', ->
       profileHelper.visitUserPage('jennifergrey')
       expect(profileHelper.nameText()).toContain('Jennifer Grey')
       expect(profileHelper.usernameText()).toContain('@jennifergrey')
       expect(profileHelper.groupsText()).toContain('Dirty Dancing Shoes')
+
+    it 'displays secret groups to other members', ->
+      page.loadPath('setup_profile_with_group_visible_to_members')
+      page.expectText('.user-page__profile', 'Secret Dirty Dancing Shoes')
+
+    it 'does not display secret groups to visitors', ->
+      page.loadPath('setup_restricted_profile')
+      page.expectNoText('.user-page__profile', 'Secret Dirty Dancing Shoes')

--- a/app/controllers/development_controller.rb
+++ b/app/controllers/development_controller.rb
@@ -129,6 +129,23 @@ class DevelopmentController < ApplicationController
     redirect_to discussion_url(public_test_discussion)
   end
 
+  def setup_restricted_profile
+    sign_in patrick
+    test_group = Group.create!(name: 'Secret Dirty Dancing Shoes',
+                                group_privacy: 'secret')
+    test_group.add_member!(jennifer)
+    redirect_to "/u/#{jennifer.username}"
+  end
+
+  def setup_profile_with_group_visible_to_members
+    sign_in patrick
+    test_group = Group.create!(name: 'Secret Dirty Dancing Shoes',
+                                group_privacy: 'secret')
+    test_group.add_admin!(patrick)
+    test_group.add_member!(jennifer)
+    redirect_to "/u/#{jennifer.username}"
+  end
+
   def setup_group_with_empty_draft
     sign_in patrick
     @test_group = Group.create!(name: 'Secret Dirty Dancing Shoes',


### PR DESCRIPTION
[Trello card](https://trello.com/c/tQLdMHfm/1049-3-test-coverage-for-user-profile-privacy)