### PR TITLE
Fix tiny, tiny video on group welcome modal

### DIFF
--- a/angular/core/components/group_page/group_welcome_modal/group_welcome_modal.haml
+++ b/angular/core/components/group_page/group_welcome_modal/group_welcome_modal.haml
@@ -5,7 +5,7 @@
 
   .modal-body
     %p{translate: "group_welcome_modal.first_step"}
-    .lmo-blank{ng-if: "showVideo"}
+    .group-welcome-model__video-wrapper{ng-if: "showVideo"}
       %iframe.group-welcome-modal__video{src: "https://www.youtube.com/embed/pF-wpXo8Rdw?showinfo=0&nologo=1", frameborder: "0", allowfullscreen=''}
     %p{translate: "group_welcome_modal.second_step"}
 

--- a/angular/core/components/group_page/group_welcome_modal/group_welcome_modal.scss
+++ b/angular/core/components/group_page/group_welcome_modal/group_welcome_modal.scss
@@ -1,11 +1,11 @@
-.modal-dialog.modal-group-welcome-modal {
-	max-width: 430px;
+.group-welcome-model__video-wrapper {
+	text-align: center;
 }
 
-.group-weclome-modal__video {
-	width: 398px;
-    height: 223px;
-    @media (max-width: 450px) { width: 100%; }
+.group-welcome-modal__video {
+	width: 100%;
+	max-width: 600px;
+	min-height: 300px;
 }
 
 


### PR DESCRIPTION
For #3063 

Small screen:
![screen shot 2016-03-09 at 2 41 02 pm](https://cloud.githubusercontent.com/assets/750477/13622651/077d7902-e605-11e5-84e4-24adee9c7c93.png)

Big screen:
![screen shot 2016-03-09 at 2 41 10 pm](https://cloud.githubusercontent.com/assets/750477/13622655/0dcef7f4-e605-11e5-8851-dfdc729756b8.png)

Can't seem to get fullscreen to happen, but linking to watch on youtube does work.