### PR TITLE
Don't allow visitors to mark as read or mute

### DIFF
--- a/angular/core/components/thread_preview/thread_preview.haml
+++ b/angular/core/components/thread_preview/thread_preview.haml
@@ -35,7 +35,7 @@
   .thread-preview__star
     %star_toggle{thread: "thread", aria-hidden: "true"}
 
-  .thread-preview__actions.hidden-xs
+  .thread-preview__actions.hidden-xs{ng-if: "thread.discussionReaderId"}
     %button.thread-preview__mark-as-read{ng-click: "thread.markAsRead()", ng-class: "{disabled: !thread.isUnread()}", title: "{{'dashboard_page.mark_as_read' | translate }}"}>
       %i.fa.fa-check>
     %button.thread-preview__mute{ng-click: "changeVolume('mute')", ng-show: "!thread.isMuted()", title: "{{ 'volume_levels.mute' | translate }}" }>

--- a/angular/test/protractor/group_spec.coffee
+++ b/angular/test/protractor/group_spec.coffee
@@ -12,6 +12,11 @@ describe 'Group Page', ->
         page.expectElement('link[rel=prev]')
         page.expectElement('link[rel=next]')
 
+      it 'does not allow mark as read or mute', ->
+        page.loadPath('view_open_group_as_visitor')
+        page.expectNoElement('.thread-preview__mark-as-read')
+        page.expectNoElement('.thread-preview__mute')
+
     describe 'see joining option for each privacy type', ->
       it 'secret group', ->
         page.loadPath('view_secret_group_as_non_member')


### PR DESCRIPTION
I think this just needs a quick once-over CR; works for me on `development/view_open_group_as_visitor`