### PR TITLE
Add motion_closed and motion_closed_by_user to salient items

### DIFF
--- a/app/models/discussion.rb
+++ b/app/models/discussion.rb
@@ -1,6 +1,11 @@
 class Discussion < ActiveRecord::Base
   PER_PAGE = 50
-  SALIENT_ITEM_KINDS = %w[new_comment new_motion new_vote motion_outcome_created]
+  SALIENT_ITEM_KINDS = %w[new_comment
+                          new_motion
+                          new_vote
+                          motion_closed
+                          motion_closed_by_user
+                          motion_outcome_created]
   THREAD_ITEM_KINDS = %w[new_comment
                          new_motion
                          new_vote

--- a/config/initializers/event_bus.rb
+++ b/config/initializers/event_bus.rb
@@ -43,7 +43,9 @@ EventBus.configure do |config|
   # update discussion reader after thread item creation
   config.listen('new_comment_event',
                 'new_motion_event',
-                'new_vote_event') do |event|
+                'new_vote_event',
+                'motion_closed_event',
+                'motion_closed_by_user_event') do |event|
     DiscussionReader.for_model(event.eventable).author_thread_item!(event.created_at)
   end
 


### PR DESCRIPTION
Addresses https://github.com/loomio/loomio/issues/3109

Does this need tests around it @gdpelican? Also, I noticed while I was testing it locally that it seemed like some of my own activity was showing up as unread. Will try and investigate further.