### PR TITLE
Handle Module::DelegationError errors from Comment via email

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -215,7 +215,7 @@ class Ability
     end
 
     can [:create], Comment do |comment|
-      user_is_member_of?(comment.group.id)
+      comment.discussion && user_is_member_of?(comment.group.id)
     end
 
     can [:update], Comment do |comment|


### PR DESCRIPTION
We're seeing a few Module::DelegationErrors and I think this might be a good way to deal with them.

Check the discussion exists as part of permissions checking, so failure to reference existing discussion results in unauthorised.

http://errbit.loomio.org/apps/56f0588e31323900110002ad/problems/5717bc276572720248000034