### PR TITLE
Make previous proposal titles on group page link to the proposal

### DIFF
--- a/angular/core/components/group_page/group_previous_proposals_card/group_previous_proposals_card.haml
+++ b/angular/core/components/group_page/group_previous_proposals_card/group_previous_proposals_card.haml
@@ -4,7 +4,7 @@
     %ul.group-previous-proposals-card__previous_proposals
       %li.group-previous-proposals-card__previous_proposal{ng-repeat: "proposal in group.closedProposals() | limitTo: 3 track by proposal.id"}
         %pie_with_position.pull-left{proposal: "proposal"}
-        %a{lmo-href-for: "group", lmo-href-action: "previous_proposals"}
+        %a{lmo-href-for: "group", lmo-href-for: "proposal"}
           .group-previous-proposals-card__proposal-title
             {{proposal.name}}
     %a.group-previous-proposals-card__link.lmo-card-minor-action{lmo-href-for: "group", lmo-href-action: "previous_proposals"}


### PR DESCRIPTION
… rather than to the previous proposals page.

Care to test it @HSalmon ?