### PR TITLE
List coordinators first for admin and non-admin memberships panel

### DIFF
--- a/angular/core/components/memberships_page/memberships_panel/memberships_panel.haml
+++ b/angular/core/components/memberships_page/memberships_panel/memberships_panel.haml
@@ -1,6 +1,6 @@
 .blank
   .row.memberships-page__table-row
-  .row.memberships-page__table-row.memberships-page__membership{ng-repeat: "membership in memberships() track by membership.id"}
+  .row.memberships-page__table-row.memberships-page__membership{ng-repeat: "membership in memberships() | orderBy: '-admin' track by membership.id", data-username: "{{membership.user().username}}"}
     .col-xs-8
       .media
         .media-left.hidden-xs


### PR DESCRIPTION
Looks like they were only ordered with coordinators first on the admin_memberships_panel, not the memberships_panel. Have updated.

Addresses: https://github.com/loomio/loomio/issues/3274