### PR TITLE
Add reference to replied-to-comment in comment replies

### DIFF
--- a/angular/core/components/thread_page/activity_card/new_comment.haml
+++ b/angular/core/components/thread_page/activity_card/new_comment.haml
@@ -15,10 +15,12 @@
     .media-left
       %user_avatar{user: "comment.author()", size: "small"}
     .media-body
-      %h3.new-comment__in-reply-to{ng-if: "comment.parentId", id: "event-{{event.id}}"}
+      %h3.new-comment__replied-to{ng-if: "comment.parentId", id: "event-{{event.id}}"}
         %strong
           %a{lmo-href-for: "comment.author()"}> {{ comment.authorName() }}
-        %span{translate: "new_comment_item.in_reply_to", translate-value-recipient: "{{comment.parentAuthorName}}"}
+        %span{translate: "new_comment_item.replied_to", translate-value-recipient: "{{comment.parentAuthorName}}"}
+        %a{lmo-href-for: "comment.parent()"}>
+          %span.new-comment__parent-comment{translate: "new_comment_item.comment"}
       %h3.new-comment__author-name{ng-if: "!comment.parentId"}
         %a{lmo-href-for: "comment.author()"}> {{ comment.authorName() }}
       .sr-only{ng-if: "!comment.parentId", id: "event-{{event.id}}", translate: "new_comment_item.aria_label", translate-value-author: "{{comment.authorName()}}"}

--- a/angular/core/components/thread_page/activity_card/new_comment.scss
+++ b/angular/core/components/thread_page/activity_card/new_comment.scss
@@ -3,6 +3,10 @@
   a { color: $primary-text-color; }
 }
 
-.new-comment__in-reply-to {
+.new-comment__replied-to {
   a { color: $primary-text-color; }
+}
+
+.new-comment__parent-comment {
+  color: $link-color;
 }

--- a/angular/test/protractor/discussion_spec.coffee
+++ b/angular/test/protractor/discussion_spec.coffee
@@ -118,11 +118,13 @@ describe 'Discussion Page', ->
       page.expectElement '.thread-item__body img'
 
     it 'replies to a comment', ->
-      threadPage.addComment('original comment right heerrr')
-      threadPage.replyLinkOnMostRecentComment().click()
-      threadPage.addComment('hi this is my comment')
-      expect(threadPage.inReplyToOnMostRecentComment()).toContain('in reply to')
-      expect(flashHelper.flashMessage()).toContain('Patrick Swayze notified of reply')
+      page.fillIn '.comment-form__comment-field', 'original comment right heerrr'
+      page.click '.comment-form__submit-button',
+                 '.thread-item__action--reply'
+      page.fillIn '.comment-form__comment-field', 'hi this is my comment'
+      page.click '.comment-form__submit-button'
+      page.expectText '.new-comment__replied-to', 'replied to'
+      page.expectFlash 'Patrick Swayze notified of reply'
 
     it 'likes a comment', ->
       threadPage.addComment('hi')

--- a/angular/test/protractor/helpers/thread_helper.coffee
+++ b/angular/test/protractor/helpers/thread_helper.coffee
@@ -63,12 +63,6 @@ module.exports = new class ThreadHelper
   mostRecentComment: ->
     element.all(By.css('.thread-item--comment')).last().getText()
 
-  replyLinkOnMostRecentComment: ->
-    element.all(By.css('.thread-item__action--reply')).last()
-
-  inReplyToOnMostRecentComment: ->
-    element.all(By.css('.new-comment__in-reply-to')).last().getText()
-
   likeLinkOnMostRecentComment: ->
     element.all(By.css('.thread-item__action--like')).last()
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -864,7 +864,8 @@ en:
       aria_label: 'Comment options'
       edit_comment: 'Edit comment'
       delete_comment: 'Delete comment'
-    in_reply_to: 'in reply to <strong>{{recipient}}</strong>'
+    replied_to: "replied to <strong>{{recipient}}</strong>'s"
+    comment: 'comment'
     edited: 'Edited'
 
   new_vote_item:


### PR DESCRIPTION
Thought this might be a good interim thing to implement while we consider more complicated options.

<img width="518" alt="screen shot 2016-05-02 at 2 56 43 pm" src="https://cloud.githubusercontent.com/assets/2882097/14946444/5dab3e4a-1076-11e6-83e0-ef0c737d88d5.png">


[Trello card](https://trello.com/c/7whXZS1b/1326-add-reference-to-replied-to-comment-in-comment-replies)
[Loomio discussion](https://www.loomio.org/d/lCfoxy9v/ux-replies-to-comments)



