### PR TITLE
fix missed yesterday blowing up because of crazy tz value

### DIFF
--- a/app/extras/send_missed_yesterday_email.rb
+++ b/app/extras/send_missed_yesterday_email.rb
@@ -1,6 +1,7 @@
 class SendMissedYesterdayEmail
   def self.to_subscribers!
     zones = User.pluck('DISTINCT time_zone').select do |zone|
+      Time.find_zone(zone) &&
       DateTime.now.in_time_zone(zone).hour == 6
     end
 


### PR DESCRIPTION
I think this will fix:
https://errbit.loomio.io/apps/57215524657272000e000001/problems/572a9da36572720010000a8b

ArgumentError
App: loomio.org Where: rake#loomio:send_missed_yesterday_email 
Environment: production Last Notice: May 05 10:10:41
activesupport-4.2.5.2/lib/active_support/core_ext/time/zones.rb:72→ rescue in find_zone!
activesupport-4.2.5.2/lib/active_support/core_ext/time/zones.rb:56→ find_zone!
activesupport-4.2.5.2/lib/active_support/core_ext/date_and_time/zones.rb:20→ in_time_zone
app/extras/send_missed_yesterday_email.rb:4→ block in to_subscribers!
app/extras/send_missed_yesterday_email.rb:3→ select
app/extras/send_missed_yesterday_email.rb:3→ to_subscribers!
lib/tasks/loomio.rake:22→ block (2 levels) in <top (required)>