### PR TITLE
Don't allow comment input while submitting

### DIFF
--- a/angular/core/components/thread_page/comment_form/comment_form.haml
+++ b/angular/core/components/thread_page/comment_form/comment_form.haml
@@ -6,7 +6,7 @@
       %h2.lmo-card-heading#comment-form-title{translate: "comment_form.aria_label"}>
       %span{translate: "comment_form.in_reply_to", translate-value-name: "{{comment.parent().authorName()}}", ng-show: "comment.parent().authorName()"}
       .lmo-relative
-        %textarea.lmo-textarea.form-control.comment-form__comment-field.lmo-primary-form-input{msd-elastic: "true", aria-labelledby: "comment-form-title", name: "body", placeholder: "Say something...", ng_model: "comment.body", mentio: true, mentio-trigger-char: "'@'", mentio_items: "mentionables", mentio-template-url: "generated/components/thread_page/comment_form/mentio_menu.html", mentio-search: "fetchByNameFragment(term)", mentio-id: "comment-field", ng-focus: "formInFocus()", ng-blur: "formLostFocus()", ng-model-options: "{ updateOn: 'default blur', debounce: {'default': 150, 'blur': 0} }"}
+        %textarea.lmo-textarea.form-control.comment-form__comment-field.lmo-primary-form-input{ng-disabled: "isDisabled", msd-elastic: "true", aria-labelledby: "comment-form-title", name: "body", placeholder: "Say something...", ng_model: "comment.body", mentio: true, mentio-trigger-char: "'@'", mentio_items: "mentionables", mentio-template-url: "generated/components/thread_page/comment_form/mentio_menu.html", mentio-search: "fetchByNameFragment(term)", mentio-id: "comment-field", ng-focus: "formInFocus()", ng-blur: "formLostFocus()", ng-model-options: "{ updateOn: 'default blur', debounce: {'default': 150, 'blur': 0} }"}
         %emoji_picker.lmo-action-dock{target-selector: "bodySelector"}
       %validation_errors{subject: "comment", field: "body"}
       .comment-row.comment-attachments{ng_repeat: "attachment in comment.newAttachments()"}


### PR DESCRIPTION
Fixes this issue:
http://g.recordit.co/ph9ByELSXs.gif

Which was occasionally causing drafts to get saved after submit, meaning they showed up after the comment was submitted.

(NB the only change here is adding `ng-disabled: "isDisabled"` to the comment form text area.)