### PR TITLE
Dockerfile: user warning redirecting to loomio-deploy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,9 @@
+#
+# Warning: this image is designed to be used with docker-compose as
+# instructed athttps://github.com/loomio/loomio-deploy
+#
+# It is not a standalone image.
+#
 FROM ruby:2.3.0
 ENV REFRESHED_AT 2015-08-07
 


### PR DESCRIPTION
Without this warning people may be inclined to assume that the
Dockerfile can be used as a standalone image.

Fixes #3330

Signed-off-by: Loic Dachary <loic@dachary.org>