### PR TITLE
Fix notify client deploy error

### DIFF
--- a/lib/tasks/deploy.rake
+++ b/lib/tasks/deploy.rake
@@ -110,7 +110,7 @@ namespace :deploy do
     run_commands [
       "#{cmd} run rake db:migrate -a #{remote}",                                      # Migrate Heroku DB
       "#{cmd} restart -a #{remote}",                                                  # Restart Heroku dynos
-      "#{cmd} run rake loomio:notify_clients_of_update -a #{remote}"                  # Notify clients of update
+      "#{cmd} run -a #{remote} rake loomio:notify_clients_of_update"                  # Notify clients of update
     ]
   end
 end


### PR DESCRIPTION
Currently, every time we deploy, the final step (notifying clients that a deploy has happened), logs this:

```
Running rake loomio:notify_clients_of_update on ⬢ <repo>... up, run.8228
rake aborted!
Don't know how to build task '<repo>' (see --tasks)
/Users/gdpelican/.rvm/gems/ruby-2.3.0/bin/ruby_executable_hooks:15:in `eval'
/Users/gdpelican/.rvm/gems/ruby-2.3.0/bin/ruby_executable_hooks:15:in `<main>'
(See full trace by running task with --trace)
```

This

a) works perfectly, and
b) is misleading and scary.

This removes that error so we just get a).