### PR TITLE
Let's see what happens when the flash stays up a bit longer

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -2,3 +2,4 @@ CANONICAL_HOST=localhost
 CANONICAL_PORT=3000
 SMTP_DOMAIN=localhost
 SUPPORT_EMAIL="support <support@localhost>"
+FLASH_TIMEOUT_SHORT=1000

--- a/.env.test
+++ b/.env.test
@@ -2,3 +2,4 @@ CANONICAL_HOST=localhost
 CANONICAL_PORT=3000
 SMTP_DOMAIN=loomio.example.org
 SUPPORT_EMAIL="support <support@loomio.example.org>"
+FLASH_TIMEOUT_SHORT=100000

--- a/angular/core/components/flash/flash_service.coffee
+++ b/angular/core/components/flash/flash_service.coffee
@@ -1,14 +1,11 @@
-angular.module('loomioApp').factory 'FlashService', ($rootScope) ->
+angular.module('loomioApp').factory 'FlashService', ($rootScope, AppConfig) ->
   new class FlashService
-
-    SHORT_TIME = 3500
-    LONG_TIME = 2147483645
 
     createFlashLevel = (level, duration) =>
       (translateKey, translateValues, actionKey, actionFn) =>
         $rootScope.$broadcast 'flashMessage',
           level:     level
-          duration:  duration or SHORT_TIME
+          duration:  duration or AppConfig.flashTimeout.short
           message:   translateKey
           options:   translateValues
           action:    actionKey
@@ -18,6 +15,6 @@ angular.module('loomioApp').factory 'FlashService', ($rootScope) ->
     info:    createFlashLevel 'info'
     warning: createFlashLevel 'warning'
     error:   createFlashLevel 'error'
-    loading: createFlashLevel 'loading', LONG_TIME
-    update:  createFlashLevel 'update', LONG_TIME
+    loading: createFlashLevel 'loading', AppConfig.flashTimeout.long
+    update:  createFlashLevel 'update', AppConfig.flashTimeout.long
     dismiss: createFlashLevel 'loading', 1

--- a/app/helpers/angular_helper.rb
+++ b/app/helpers/angular_helper.rb
@@ -41,6 +41,10 @@ module AngularHelper
         threadItems:       ENV['THREAD_PAGE_SIZE'],
         exploreGroups:     ENV['EXPLORE_PAGE_SIZE'] || 10
       },
+      flashTimeout: {
+        short: (ENV['FLASH_TIMEOUT_SHORT'] || 3500).to_i,
+        long:  (ENV['FLASH_TIMEOUT_LONG']  || 2147483645).to_i
+      },
       oauthProviders: [
         ({ name: :facebook, href: user_omniauth_authorize_path(:facebook) } if ENV['FACEBOOK_KEY']),
         ({ name: :twitter,  href: user_omniauth_authorize_path(:twitter)  } if ENV['TWITTER_KEY']),


### PR DESCRIPTION
This should fix some of the spurious / sporadic protractor errors, including

- `expected 'Welcome to the group!' but got ''`
- `expected page text to include 'Successfully signed in'`

(I believe there are others)