### PR TITLE
Serialize out commit hash with installed plugins

### DIFF
--- a/lib/plugins/base.rb
+++ b/lib/plugins/base.rb
@@ -9,7 +9,7 @@ module Plugins
 
   class Base
     attr_accessor :name, :installed
-    attr_reader :assets, :actions, :events, :outlets, :routes, :translations, :enabled
+    attr_reader :assets, :actions, :events, :outlets, :routes, :translations, :enabled, :commit
 
     def self.setup!(name)
       Repository.store new(name).tap { |plugin| yield plugin }
@@ -17,6 +17,7 @@ module Plugins
 
     def initialize(name)
       @name = name
+      @commit = `git rev-parse HEAD`
       @translations = {}
       @assets, @actions, @events, @outlets, @routes = Set.new, Set.new, Set.new, Set.new, Set.new
       @config = YAML.load_file([@name, 'config.yml'].join('/'))


### PR DESCRIPTION
This allows us to serialize out the commit hash of each installed plugin, which will greatly help with debugging plugin issues.
![screen shot 2016-07-08 at 2 00 04 am](https://cloud.githubusercontent.com/assets/750477/16678733/d744a5da-44af-11e6-916b-6395969dd46f.png)
