### PR TITLE
Revert "Display thread preview link in flex"

### DIFF
--- a/angular/core/components/thread_preview/thread_preview.scss
+++ b/angular/core/components/thread_preview/thread_preview.scss
@@ -47,7 +47,7 @@
 }
 
 .thread-preview__link {
-  @include displayFlex;
+  display: block;
   padding: $thinPaddingSize $cardPaddingSize;
   color: $primary-text-color;
   text-decoration: none;


### PR DESCRIPTION
Reverts loomio/loomio#3515

This breaks text overflow on thread collection preview and was only put in for groups with tags. I'll find another way.