### PR TITLE
People misinterpret the markdown help

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -320,7 +320,7 @@ en:
       body: |
         Repeat out loud:
 
-        Square brackets for name then round brackets for URL.
+        Square brackets for name then round brackets for URL. There's no spaces between the brackets.
 
         [Loomio Homepage](https://www.loomio.org/)
 


### PR DESCRIPTION
I've seen a couple times where people think that there is supposed to be a space between the brackets. I think the problem is that the `monospace font makes all the characters the same width so it looks a bit like a space between the brackets []()`. 

I reckon this little tweak should help.