### PR TITLE
Fix race condition on last read item

### DIFF
--- a/app/models/discussion_reader.rb
+++ b/app/models/discussion_reader.rb
@@ -61,26 +61,20 @@ class DiscussionReader < ActiveRecord::Base
     end
   end
 
-  def viewed!(age_of_last_read_item = nil)
-    return if user.nil?
-    read_at = age_of_last_read_item || discussion.last_activity_at
+  def viewed!(read_at = discussion.last_activity_at)
+    return if user.nil? || (self.last_read_at && self.last_read_at >= read_at)
 
-    if self.last_read_at.nil? or (read_at >= self.last_read_at)
-      self.last_read_at = read_at
-      reset_counts!
-    end
-
+    reset_counts! read_at
     EventBus.broadcast('discussion_reader_viewed!', discussion, user)
   end
 
-  def reset_counts!
-    self.read_items_count = read_items.count
-    self.read_salient_items_count = read_salient_items.count
-    self.last_read_sequence_id = if read_items_count == 0
-                                   0
-                                 else
-                                   read_items.last.sequence_id
-                                 end
+  def reset_counts!(read_at = self.last_read_at)
+    assign_attributes(
+      last_read_at:             [self.last_read_at, read_at].compact.max,
+      last_read_sequence_id:    self.read_items(read_at).maximum(:sequence_id).to_i,
+      read_items_count:         self.read_items(read_at).count,
+      read_salient_items_count: self.read_salient_items(read_at).count
+    )
     save!(validate: false)
   end
 

--- a/spec/models/discussion_reader_spec.rb
+++ b/spec/models/discussion_reader_spec.rb
@@ -27,4 +27,52 @@ describe DiscussionReader do
     end
   end
 
+  describe 'reset_counts!' do
+    let!(:other_membership) { create(:membership, user: other_user, group: group) }
+    let!(:older_item) { CommentService.create(comment: build(:comment, discussion: discussion, created_at: 5.days.ago), actor: other_user) }
+    let!(:newer_item) { CommentService.create(comment: build(:comment, discussion: discussion, created_at: 2.days.ago), actor: other_user) }
+    before do
+      reader.update(last_read_at: 4.days.ago,
+                    last_read_sequence_id: 0,
+                    read_items_count: 0,
+                    read_salient_items_count: 0)
+    end
+
+    it 'updates the counts correctly from existing last_read_at' do
+      reader.reset_counts!
+      expect(reader.last_read_sequence_id).to eq 1
+      expect(reader.read_items_count).to eq 1
+      expect(reader.read_salient_items_count).to eq 1
+    end
+
+    it 'updates the existing counts correctly from a given last_read_at' do
+      reader.reset_counts!(3.days.ago)
+      expect(reader.last_read_sequence_id).to eq 1
+      expect(reader.read_items_count).to eq 1
+      expect(reader.read_salient_items_count).to eq 1
+    end
+
+    it 'updates the existing counts correctly from a recent last_read_at' do
+      reader.reset_counts!(1.day.ago)
+      expect(reader.last_read_sequence_id).to eq 2
+      expect(reader.read_items_count).to eq 2
+      expect(reader.read_salient_items_count).to eq 2
+    end
+
+    it 'does not do anything for an old last_read_at' do
+      reader.reset_counts!(6.days.ago)
+      expect(reader.last_read_sequence_id).to eq 0
+      expect(reader.read_items_count).to eq 0
+      expect(reader.read_salient_items_count).to eq 0
+    end
+
+    it 'does not do anything if last_read_at does not exist and is not given' do
+      reader.update(last_read_at: nil)
+      reader.reset_counts!
+      expect(reader.last_read_sequence_id).to eq 0
+      expect(reader.read_items_count).to eq 0
+      expect(reader.read_salient_items_count).to eq 0
+    end
+  end
+
 end


### PR DESCRIPTION
This should fix the issue I'm seeing occasionally where the last unread item is being skipped, resulting in this the last unread line appearing at the end of the thread, with no way to clear the unread item.

I want to test this some more, so don't merge just yet.