### PR TITLE
Update intercom_service.coffee

### DIFF
--- a/angular/core/services/intercom_service.coffee
+++ b/angular/core/services/intercom_service.coffee
@@ -5,7 +5,7 @@ angular.module('loomioApp').factory 'IntercomService', ($rootScope, $window, App
     key: group.key
     name: group.name
     description: group.description.substring(0, 250)
-    admin_link: AppConfig.baseUrl+"/admin/groups/#{group.key}"
+    admin_link: AppConfig.baseUrl+"admin/groups/#{group.key}"
     subscription_kind: group.subscriptionKind
     subscription_plan: group.subscriptionPlan
     subscription_expires_at: group.subscriptionExpiresAt


### PR DESCRIPTION
Remove extra slash. Currently being sent thru as "admin_link":"https://www.loomio.org//admin/groups/VKlSony8"