### PR TITLE
Add start group option to sidebar

### DIFF
--- a/angular/core/components/sidebar/sidebar.coffee
+++ b/angular/core/components/sidebar/sidebar.coffee
@@ -3,7 +3,7 @@ angular.module('loomioApp').directive 'sidebar', ->
   restrict: 'E'
   templateUrl: 'generated/components/sidebar/sidebar.html'
   replace: true
-  controller: ($scope, Session, $rootScope, $window, RestfulClient, $mdMedia, ThreadQueryService, UserHelpService, AppConfig, IntercomService, $mdSidenav, LmoUrlService, Records) ->
+  controller: ($scope, Session, $rootScope, $window, RestfulClient, $mdMedia, ThreadQueryService, UserHelpService, AppConfig, IntercomService, $mdSidenav, LmoUrlService, Records, ModalService, GroupForm) ->
     $scope.showSidebar = $mdMedia("gt-md")
     $scope.currentState = ""
 
@@ -46,3 +46,6 @@ angular.module('loomioApp').directive 'sidebar', ->
 
     $scope.currentUser = ->
       Session.user()
+
+    $scope.startGroup = ->
+      ModalService.open GroupForm, group: -> Records.groups.build()

--- a/angular/core/components/sidebar/sidebar.haml
+++ b/angular/core/components/sidebar/sidebar.haml
@@ -36,6 +36,10 @@
             %span {{group.name}}
           .sidebar__list-item-padding
         %md_list_item
+          %md_button.sidebar__list-item-button.sidebar__list-item-button--explore{href: "#", ng-click: "startGroup()", aria-label: "{{ 'sidebar.start_group' | translate }}"}
+            %md_avatar_icon.sidebar__list-item-icon.i.fa.fa-lg.fa-plus
+            %span{translate: "sidebar.start_group"}
+        %md_list_item
           %md_button.sidebar__list-item-button.sidebar__list-item-button--explore{href: "#", lmo-href: "/explore", aria-label: "{{ 'sidebar.explore' | translate }}", ng-class: "{'sidebar__list-item--selected': onPage('explorePage')}"}
             %md_avatar_icon.sidebar__list-item-icon.i.fa.fa-lg.fa-globe
             %span{translate: "sidebar.explore"}

--- a/angular/core/components/sidebar/sidebar.haml
+++ b/angular/core/components/sidebar/sidebar.haml
@@ -36,7 +36,7 @@
             %span {{group.name}}
           .sidebar__list-item-padding
         %md_list_item
-          %md_button.sidebar__list-item-button.sidebar__list-item-button--explore{href: "#", ng-click: "startGroup()", aria-label: "{{ 'sidebar.start_group' | translate }}"}
+          %md_button.sidebar__list-item-button.sidebar__list-item-button--start-group{href: "#", ng-click: "startGroup()", aria-label: "{{ 'sidebar.start_group' | translate }}"}
             %md_avatar_icon.sidebar__list-item-icon.i.fa.fa-lg.fa-plus
             %span{translate: "sidebar.start_group"}
         %md_list_item

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -211,6 +211,7 @@ en:
     recent: 'Recent'
     unread: 'Unread'
     muted: 'Muted'
+    start_group: 'Start new group'
     explore: 'Public groups'
     edit_profile: 'Edit profile'
     email_settings: 'Email settings'


### PR DESCRIPTION
[Trello card](https://trello.com/c/v6NpQG2k/1815-1-start-group-is-less-obvious-now-add-to-sidebar)

![start-group-sidebar](https://cloud.githubusercontent.com/assets/2882097/17685143/7cada7fa-63b5-11e6-88f7-df8984271cff.gif)
