### PR TITLE
Adjustments to weekly analytics emails

### DIFF
--- a/app/assets/stylesheets/email.css
+++ b/app/assets/stylesheets/email.css
@@ -175,3 +175,7 @@ body { max-width: 600px; font-family: 'FontAwesome',"HelveticaNeue", "Helvetica 
   color: #666;
   font-size: small;
 }
+
+.align-left {
+  text-align: left;
+}

--- a/app/extras/queries/group_analytics.rb
+++ b/app/extras/queries/group_analytics.rb
@@ -19,7 +19,8 @@ class Queries::GroupAnalytics
       active_members:     pluralize(active_users.count, 'member'),
       active_users:       active_users.map  { |u| activity_for(u) }
                                       .sort { |a,b| b[:motions_created] <=> a[:motions_created]}
-                                      .take(10)
+                                      .take(10),
+      has_activity:       eventables[:all].count > 0
     }
   end
 

--- a/app/jobs/send_analytics_email_job.rb
+++ b/app/jobs/send_analytics_email_job.rb
@@ -1,9 +1,8 @@
 class SendAnalyticsEmailJob < ActiveJob::Base
   def perform
     Group.with_analytics.find_each do |group|
-      stats = Queries::GroupAnalytics.new(group: group).stats
       BaseMailer.send_bulk_mail(to: group.admins) do |user|
-        UserMailer.delay(priority: 10).analytics(user: user, group: group, stats: stats)
+        UserMailer.delay(priority: 10).analytics(user: user, group: group)
       end
     end
   end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -50,9 +50,9 @@ class UserMailer < BaseMailer
                      locale: locale_fallback(user.try(:locale), inviter.try(:locale))
   end
 
-  def analytics(user:, group:, stats: nil)
+  def analytics(user:, group:)
     @user, @group = user, group
-    @stats = stats || Queries::GroupAnalytics.new(group: group).stats
+    @stats = Queries::GroupAnalytics.new(group: group).stats
     send_single_mail to: @user.email,
                      subject_key: "email.analytics.subject",
                      subject_params: { which_group: @group.name },

--- a/app/views/user_mailer/analytics.html.haml
+++ b/app/views/user_mailer/analytics.html.haml
@@ -1,4 +1,4 @@
-%h2= t(:"email.analytics.title", since: @stats[:since].strftime('%m/%d'), till:  @stats[:till].strftime('%m/%d'))
+%h2= t(:"email.analytics.title", since: @stats[:since].strftime('%d %B'))
 
 %p= raw t(:"email.analytics.stats", @stats)
 

--- a/app/views/user_mailer/analytics.html.haml
+++ b/app/views/user_mailer/analytics.html.haml
@@ -2,23 +2,26 @@
 
 %p= raw t(:"email.analytics.stats", @stats)
 
-%table.stats-table
-  %thead
-    %th
-    %th= t(:"email.analytics.user_table.motions_created")
-    %th= t(:"email.analytics.user_table.discussions_created")
-    %th= t(:"email.analytics.user_table.comments_created")
-    %th= t(:"email.analytics.user_table.votes_created")
-  %tbody
-    - @stats[:active_users].each do |u|
-      %tr
-        %td= u[:name]
-        %td= (u[:motions_created]     if u[:motions_created] > 0)
-        %td= (u[:discussions_created] if u[:discussions_created] > 0)
-        %td= (u[:comments_created]    if u[:comments_created] > 0)
-        %td= (u[:votes_created]       if u[:votes_created] > 0)
+- if @stats[:has_activity]
+  %table.stats-table
+    %thead
+      %th
+      %th= t(:"email.analytics.user_table.motions_created")
+      %th= t(:"email.analytics.user_table.discussions_created")
+      %th= t(:"email.analytics.user_table.comments_created")
+      %th= t(:"email.analytics.user_table.votes_created")
+    %tbody
+      - @stats[:active_users].each do |u|
+        %tr
+          %td= u[:name]
+          %td= (u[:motions_created]     if u[:motions_created] > 0)
+          %td= (u[:discussions_created] if u[:discussions_created] > 0)
+          %td= (u[:comments_created]    if u[:comments_created] > 0)
+          %td= (u[:votes_created]       if u[:votes_created] > 0)
 
-%p= raw t(:"email.analytics.contact_us", contact_link: contact_url)
+  %p= raw t(:"email.analytics.contact_us", contact_link: contact_url)
+- else
+  %p= raw t(:"email.analytics.no_activity", contact_link: contact_url)
 
 - if @stats[:is_trial]
   - if @stats[:expires_at] > Time.zone.now

--- a/app/views/user_mailer/analytics.html.haml
+++ b/app/views/user_mailer/analytics.html.haml
@@ -13,7 +13,7 @@
     %tbody
       - @stats[:active_users].each do |u|
         %tr
-          %td= u[:name]
+          %td.align-left= u[:name]
           %td= (u[:motions_created]     if u[:motions_created] > 0)
           %td= (u[:discussions_created] if u[:discussions_created] > 0)
           %td= (u[:comments_created]    if u[:comments_created] > 0)

--- a/app/views/user_mailer/analytics.text.haml
+++ b/app/views/user_mailer/analytics.text.haml
@@ -3,7 +3,7 @@
 
 = raw t(:"email.analytics.stats", @stats)
 
-- if @stats.has_activity
+- if @stats[:has_activity]
   = "Name | Motions created | Discussions created | Comments created | Votes created"
   = '---------------------------------------------------------------------------'
 

--- a/app/views/user_mailer/analytics.text.haml
+++ b/app/views/user_mailer/analytics.text.haml
@@ -3,14 +3,17 @@
 
 = raw t(:"email.analytics.stats", @stats)
 
-= "Name | Motions created | Discussions created | Comments created | Votes created"
-= '---------------------------------------------------------------------------'
+- if @stats.has_activity
+  = "Name | Motions created | Discussions created | Comments created | Votes created"
+  = '---------------------------------------------------------------------------'
 
-- @stats[:active_users].each do |u|
-  = "#{u[:name]}|#{u[:motions_created]}|#{u[:discussions_created]}|#{u[:comments_created]}|#{u[:votes_created]}"
+  - @stats[:active_users].each do |u|
+    = "#{u[:name]}|#{u[:motions_created]}|#{u[:discussions_created]}|#{u[:comments_created]}|#{u[:votes_created]}"
 
 
-= raw t(:"email.analytics.contact_us", contact_link: contact_url)
+  = raw t(:"email.analytics.contact_us", contact_link: contact_url)
+- else
+  = raw t(:"email.analytics.no_activity", contact_link: contact_url)
 
 - if @stats[:is_trial]
   - if @stats[:expires_at] > Time.zone.now

--- a/app/views/user_mailer/analytics.text.haml
+++ b/app/views/user_mailer/analytics.text.haml
@@ -4,7 +4,7 @@
 = raw t(:"email.analytics.stats", @stats)
 
 - if @stats[:has_activity]
-  = "Name | Motions created | Discussions created | Comments created | Votes created"
+  = raw t(:"email.analytics.table_header")
   = '---------------------------------------------------------------------------'
 
   - @stats[:active_users].each do |u|

--- a/app/views/user_mailer/analytics.text.haml
+++ b/app/views/user_mailer/analytics.text.haml
@@ -1,4 +1,4 @@
-= "Your weekly summary for #{@stats[:since].strftime('%m/%d')} - #{@stats[:till].strftime('%m/%d')}"
+= raw t(:"email.analytics.title", since: @stats[:since].strftime('%d %B'))
 = '---------------------------------------------------------------------------'
 
 = raw t(:"email.analytics.stats", @stats)

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -131,7 +131,7 @@ en:
       you_agreed: You %{past_tense_position}
     analytics:
       subject: "%{which_group}'s week on Loomio"
-      title: "Your weekly summary for %{since} - %{till}"
+      title: "Your summary for the week starting %{since}"
       stats: "<strong>%{active_members}</strong> out of <strong>%{group_members}</strong> in your group were active in the last week. Your group raised <strong>%{motions}</strong> and made <strong>%{comments}</strong> in <strong>%{discussions}</strong>."
       contact_us: "Looking for more stats? <a href='%{contact_link}'>Get in touch</a>."
       trial_subscription: "%{which_group} is on a <strong>free trial</strong> ending <strong>%{expires_at}</strong>. You can choose a subscription plan <a href='%{subscription_link}'>here</a>."

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -134,6 +134,7 @@ en:
       title: "Your summary for the week starting %{since}"
       stats: "<strong>%{active_members}</strong> out of <strong>%{group_members}</strong> in your group were active in the last week. Your group raised <strong>%{motions}</strong> and made <strong>%{comments}</strong> in <strong>%{discussions}</strong>."
       contact_us: "Looking for more stats? <a href='%{contact_link}'>Get in touch</a>."
+      no_activity: "Want to talk with one of our collaboration coaches about getting the most out of Loomio? <a href='%{contact_link}'>Get in touch</a>"
       trial_subscription: "%{which_group} is on a <strong>free trial</strong> ending <strong>%{expires_at}</strong>. You can choose a subscription plan <a href='%{subscription_link}'>here</a>."
       trial_expired: "%{which_group} has reached the end of its free Loomio trial. "
       heart: "❤ from team Loomio"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -132,6 +132,7 @@ en:
     analytics:
       subject: "%{which_group}'s week on Loomio"
       title: "Your summary for the week starting %{since}"
+      table_header: "Name | Motions created | Discussions created | Comments created | Votes created"
       stats: "<strong>%{active_members}</strong> out of <strong>%{group_members}</strong> in your group were active in the last week. Your group raised <strong>%{motions}</strong> and made <strong>%{comments}</strong> in <strong>%{discussions}</strong>."
       contact_us: "Looking for more stats? <a href='%{contact_link}'>Get in touch</a>."
       no_activity: "Want to talk with one of our collaboration coaches about getting the most out of Loomio? <a href='%{contact_link}'>Get in touch</a>"

--- a/spec/extras/queries/group_analytics_spec.rb
+++ b/spec/extras/queries/group_analytics_spec.rb
@@ -67,6 +67,15 @@ describe Queries::GroupAnalytics do
       expect(subject.stats[:discussions]).to eq "1 discussion thread"
     end
 
+    it 'sets has_activity to true when there is activity' do
+      new_comment_event
+      expect(subject.stats[:has_activity]).to eq true
+    end
+
+    it 'sets has_activity to false when there is no activity' do
+      expect(subject.stats[:has_activity]).to eq false
+    end
+
     it 'sorts users by their motion creation activity' do
       new_motion_event; another_user_motion_event; yet_another_user_motion_event
       expect(subject.stats[:active_users][0][:name]).to eq another_user.name


### PR DESCRIPTION
- Left aligned names in table
- Language tweak for title
- Replace table with contact us message in case of no activity
- Fix for admins with multiple analytics emails
