### PR TITLE
Reveal group subscription status in admin panel

### DIFF
--- a/app/admin/groups.rb
+++ b/app/admin/groups.rb
@@ -67,10 +67,12 @@ ActiveAdmin.register Group do
     column :description, :sortable => :description do |group|
       group.description
     end
-    column :is_commercial
     column :archived_at
     column :analytics_enabled
     column :enable_experiments
+    column "Subscription" do |group|
+      group.subscription.kind if group.subscription
+    end
     actions
   end
 
@@ -79,6 +81,7 @@ ActiveAdmin.register Group do
       row :group_request
       row :standard_plan_link do link_to("standard subscription link", ChargifyService.standard_plan_url(group), target: '_blank' ) end
       row :plus_plan_link do link_to("plus subscription link", ChargifyService.plus_plan_url(group), target: '_blank') end
+      row('Subscription status') do |group| group.subscription.kind if group.subscription end
       group.attributes.each do |k,v|
         row k, v.inspect
       end


### PR DESCRIPTION
[Trello card](https://trello.com/c/4S4xQp3d/1673-2-reveal-subscription-status-for-groups-in-admin-group-list)
<img width="459" alt="screen shot 2016-08-29 at 12 32 22 pm" src="https://cloud.githubusercontent.com/assets/2882097/18039834/b7280aa2-6dfa-11e6-9eaf-3a2b0f4030c5.png">
<img width="1267" alt="screen shot 2016-08-29 at 12 32 34 pm" src="https://cloud.githubusercontent.com/assets/2882097/18039835/b72ef5d8-6dfa-11e6-87c6-34ffd8458591.png">
