### PR TITLE
Ensure group logos are always square on email settings page

### DIFF
--- a/angular/core/components/email_settings_page/email_settings_page.haml
+++ b/angular/core/components/email_settings_page/email_settings_page.haml
@@ -31,7 +31,7 @@
         %button.email-settings-page__change-default-link.lmo-btn-link{ng-click: "emailSettingsPage.changeDefaultMembershipVolume()", translate: "email_settings_page.change_default"}
         %ul.email-settings-page__groups
           %li.email-settings-page__group{ng-repeat: "group in emailSettingsPage.user.groups() track by group.id"}
-            %img.lmo-box--medium{ng-src: "{{group.logoUrl()}}"}
+            %group_avatar{group: "group", size: "medium"}
             .email-settings-page__group-details
               %strong.email-settings-page__group-name
                 %span{ng-if: "group.isSubgroup()"}>


### PR DESCRIPTION
Fix for: https://github.com/loomio/loomio/issues/3656

<img width="737" alt="screen shot 2016-08-30 at 12 34 42 pm" src="https://cloud.githubusercontent.com/assets/2882097/18072010/931f6f88-6eae-11e6-804d-4c45b17c2e6c.png">
