### PR TITLE
Remove broken translations from weekly email update

### DIFF
--- a/config/locales/server.es.yml
+++ b/config/locales/server.es.yml
@@ -135,7 +135,6 @@ es:
       you_agreed: 'Tú %{past_tense_position}'
     analytics:
       subject: 'semana de %{which_group} en Loomio'
-      title: 'Tu resumen semanal para %{since} - %{till}'
       stats: '<strong>%{active_members}</strong> de <strong>%{group_members}</strong> en tu grupo eran activos durante la semana pasada. Tu grupo presentó <strong>%{motions}</strong> e hizo <strong>%{comments}</strong> en <strong>%{discussions}</strong>.'
       contact_us: "Buscas mas estadísticas? <a href='%{contact_link}'>Contáctanos</a>."
       trial_subscription: "%{which_group} sigue con una <strong>prueba gratis</strong> hasta <strong>%{expires_at}</strong>. Se puede escoger un plan de suscripción <a href='%{subscription_link}'>aqui</a>."

--- a/config/locales/server.fr.yml
+++ b/config/locales/server.fr.yml
@@ -97,7 +97,6 @@ fr:
       you_agreed: 'Vous %{past_tense_position}'
     analytics:
       subject: 'Semaine de %{which_group} sur Loomio'
-      title: 'Votre résumé hebdomadaire pour %{since} - %{till}'
       contact_us: "Besoin de plus de stats ? <a href='%{contact_link}'>Contactez-nous</a>."
       heart: "❤ de l'équipe Loomio"
       user_table:

--- a/config/locales/server.nl-NL.yml
+++ b/config/locales/server.nl-NL.yml
@@ -84,7 +84,6 @@ nl-NL:
       you_agreed: 'Je %{past_tense_position}'
     analytics:
       subject: "%{which_group}'s week op Loomio"
-      title: 'Je wekelijkse samenvatting voor %{since} - %{till}'
       stats: '<strong>%{active_members}</strong> van <strong>%{group_members}</strong> in je groep waren in de afgelopen week actief. Je groep resulteerde in <strong>%{motions}</strong> en had <strong>%{comments}</strong> in <strong>%{discussions}</strong>.'
       heart: ❤ van team Loomio
       user_table:

--- a/config/locales/server.zh-TW.yml
+++ b/config/locales/server.zh-TW.yml
@@ -128,7 +128,6 @@ zh-TW:
       you_agreed: '您%{past_tense_position}'
     analytics:
       subject: '%{which_group} 在 Loomio 上的一週'
-      title: '您的 %{since} - %{till} 週總結'
       stats: '<strong>%{group_members}</strong> 中的 <strong>%{active_members}</strong> 在過去一週中在您的群組中相當活躍。您的群組提升了 <strong>%{motions}</strong> 並在<strong>%{discussions}</strong> 中做出了 <strong>%{comments}</strong>。'
       contact_us: "想看更多統計？<a href='%{contact_link}'>與我們聯絡</a>。"
       trial_subscription: "%{which_group} 目前<strong>免費試用</strong>結束於 <strong>%{expires_at}</strong>。您可以在<a href='%{subscription_link}'>這裡</a>選擇一個訂閱計畫。"


### PR DESCRIPTION
These were broken because we changed the variables passed into them. 