### PR TITLE
Ensure parents of orphan subgroups are visible in sidebar

### DIFF
--- a/angular/core/components/sidebar/sidebar.coffee
+++ b/angular/core/components/sidebar/sidebar.coffee
@@ -42,7 +42,7 @@ angular.module('loomioApp').directive 'sidebar', ->
         $mdSidenav('left').close()
 
     $scope.groups = ->
-      Session.user().groups()
+      Session.user().groups().concat(Session.user().orphanParents())
 
     $scope.currentUser = ->
       Session.user()

--- a/angular/core/models/user_model.coffee
+++ b/angular/core/models/user_model.coffee
@@ -42,6 +42,10 @@ angular.module('loomioApp').factory 'UserModel', (BaseModel, AppConfig) ->
       _.filter @groups(), (group) =>
         group.isSubgroup() and !@isMemberOf(group.parent())
 
+    orphanParents: ->
+       _.map @orphanSubgroups(), (group) =>
+        group.parent()
+
     isAuthorOf: (object) ->
       @id == object.authorId
 


### PR DESCRIPTION
Fix for: https://github.com/loomio/loomio/issues/3653
<img width="1025" alt="screen shot 2016-08-31 at 1 13 31 pm" src="https://cloud.githubusercontent.com/assets/2882097/18112614/086154c2-6f7d-11e6-8dec-4fe798e1a150.png">


<img width="1020" alt="screen shot 2016-08-31 at 1 13 47 pm" src="https://cloud.githubusercontent.com/assets/2882097/18112615/0861cd30-6f7d-11e6-9f76-8ec746fabd43.png">

