### PR TITLE
Admin moving of group from admin panel

### DIFF
--- a/angular/core/css/1_utilities.scss
+++ b/angular/core/css/1_utilities.scss
@@ -274,10 +274,6 @@ img.emojione {
   height: 25px;
 }
 
-.md-dialog-container {
-  z-index: 10000000000;
-}
-
 @keyframes fadeIn {
   0% {
     opacity: 0;

--- a/angular/core/css/1_utilities.scss
+++ b/angular/core/css/1_utilities.scss
@@ -274,6 +274,10 @@ img.emojione {
   height: 25px;
 }
 
+.md-dialog-container {
+  z-index: 10000000000;
+}
+
 @keyframes fadeIn {
   0% {
     opacity: 0;

--- a/app/admin/groups.rb
+++ b/app/admin/groups.rb
@@ -145,7 +145,7 @@ ActiveAdmin.register Group do
 
     panel 'Move group' do
       form action: move_admin_group_path(group), method: :post do |f|
-        f.label "Parent group id"
+        f.label "Parent group id / key"
         f.input name: :parent_id, value: group.parent_id
         f.input type: :submit, value: "Move group"
       end
@@ -176,7 +176,7 @@ ActiveAdmin.register Group do
 
   member_action :move, method: :post do
     group = Group.friendly.find(params[:id])
-    if parent = Group.friendly.find_by(id: params[:parent_id])
+    if parent = Group.find_by(key: params[:parent_id]) || Group.find_by(id: params[:parent_id].to_i)
       group.subscription&.destroy
       group.update(parent: parent)
     end

--- a/app/admin/groups.rb
+++ b/app/admin/groups.rb
@@ -142,6 +142,15 @@ ActiveAdmin.register Group do
         link_to 'Unarchive this group', unarchive_admin_group_path(group), method: :post, data: {confirm: "Are you sure you wanna unarchive #{group.name}, pal?"}
       end
     end
+
+    panel 'Move group' do
+      form action: move_admin_group_path(group), method: :post do |f|
+        f.label "Parent group id"
+        f.input name: :parent_id, value: group.parent_id
+        f.input type: :submit, value: "Move group"
+      end
+    end
+
     active_admin_comments
   end
 
@@ -163,6 +172,15 @@ ActiveAdmin.register Group do
 
   collection_action :massey_data, method: :get do
     render json: Group.visible_to_public.pluck(:id, :parent_id, :name, :description)
+  end
+
+  member_action :move, method: :post do
+    group = Group.friendly.find(params[:id])
+    if parent = Group.friendly.find_by(id: params[:parent_id])
+      group.subscription&.destroy
+      group.update(parent: parent)
+    end
+    redirect_to admin_group_path(group)
   end
 
   member_action :archive, :method => :post do


### PR DESCRIPTION
![screen shot 2016-09-12 at 5 47 06 am](https://cloud.githubusercontent.com/assets/750477/18424921/60b81236-78ac-11e6-961e-8019c423e08c.png)

NB: This only covers moving an existing parent or subgroup to another parent; it does not support making a subgroup it's own parent group. The input will display the parent group's ID, but you can input either a group id or a group key and it will update correctly.

cc @natiloomio 