### PR TITLE
Move thread preview to flex

### DIFF
--- a/angular/core/components/thread_preview/thread_preview.scss
+++ b/angular/core/components/thread_preview/thread_preview.scss
@@ -51,6 +51,7 @@
   padding: $thinPaddingSize $cardPaddingSize;
   color: $primary-text-color;
   text-decoration: none;
+  @include displayFlex;
 }
 
 .thread-preview__link:hover {
@@ -60,7 +61,6 @@
 
 .thread-preview__icon {
   @include boxMedium;
-  float: left;
 }
 
 .thread-preview__pie-canvas {


### PR DESCRIPTION
Before:
![screen shot 2016-09-13 at 3 23 05 pm](https://cloud.githubusercontent.com/assets/750477/18477619/3733405a-79c6-11e6-882a-03cd9afc58b5.png)

After:
![screen shot 2016-09-13 at 3 22 39 pm](https://cloud.githubusercontent.com/assets/750477/18477623/3c141edc-79c6-11e6-9b2e-00adfcb4db33.png)

# QA Checklist

### Browser Compatibility

desktop:

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] IE/Edge

mobile:

- [ ] chrome
- [ ] firefox
- [ ] safari