### PR TITLE
Remember me by default

### DIFF
--- a/angular/core/components/sign_in_form/sign_in_form.coffee
+++ b/angular/core/components/sign_in_form/sign_in_form.coffee
@@ -1,7 +1,7 @@
 angular.module('loomioApp').factory 'SignInForm', ->
   templateUrl: 'generated/components/sign_in_form/sign_in_form.html'
   controller: ($scope, $location, $window, preventClose, KeyEventService, Session, AppConfig, Records, FormService) ->
-    $scope.session = Records.sessions.build(type: 'password')
+    $scope.session = Records.sessions.build(type: 'password', rememberMe: true)
     $scope.preventClose = preventClose
 
     KeyEventService.registerKeyEvent $scope, 'pressedEsc', (elem, e) ->

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -9,6 +9,7 @@ class Users::SessionsController < Devise::SessionsController
 
   def new
     super do |user|
+      resource.remember_me = true
       @invitation = invitation_from_session
       user.email = @invitation&.recipient_email
     end


### PR DESCRIPTION
For #3708 

- [ ] Setting 'remember me' remembers me
- [ ] Setting 'remember me' to false doesn't remember me
- [ ] Remember me is set as default on in-app login
- [ ] Remember me is set as default on /users/sign_in