### PR TITLE
add gtm id for marketing container

### DIFF
--- a/app/views/application/_google_analytics.html.haml
+++ b/app/views/application/_google_analytics.html.haml
@@ -1,7 +1,7 @@
-- if ENV['GOOGLE_TAG_MANAGER_ID']
+- if code
   :javascript
     (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
     j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     '//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','#{ENV["GOOGLE_TAG_MANAGER_ID"]}');
+    })(window,document,'script','dataLayer','#{code}');

--- a/app/views/layouts/angular.html.haml
+++ b/app/views/layouts/angular.html.haml
@@ -17,7 +17,7 @@
     %link{href: client_asset_path(:"print.min.css"), rel: 'stylesheet', media: 'print'}
 
     = render 'angular/metadata'
-    = render 'application/google_analytics'
+    = render 'application/google_analytics', code: ENV['GOOGLE_TAG_MANAGER_ID']
     = render 'angular/intercom' if current_user_or_visitor.is_logged_in?
 
   %body{'ng-keydown' => 'keyDown($event)', layout: "column", flex: ""}

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -10,7 +10,7 @@
     = theme_stylesheet_link_tag
     = csrf_meta_tags
     = render 'application/social_metadata', description: @meta_description, title: @meta_title
-    = render 'application/google_analytics'
+    = render 'application/google_analytics', code: ENV['GOOGLE_TAG_MANAGER_ID']
 
   %body{class: "pages #{controller_name} #{action_name}"}
     .navbar.navbar-top{role: 'navigation'}

--- a/app/views/layouts/pages.html.haml
+++ b/app/views/layouts/pages.html.haml
@@ -29,7 +29,7 @@
 
   = javascript_include_tag "//cdnjs.cloudflare.com/ajax/libs/jquery/3.0.0/jquery.min.js"
 
-  = render 'application/google_analytics'
+  = render 'application/google_analytics', code: ENV['GOOGLE_TAG_MANAGER_ID_FOR_MARKETING']
 
   %meta{'name' => 'viewport', 'content' => 'width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0'}
 


### PR DESCRIPTION
This adds support for using a seperate GTM ID on the marketing page.