### PR TITLE
Unify thread mailer footer link

### DIFF
--- a/app/helpers/email_helper.rb
+++ b/app/helpers/email_helper.rb
@@ -24,10 +24,6 @@ module EmailHelper
                                                   format: format)
   end
 
-  def comment_url_helper(comment)
-    discussion_url(comment.discussion, @utm_hash.merge(anchor: "comment-#{comment.id}"))
-  end
-
   def motion_closing_time_for(user)
     @motion.closing_at.in_time_zone(TimeZoneToCity.convert user.time_zone).strftime('%A %-d %b - %l:%M%P')
   end
@@ -52,9 +48,9 @@ module EmailHelper
     end
   end
 
-  def polymorphic_url(model)
+  def polymorphic_url(model, opts = {})
     case model
-    when Comment then comment_url_helper(model)
+    when Comment then comment_url(model.discussion, model, opts)
     else super
     end
   end

--- a/app/mailers/thread_mailer.rb
+++ b/app/mailers/thread_mailer.rb
@@ -9,7 +9,7 @@ class ThreadMailer < BaseMailer
     @event = event
     @discussion = event.eventable
     @author = @discussion.author
-    @link = discussion_url(@discussion, @utm_hash)
+    @link = polymorphic_url(@discussion, @utm_hash)
     send_thread_email
   end
 
@@ -19,7 +19,7 @@ class ThreadMailer < BaseMailer
     @comment = event.eventable
     @discussion = @comment.discussion
     @author = @comment.author
-    @link = comment_url_helper(@comment)
+    @link = polymorphic_url(@comment, @utm_hash)
     send_thread_email
   end
 
@@ -45,7 +45,7 @@ class ThreadMailer < BaseMailer
     @reply = event.eventable
     @discussion = @reply.discussion
     @author = @reply.author
-    @link = comment_url_helper(@reply)
+    @link = polymorphic_url(@reply, @utm_hash)
     send_thread_email(subject_key: 'email.comment_replied_to.subject',
                       subject_params: { who: @author.name,
                                         which: @discussion.group.full_name })
@@ -58,7 +58,7 @@ class ThreadMailer < BaseMailer
     @discussion = @vote.motion.discussion
     @author = @vote.author
     @motion = @vote.motion
-    @link = motion_url(@motion, @utm_hash)
+    @link = polymorphic_url(@motion, @utm_hash)
     send_thread_email
   end
 
@@ -69,7 +69,7 @@ class ThreadMailer < BaseMailer
     @discussion = @motion.discussion
     @author = @motion.author
     @group = @discussion.group
-    @link = motion_url(@motion, @utm_hash)
+    @link = polymorphic_url(@motion, @utm_hash)
     send_thread_email(subject_key: "email.new_motion_created.subject",
                       subject_params: {proposal_title: @motion.title})
   end
@@ -81,7 +81,7 @@ class ThreadMailer < BaseMailer
     @author = @motion.author
     @discussion = @motion.discussion
     @group = @discussion.group
-    @link = motion_url(@motion, @utm_hash)
+    @link = polymorphic_url(@motion, @utm_hash)
     send_thread_email(subject_key: "email.proposal_closing_soon.subject",
                       subject_params: {proposal_title: @motion.title})
   end
@@ -93,7 +93,7 @@ class ThreadMailer < BaseMailer
     @discussion = @motion.discussion
     @author = @motion.outcome_author
     @group = @motion.group
-    @link = motion_url(@motion, @utm_hash)
+    @link = polymorphic_url(@motion, @utm_hash)
     send_thread_email(subject_key: "email.proposal_outcome.subject",
                       subject_params: {motion: @motion.name})
   end
@@ -106,7 +106,7 @@ class ThreadMailer < BaseMailer
     @author = @motion.author
     @motion = @motion
     @group = @motion.group
-    @link = motion_url(@motion, @utm_hash)
+    @link = polymorphic_url(@motion, @utm_hash)
     send_thread_email(subject_key: "email.proposal_closed.subject",
                       subject_params: {which: @motion.name})
   end

--- a/spec/helpers/email_helper_spec.rb
+++ b/spec/helpers/email_helper_spec.rb
@@ -13,6 +13,29 @@ describe EmailHelper do
     end
   end
 
+  describe 'polymorphic_url' do
+    let(:group) { create :group }
+    let(:discussion) { create :discussion }
+    let(:comment) { create :comment }
+    let(:utm_hash) { { utm_medium: "wark" }}
+
+    it 'returns a discussion url' do
+      expect(helper.polymorphic_url(discussion)).to match "/d/#{discussion.key}"
+    end
+
+    it 'returns a group url' do
+      expect(helper.polymorphic_url(group)).to match "/g/#{group.key}"
+    end
+
+    it 'returns a comment url' do
+      expect(helper.polymorphic_url(comment)).to match "/d/#{comment.discussion.key}/comment/#{comment.id}"
+    end
+
+    it 'can accept a utm hash' do
+      expect(helper.polymorphic_url(comment, utm_hash)).to match "utm_medium=wark"
+    end
+  end
+
   describe 'time_formatted_relative_to_age' do
     let(:time){ Time.parse "2013-01-02 16:55:00 UTC" }
 


### PR DESCRIPTION
Ensure email footer links are always going to the right place
For #3690