### PR TITLE
Allow specifying subscription plans with plugins

### DIFF
--- a/angular/core/components/outlet/outlet.coffee
+++ b/angular/core/components/outlet/outlet.coffee
@@ -4,9 +4,22 @@ angular.module('loomioApp').directive 'outlet', ($compile, AppConfig) ->
   replace: true
   link: (scope, elem, attrs) ->
 
-    shouldCompile = (model, experimental) ->
-      return true if !experimental? or !model? or !model.group?
-      model.group().parentOrSelf().enableExperiments
+    shouldCompile = (outlet) ->
+      # model is not associated with a group
+      return true if !scope.model? or !scope.model.group?
+
+      # outlet is servicing a standard plugin
+      return true if !(outlet.experimental? or outlet.plans?)
+
+      group = scope.model.group().parentOrSelf()
+      # outlet is servicing an experimental plugin for an experiments enabled group
+      return true if outlet.experimental? and group.enableExperiments
+
+      # outlet is a premium plugin servicing a premium group
+      return true if _.include(outlet.plans, group.subscriptionPlan)
+
+      # otherwise don't show the plugin
+      return false
 
     # <my_directive discussion='model' />
     compileHtml = (model, component) ->
@@ -14,5 +27,4 @@ angular.module('loomioApp').directive 'outlet', ($compile, AppConfig) ->
       $compile "<#{_.snakeCase(component)} #{modelDirective} />"
 
     _.map AppConfig.plugins.outlets[_.snakeCase(attrs.name)], (outlet) ->
-      if shouldCompile(scope.model, outlet.experimental)
-        elem.append compileHtml(scope.model, outlet.component)(scope)
+      elem.append(compileHtml(scope.model, outlet.component)(scope)) if shouldCompile(outlet)

--- a/lib/plugins/README.md
+++ b/lib/plugins/README.md
@@ -309,15 +309,30 @@ but might not be ready for all of our users to see just yet. To enable this, we'
 added the ability to mark some plugins as 'experimental', which means they will
 only be loaded for groups who have opted in to see our mad science.
 
-In order to mark a plugin as an experiment, simply add the line `experiment: true`
+In order to mark a plugin as an experiment, simply add the line `experimental: true`
 to the plugin's entry in `plugins.yml`, like so:
 
 ```yaml
 kickflip:
-  repo:       loomio/kickflip
-  version:    master
-  experiment: true
+  repo:         loomio/kickflip
+  branch:       master
+  experimental: true
 ```
+
+###### Constraining a plugin to certain subscription levels
+
+We also have plugins which we only want to appear for our paying customers. In order to do this on your instance,
+you can provide the config with a list of 'plans', like so:
+
+```yaml
+kickflip:
+  repo:     loomio/kickflip
+  plans:
+    - standard
+    - plus
+```
+
+This will be compared to the 'plan' field of the group's subscription when deciding whether to display the plugin or not.
 
 ###### How this works:
 

--- a/lib/plugins/base.rb
+++ b/lib/plugins/base.rb
@@ -4,7 +4,7 @@ module Plugins
   class NoCodeSpecifiedError < Exception; end
   class NoClassSpecifiedError < Exception; end
   class InvalidAssetType < Exception; end
-  Outlet = Struct.new(:plugin, :component, :outlet_name, :experimental)
+  Outlet = Struct.new(:plugin, :component, :outlet_name, :experimental, :plans)
   VALID_ASSET_TYPES = [:coffee, :scss, :haml, :js, :css]
 
   class Base
@@ -70,7 +70,7 @@ module Plugins
 
     def use_component(component, outlet: nil)
       [:coffee, :scss, :haml].each { |ext| use_asset("components/#{component}/#{component}.#{ext}") }
-      Array(outlet).each { |o| @outlets.add Outlet.new(@name, component, o, @config['experimental']) }
+      Array(outlet).each { |o| @outlets.add Outlet.new(@name, component, o, @config['experimental'], @config['plans']) }
     end
 
     def use_client_route(path, component)


### PR DESCRIPTION
Could be activated in plugins.yml so:

```
plugin_for_standard_groups:
  repo: loomio/standard_plugin
  plans:
    - standard

plugin_for_plus_groups:
  repo: loomio/plus_plugin
  plans:
    - standard
    - plus
```
