### PR TITLE
Don't serialize out attachments / mentions for dashboard / inbox

### DIFF
--- a/app/controllers/api/discussions_controller.rb
+++ b/app/controllers/api/discussions_controller.rb
@@ -12,13 +12,13 @@ class API::DiscussionsController < API::RestfulController
   def dashboard
     raise CanCan::AccessDenied.new unless current_user.is_logged_in?
     instantiate_collection { |collection| collection_for_dashboard collection }
-    respond_with_collection
+    respond_with_collection(serializer: Dashboard::DiscussionSerializer)
   end
 
   def inbox
     raise CanCan::AccessDenied.new unless current_user.is_logged_in?
     instantiate_collection { |collection| collection_for_inbox collection }
-    respond_with_collection
+    respond_with_collection(serializer: Dashboard::DiscussionSerializer)
   end
 
   def move

--- a/app/serializers/dashboard/discussion_serializer.rb
+++ b/app/serializers/dashboard/discussion_serializer.rb
@@ -1,0 +1,9 @@
+class Dashboard::DiscussionSerializer < ::DiscussionSerializer
+  def include_attachments?
+    false
+  end
+
+  def include_mentioned_usernames?
+    false
+  end
+end

--- a/app/serializers/dashboard/motion_serializer.rb
+++ b/app/serializers/dashboard/motion_serializer.rb
@@ -1,0 +1,9 @@
+class Dashboard::MotionSerializer < ::MotionSerializer
+  def include_attachments?
+    false
+  end
+
+  def include_mentioned_usernames?
+    false
+  end
+end

--- a/app/serializers/discussion_serializer.rb
+++ b/app/serializers/discussion_serializer.rb
@@ -50,7 +50,7 @@ class DiscussionSerializer < ActiveModel::Serializer
 
   has_one :author, serializer: UserSerializer, root: :users
   has_one :group, serializer: GroupSerializer, root: :groups
-  has_one :active_proposal, serializer: MotionSerializer, root: :proposals
+  has_one :active_proposal, serializer: Dashboard::MotionSerializer, root: :proposals
   has_one :active_proposal_vote, serializer: VoteSerializer, root: :votes
   has_many :attachments, serializer: AttachmentSerializer, root: :attachments
 


### PR DESCRIPTION
Currently our dashboard and inbox queries are getting killed by loading up a bunch of attachments:

**Dashboard**
![screen shot 2016-09-20 at 5 45 47 pm](https://cloud.githubusercontent.com/assets/750477/18680275/eaf55990-7f5a-11e6-8ad6-41d91e6bb075.png)

**Inbox**
![screen shot 2016-09-20 at 5 46 52 pm](https://cloud.githubusercontent.com/assets/750477/18680258/dcb00dee-7f5a-11e6-998a-f9a59ed1e683.png)

Over 55% of the time spent in the request is used doing an N+1 query for attachments which we don't use on these pages at all.

Here I've introduced a pair of new serializers for use with dashboard / inbox which ignores attachments (and, as a bonus, @mentions, which also incur a db hit and we also don't care about) for Discussions and Motions, which should halve the time it takes to process these queries. Wee performance!

On the plus side, it looks like folks are getting good mileage out of the discussion attachments feature, with about 2500 discussion attachments since we rolled out the feature June 9th, or about 15% of the 16.8k discussions created in that time. (There have been 90 motion attachments in that time, or 1% of the 7.5k motions created.)