### PR TITLE
Add test ensuring link in email takes user to relevant comment

### DIFF
--- a/angular/test/protractor/discussion_spec.coffee
+++ b/angular/test/protractor/discussion_spec.coffee
@@ -4,6 +4,8 @@ describe 'Discussion Page', ->
   discussionForm = require './helpers/discussion_form_helper.coffee'
   threadPage = require './helpers/thread_helper.coffee'
   flashHelper = require './helpers/flash_helper.coffee'
+  emailhelper = require './helpers/email_helper.coffee'
+  staticPage = require './helpers/static_page_helper.coffee'
   page = require './helpers/page_helper.coffee'
 
   describe 'starting a thread via start menu', ->
@@ -215,3 +217,10 @@ describe 'Discussion Page', ->
       threadPage.selectDeleteCommentOption()
       threadPage.confirmCommentDeletion()
       expect(threadPage.activityPanel()).not.toContain('original comment right thur')
+
+  describe 'following a link in a thread email', ->
+    it 'successfully takes you to relevant comment', ->
+      page.loadPath 'setup_reply_email'
+      emailhelper.openLastEmail()
+      staticPage.click 'a'
+      page.expectText '.activity-card', 'Hello Jennifer'

--- a/app/controllers/development_controller.rb
+++ b/app/controllers/development_controller.rb
@@ -535,6 +535,15 @@ class DevelopmentController < ApplicationController
     redirect_to dashboard_url
   end
 
+  def setup_reply_email
+    sign_in jennifer
+    comment = Comment.new(discussion: test_discussion, body: 'Hello Patrick')
+    CommentService.create(comment: comment, actor: jennifer)
+    reply = Comment.new(discussion: test_discussion, body: 'Hello Jennifer', parent: comment)
+    CommentService.create(comment: reply, actor: patrick)
+    redirect_to discussion_url(test_discussion)
+  end
+
   def email_settings_as_logged_in_user
     test_group
     sign_in patrick


### PR DESCRIPTION
@gdpelican, @robguthrie, here is the test for navigating to a comment via email