### PR TITLE
Refactor start group controller

### DIFF
--- a/app/controllers/start_group_controller.rb
+++ b/app/controllers/start_group_controller.rb
@@ -8,9 +8,7 @@ class StartGroupController < ApplicationController
 
   def create
     if group_with_creator.errors.empty?
-      GroupService.create(group:  group_with_creator.group,
-                          params: group_with_creator.creator,
-                          actor:  current_user_or_visitor)
+      GroupService.create(group:  group_with_creator.group, actor: group_with_creator.creator)
     else
       render :new
     end

--- a/app/controllers/start_group_controller.rb
+++ b/app/controllers/start_group_controller.rb
@@ -21,6 +21,6 @@ class StartGroupController < ApplicationController
   end
 
   def redirect_to_dashboard
-    redirect_to_dashboard_path(start_group: true) if current_user_or_visitor.is_logged_in?
+    redirect_to dashboard_path(start_group: true) if current_user_or_visitor.is_logged_in?
   end
 end

--- a/app/controllers/start_group_controller.rb
+++ b/app/controllers/start_group_controller.rb
@@ -7,8 +7,8 @@ class StartGroupController < ApplicationController
   end
 
   def create
-    if group.with_creator.errors.empty?
-      StartGroupJob.perform_later(group_with_creator)
+    if group_with_creator.errors.empty?
+      StartGroupJob.perform_later(params)
     else
       render :new
     end

--- a/app/controllers/start_group_controller.rb
+++ b/app/controllers/start_group_controller.rb
@@ -1,33 +1,26 @@
 class StartGroupController < ApplicationController
+  before_action :redirect_to_dashboard
 
   def new
-    @errors = []
-    @group = Group.new
-    if !current_user_or_visitor.is_logged_in?
-      render :new
-    else
-      redirect_to dashboard_path(start_group: true)
-    end
+    group_with_creator
+    render :new
   end
 
   def create
-    # TODO: move these validations into the group model... where they should already be really.
-    @group = Group.new(permitted_params.group, is_referral: false)
-    @email = params[:email]
-    @name =  params[:name]
-    @errors = []
-    @errors << 'name' if @name.blank?
-    @errors << 'email' unless /^[^@]+@[^@]+\.[^@]+$/.match @email
-    @errors << 'group_name' if @group.name.blank?
-
-    # check for valid name and email
-    if @group.valid? and @errors.empty?
-      GroupService.create(group: @group, actor: LoggedOutUser.new)
-      InvitationService.invite_admin_to_group(group: @group,
-                                              name: @name,
-                                              email: @email)
+    if group_with_creator.start!
+      # it worked!
     else
       render :new
     end
+  end
+
+  private
+
+  def group_with_creator
+    @group_with_creator ||= GroupWithCreator.new(params)
+  end
+
+  def redirect_to_dashboard
+    redirect_to_dashboard_path(start_group: true) if current_user_or_visitor.is_logged_in?
   end
 end

--- a/app/controllers/start_group_controller.rb
+++ b/app/controllers/start_group_controller.rb
@@ -8,7 +8,7 @@ class StartGroupController < ApplicationController
 
   def create
     if group_with_creator.errors.empty?
-      GroupService.create(group:  group_with_creator.group, actor: group_with_creator.creator)
+      GroupService.create(group: group_with_creator.group, actor: group_with_creator.creator)
     else
       render :new
     end

--- a/app/controllers/start_group_controller.rb
+++ b/app/controllers/start_group_controller.rb
@@ -8,7 +8,9 @@ class StartGroupController < ApplicationController
 
   def create
     if group_with_creator.errors.empty?
-      StartGroupJob.perform_later(params)
+      GroupService.create(group:  group_with_creator.group,
+                          params: group_with_creator.creator,
+                          actor:  current_user_or_visitor)
     else
       render :new
     end

--- a/app/controllers/start_group_controller.rb
+++ b/app/controllers/start_group_controller.rb
@@ -7,8 +7,8 @@ class StartGroupController < ApplicationController
   end
 
   def create
-    if group_with_creator.start!
-      # it worked!
+    if group.with_creator.errors.empty?
+      StartGroupJob.perform_later(group_with_creator)
     else
       render :new
     end

--- a/app/jobs/start_group_job.rb
+++ b/app/jobs/start_group_job.rb
@@ -1,9 +1,0 @@
-class StartGroupJob < ActiveJob::Base
-  def perform(params)
-    group = GroupWithCreator.new(params).group
-    GroupService.create(group: group, actor: LoggedOutUser.new)
-    InvitationService.invite_admin_to_group(group: group,
-                                            name:  params[:name],
-                                            email: params[:email])
-  end
-end

--- a/app/jobs/start_group_job.rb
+++ b/app/jobs/start_group_job.rb
@@ -1,8 +1,9 @@
 class StartGroupJob < ActiveJob::Base
-  def perform(group_with_creator)
-    GroupService.create(group: group_with_creator.group, actor: LoggedOutUser.new)
-    InvitationService.invite_admin_to_group(group: group_with_creator.group,
-                                            name:  group_with_creator.name,
-                                            email: group_with_creator.email)
+  def perform(params)
+    group = GroupWithCreator.new(params).group
+    GroupService.create(group: group, actor: LoggedOutUser.new)
+    InvitationService.invite_admin_to_group(group: group,
+                                            name:  params[:name],
+                                            email: params[:email])
   end
 end

--- a/app/jobs/start_group_job.rb
+++ b/app/jobs/start_group_job.rb
@@ -1,0 +1,8 @@
+class StartGroupJob < ActiveJob::Base
+  def perform(group_with_creator)
+    GroupService.create(group: group_with_creator.group, actor: LoggedOutUser.new)
+    InvitationService.invite_admin_to_group(group: group_with_creator.group,
+                                            name:  group_with_creator.name,
+                                            email: group_with_creator.email)
+  end
+end

--- a/app/mailers/invite_people_mailer.rb
+++ b/app/mailers/invite_people_mailer.rb
@@ -1,10 +1,7 @@
 class InvitePeopleMailer < BaseMailer
   layout 'invite_people_mailer'
 
-  def to_start_group(invitation:,
-                     sender_email: ,
-                     locale: )
-
+  def to_start_group(invitation:, sender_email: User.helper_bot_email, locale: I18n.locale)
     @invitation = invitation
     send_single_mail to:       @invitation.recipient_email,
                      locale:   locale,

--- a/app/models/group_with_creator.rb
+++ b/app/models/group_with_creator.rb
@@ -10,7 +10,7 @@ GroupWithCreator = Struct.new(:params) do
 
   def errors
     return [] if params[:action] == 'new'
-    [
+    @errors ||= [
       ('group_name' unless group.valid?),
       ('email'      unless creator.email.present?),
       ('name'       unless creator.name.present?)

--- a/app/models/group_with_creator.rb
+++ b/app/models/group_with_creator.rb
@@ -1,0 +1,41 @@
+GroupWithCreator = Struct.new(:params) do
+
+  def start!
+    return unless errors.empty?
+    GroupService.delay.create(group: group, actor: LoggedOutUser.new)
+    InvitationService.delay.invite_admin_to_group(group: group, name: name, email: email)
+  end
+
+  def group
+    @group ||= Group.new(group_params)
+  end
+
+  def email
+    @email ||= params[:email]
+  end
+
+  def name
+    @name  ||= params[:name]
+  end
+
+  def errors
+    return [] if new?
+    [
+      ('group_name' unless group.valid?),
+      ('email'      unless email.present?),
+      ('name'       unless name.present?)
+    ].compact
+  end
+
+  private
+
+  def new?
+    params[:action] == 'new'
+  end
+
+  def group_params
+    return {} if new?
+    { name: params.dig(:group, :name), description: params.dig(:group, :description) }
+  end
+
+end

--- a/app/models/group_with_creator.rb
+++ b/app/models/group_with_creator.rb
@@ -4,20 +4,12 @@ GroupWithCreator = Struct.new(:params) do
     @group ||= Group.new(group_params)
   end
 
-  def email
-    @email ||= params[:email]
-  end
-
-  def name
-    @name  ||= params[:name]
-  end
-
   def errors
     return [] if new?
     [
       ('group_name' unless group.valid?),
-      ('email'      unless email.present?),
-      ('name'       unless name.present?)
+      ('email'      unless params[:email].present?),
+      ('name'       unless params[:name].present?)
     ].compact
   end
 

--- a/app/models/group_with_creator.rb
+++ b/app/models/group_with_creator.rb
@@ -4,8 +4,12 @@ GroupWithCreator = Struct.new(:params) do
     @group ||= Group.new(group_params)
   end
 
+  def creator
+    { creator: params.slice(:name, :email) }
+  end
+
   def errors
-    return [] if new?
+    return [] if params[:action] == 'new'
     [
       ('group_name' unless group.valid?),
       ('email'      unless params[:email].present?),
@@ -15,12 +19,7 @@ GroupWithCreator = Struct.new(:params) do
 
   private
 
-  def new?
-    params[:action] == 'new'
-  end
-
   def group_params
-    return {} if new?
     { name: params.dig(:group, :name), description: params.dig(:group, :description) }
   end
 

--- a/app/models/group_with_creator.rb
+++ b/app/models/group_with_creator.rb
@@ -1,11 +1,5 @@
 GroupWithCreator = Struct.new(:params) do
 
-  def start!
-    return unless errors.empty?
-    GroupService.delay.create(group: group, actor: LoggedOutUser.new)
-    InvitationService.delay.invite_admin_to_group(group: group, name: name, email: email)
-  end
-
   def group
     @group ||= Group.new(group_params)
   end

--- a/app/models/group_with_creator.rb
+++ b/app/models/group_with_creator.rb
@@ -5,22 +5,22 @@ GroupWithCreator = Struct.new(:params) do
   end
 
   def creator
-    { creator: params.slice(:name, :email) }
+    @creator ||= LoggedOutUser.new(name: params[:name], email: params[:email])
   end
 
   def errors
     return [] if params[:action] == 'new'
     [
       ('group_name' unless group.valid?),
-      ('email'      unless params[:email].present?),
-      ('name'       unless params[:name].present?)
+      ('email'      unless creator.email.present?),
+      ('name'       unless creator.name.present?)
     ].compact
   end
 
   private
 
   def group_params
-    { name: params.dig(:group, :name), description: params.dig(:group, :description) }
+    params[:group].permit(:name, :description) if params[:group]
   end
 
 end

--- a/app/services/group_service.rb
+++ b/app/services/group_service.rb
@@ -1,5 +1,5 @@
 module GroupService
-  def self.create(group:, params: {}, actor:)
+  def self.create(group:, actor: )
     actor.ability.authorize! :create, group
 
     return false unless group.valid?

--- a/app/services/group_service.rb
+++ b/app/services/group_service.rb
@@ -1,5 +1,5 @@
 module GroupService
-  def self.create(group:, actor: )
+  def self.create(group:, params: {}, actor:)
     actor.ability.authorize! :create, group
 
     return false unless group.valid?
@@ -22,7 +22,7 @@ module GroupService
 
     group.add_admin! actor if actor.is_logged_in?
 
-    EventBus.broadcast('group_create', group, actor)
+    EventBus.broadcast('group_create', group, params, actor)
   end
 
   def self.update(group:, params:, actor:)

--- a/app/services/group_service.rb
+++ b/app/services/group_service.rb
@@ -22,7 +22,7 @@ module GroupService
 
     group.add_admin! actor if actor.is_logged_in?
 
-    EventBus.broadcast('group_create', group, params, actor)
+    EventBus.broadcast('group_create', group, actor)
   end
 
   def self.update(group:, params:, actor:)

--- a/app/services/invitation_service.rb
+++ b/app/services/invitation_service.rb
@@ -16,16 +16,17 @@ class InvitationService
     Invitation.create(args)
   end
 
-  def self.invite_admin_to_group(group: , name:, email:)
-    invitation = InvitationService.create_invite_to_start_group(group: group,
-                                                                inviter: User.helper_bot,
-                                                                recipient_email: email,
-                                                                recipient_name: name)
+  def self.invite_creator_to_group(group:, creator:)
+    return unless creator.email.present?
 
-    InvitePeopleMailer.delay(priority: 1).to_start_group(invitation: invitation,
-                                                         sender_email: User.helper_bot_email,
-                                                         locale: I18n.locale)
-    invitation
+    InvitePeopleMailer.delay(priority: 1).to_start_group(
+      invitation: InvitationService.create_invite_to_start_group(
+        group:           group,
+        inviter:         User.helper_bot,
+        recipient_email: creator.email,
+        recipient_name:  creator.name
+      )
+    )
   end
 
   def self.invite_to_group(recipient_emails: nil,

--- a/app/services/invitation_service.rb
+++ b/app/services/invitation_service.rb
@@ -17,8 +17,6 @@ class InvitationService
   end
 
   def self.invite_creator_to_group(group:, creator:)
-    return unless creator.email.present?
-
     InvitePeopleMailer.delay(priority: 1).to_start_group(
       invitation: InvitationService.create_invite_to_start_group(
         group:           group,

--- a/app/views/start_group/create.html.haml
+++ b/app/views/start_group/create.html.haml
@@ -3,7 +3,7 @@
     .inner-container
       .start-group__success
         %h1= t :"start_group_form.success.header"
-        %p= t :"start_group_form.success.email_delivered", email: @email
+        %p= t :"start_group_form.success.email_delivered", email: @group_with_creator.email
 
         %h3= t :"start_group_form.success.email_not_arrived"
         %p= t :"start_group_form.success.please_hold"

--- a/app/views/start_group/create.html.haml
+++ b/app/views/start_group/create.html.haml
@@ -3,7 +3,7 @@
     .inner-container
       .start-group__success
         %h1= t :"start_group_form.success.header"
-        %p= t :"start_group_form.success.email_delivered", email: @group_with_creator.email
+        %p= t :"start_group_form.success.email_delivered", email: @group_with_creator.params[:email]
 
         %h3= t :"start_group_form.success.email_not_arrived"
         %p= t :"start_group_form.success.please_hold"

--- a/app/views/start_group/new.html.haml
+++ b/app/views/start_group/new.html.haml
@@ -5,18 +5,18 @@
         .col-md-8.col-md-offset-2.col-xs-12
           %h1= t :"start_group_form.header"
           %h2= t :"start_group_form.start_making_decisions"
-          = form_for @group, url: start_group_path, html: {class: 'form-horizontal'} do |f|
+          = form_for @group_with_creator.group, url: start_group_path, html: {class: 'form-horizontal'} do |f|
             .form-group
               .col-sm-3
               .col-sm-9
-                - if @errors.any?
+                - if @group_with_creator.errors.any?
                   .form__error= t :"start_group_form.form_error"
 
             .form-group
               .col-sm-4
                 %label.control-label{for: 'group_name'}= t :"start_group_form.group_name"
               .col-sm-8
-                - if @errors.include? 'group_name'
+                - if @group_with_creator.errors.include? 'group_name'
                   .form__error= t :"start_group_form.group_name_error"
                 = f.text_field :name, class: 'form-control', id: 'group_name'
 
@@ -31,7 +31,7 @@
                 .col-sm-4
                   %label.control-label{for: 'name'}= t :"start_group_form.name"
                 .col-sm-8
-                  - if @errors.include? 'name'
+                  - if @group_with_creator.errors.include? 'name'
                     .form__error= t :"start_group_form.name_error"
                   %input.form-control{type: 'text', name: 'name', value: "#{params[:name]}", id: 'name'}
 
@@ -39,7 +39,7 @@
                 .col-sm-4
                   %label.control-label{for: 'email'}= t :"start_group_form.email"
                 .col-sm-8
-                  - if @errors.include? 'email'
+                  - if @group_with_creator.errors.include? 'email'
                     .form__error= t :"start_group_form.email_error"
                   %input.form-control{type: 'text', name: 'email', value: "#{params[:email]}", id: 'email'}
 

--- a/config/initializers/event_bus.rb
+++ b/config/initializers/event_bus.rb
@@ -6,7 +6,14 @@ EventBus.configure do |config|
   config.listen('motion_create')     { |motion|     Draft.purge(user: motion.author, draftable: motion.discussion, field: :motion) }
   config.listen('vote_create')       { |vote|       Draft.purge(user: vote.user, draftable: vote.motion, field: :vote) }
 
-  config.listen('group_create') { |group, actor|    InvitationService.delay.invite_creator_to_group(group: group, creator: actor) }
+  # Add creator to group on group creation
+  config.listen('group_create') do |group, actor|
+    if actor.is_logged_in?
+      group.add_admin! actor
+    elsif actor.email.present?
+      InvitationService.delay.invite_creator_to_group(group: group, creator: actor)
+    end
+  end
 
   # Index search vectors after model creation
   config.listen('discussion_create', 'discussion_update') { |discussion| SearchVector.index! discussion.id }

--- a/config/initializers/event_bus.rb
+++ b/config/initializers/event_bus.rb
@@ -6,10 +6,12 @@ EventBus.configure do |config|
   config.listen('motion_create')     { |motion|     Draft.purge(user: motion.author, draftable: motion.discussion, field: :motion) }
   config.listen('vote_create')       { |vote|       Draft.purge(user: vote.user, draftable: vote.motion, field: :vote) }
 
-  config.listen('group_create') do |group, params|
-    InvitationService.delay.invite_admin_to_group(group: group,
-                                                  name:  params.dig(:creator, :name),
-                                                  email: params.dig(:creator, :email)) if params[:creator]
+  config.listen('group_create') do |group, actor|
+    InvitationService.delay.invite_admin_to_group(
+      group: group,
+      name:  actor.name,
+      email: actor.email
+    ) unless actor.is_logged_in?
   end
 
   # Index search vectors after model creation

--- a/config/initializers/event_bus.rb
+++ b/config/initializers/event_bus.rb
@@ -7,10 +7,9 @@ EventBus.configure do |config|
   config.listen('vote_create')       { |vote|       Draft.purge(user: vote.user, draftable: vote.motion, field: :vote) }
 
   config.listen('group_create') do |group, params|
-    return unless params[:creator]
     InvitationService.delay.invite_admin_to_group(group: group,
                                                   name:  params.dig(:creator, :name),
-                                                  email: params.dig(:creator, :email))
+                                                  email: params.dig(:creator, :email)) if params[:creator]
   end
 
   # Index search vectors after model creation

--- a/config/initializers/event_bus.rb
+++ b/config/initializers/event_bus.rb
@@ -6,13 +6,7 @@ EventBus.configure do |config|
   config.listen('motion_create')     { |motion|     Draft.purge(user: motion.author, draftable: motion.discussion, field: :motion) }
   config.listen('vote_create')       { |vote|       Draft.purge(user: vote.user, draftable: vote.motion, field: :vote) }
 
-  config.listen('group_create') do |group, actor|
-    InvitationService.delay.invite_admin_to_group(
-      group: group,
-      name:  actor.name,
-      email: actor.email
-    ) unless actor.is_logged_in?
-  end
+  config.listen('group_create') { |group, actor|    InvitationService.delay.invite_creator_to_group(group: group, creator: actor) }
 
   # Index search vectors after model creation
   config.listen('discussion_create', 'discussion_update') { |discussion| SearchVector.index! discussion.id }


### PR DESCRIPTION
The start group action is currently one of the slowest routes in our app:

![screen shot 2016-10-03 at 8 02 52 pm](https://cloud.githubusercontent.com/assets/750477/19058342/74993b00-89a4-11e6-8ca4-fc79cf043d3a.png)

Which sucks because it's right at the front door of the Buyer experience.

This is a refactor to kick off the actual group creation and admin invitation (which are relatively slow and pretty safe to assume successful) into a side job, so that the request itself can be quick like 🐰 .