### PR TITLE
Speed up motion close

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,6 +60,7 @@ gem 'safe_shell'
 gem 'premailer-rails'
 gem 'griddler', github: 'loomio/griddler'
 gem "griddler-mailin", github: 'loomio/griddler-mailin'
+gem 'activerecord-import'
 
 group :development, :test do
   gem 'minitest'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,6 +87,8 @@ GEM
       activemodel (= 4.2.5.2)
       activesupport (= 4.2.5.2)
       arel (~> 6.0)
+    activerecord-import (0.15.0)
+      activerecord (>= 3.2)
     activerecord_any_of (1.3)
       activerecord (>= 3.2.13, < 5)
     activesupport (4.2.5.2)
@@ -684,6 +686,7 @@ PLATFORMS
 DEPENDENCIES
   active_model_serializers (~> 0.8.1)
   activeadmin!
+  activerecord-import
   activerecord_any_of
   ahoy_email (~> 0.3.1)
   ahoy_matey (~> 1.1.1)

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -34,7 +34,11 @@ class Event < ActiveRecord::Base
     Events::BaseSerializer
   end
 
-  def users_to_notify
+  def notify!(user)
+    notifications.create!(user: user) if user
+  end
+
+  def users_to_notify # overridden for events which have more complicated rules for notifying users
     User.none
   end
 

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -34,8 +34,8 @@ class Event < ActiveRecord::Base
     Events::BaseSerializer
   end
 
-  def notify!(user)
-    notifications.create!(user: user) if user
+  def users_to_notify
+    User.none
   end
 
   private

--- a/app/models/events/motion_closing_soon.rb
+++ b/app/models/events/motion_closing_soon.rb
@@ -4,6 +4,10 @@ class Events::MotionClosingSoon < Event
            eventable: motion).tap { |e| EventBus.broadcast('motion_closing_soon_event', e) }
   end
 
+  def users_to_notify
+    Queries::UsersByVolumeQuery.normal_or_loud(discussion)
+  end
+
   def motion
     eventable
   end

--- a/app/models/events/motion_outcome_created.rb
+++ b/app/models/events/motion_outcome_created.rb
@@ -6,6 +6,10 @@ class Events::MotionOutcomeCreated < Event
            user: user).tap { |e| EventBus.broadcast('motion_outcome_created_event', e) }
   end
 
+  def users_to_notify
+    Queries::UsersByVolumeQuery.normal_or_loud(discussion).without(eventable.outcome_author)
+  end
+
   def motion
     eventable
   end

--- a/app/models/motion.rb
+++ b/app/models/motion.rb
@@ -110,8 +110,7 @@ class Motion < ActiveRecord::Base
 
   def close!
     did_not_votes.delete_all
-    non_voters = group_members - voters
-    DidNotVote.create! non_voters.uniq.map { |user| {motion: self, user: user} }
+    did_not_votes.import (group_members - voters).map { |user| did_not_votes.build(user: user) }
     update(closed_at: Time.now, members_count: group.memberships_count)
   end
 

--- a/config/initializers/event_bus.rb
+++ b/config/initializers/event_bus.rb
@@ -119,14 +119,9 @@ EventBus.configure do |config|
                 'invitation_accepted_event',
                 'new_coordinator_event') { |event, user| event.notify!(user) }
 
-  # notify users of motion closing soon
-  config.listen('motion_closing_soon_event') do |event|
-    Queries::UsersByVolumeQuery.normal_or_loud(event.discussion).find_each { |user| event.notify!(user) }
-  end
-
-  # notify users of motion outcome created
-  config.listen('motion_outcome_created_event') do |event|
-    Queries::UsersByVolumeQuery.normal_or_loud(event.discussion).without(event.motion.outcome_author).find_each { |user| event.notify!(user) }
+  # notify users of motion closing soon and motion outcome created
+  config.listen('motion_outcome_created_event', 'motion_closing_soon_event') do |event|
+    event.notifications.import event.users_to_notify.map { |user| event.notifications.build(user: user) }
   end
 
   # notify users of comment liked

--- a/spec/services/motion_service_spec.rb
+++ b/spec/services/motion_service_spec.rb
@@ -94,6 +94,7 @@ describe 'MotionService' do
   describe 'closing the motion' do
 
     describe '.close' do
+      before { motion.save }
 
       it 'stores users that did not vote' do
         MotionService.close(motion)


### PR DESCRIPTION
Currently, two of the slower routes in our app are closing a motion, and creating an outcome (both key routes to the core workflow).

For closing a motion, this slowness can be attributed to creating heaps of DidNotVote records one at a time.

For creating an outcome, it's that we're notifying tonnes of users one at a time, which can get quite slow when there are lots of members in the group. (this is the case for motion_closing_soon as well, although this is less problematic because that code happens in a side job.)

So, I've introduced the activerecord import gem, which allows for batch insertions and should take waaay less time for groups with lots of members.