### PR TITLE
Link group member avatars to profiles

### DIFF
--- a/angular/core/components/group_page/members_card/members_card.haml
+++ b/angular/core/components/group_page/members_card/members_card.haml
@@ -3,7 +3,8 @@
     %h2#members-card-title.lmo-card-heading{ translate: "group_page.members"}
     .members-card__list
       .members-card__avatar{ng-if: "group.memberships().length > 1", ng-repeat: "membership in group.memberships() | orderBy: '-admin' | limitTo:10"}
-        %user_avatar{user: "membership.user()", coordinator: "membership.admin", size: "medium"}
+        %a.members-card__avatar-link{lmo-href-for: "membership.user()"}
+          %user_avatar{user: "membership.user()", coordinator: "membership.admin", size: "medium"}
       .lmo-placeholder{translate: "group_page.members_placeholder", ng-if: "showMembersPlaceholder()" }
     .members-card__invite-members{ng-if: "canAddMembers()"}
       %button.members-card__invite-members-btn{ng_click: "invitePeople()"}

--- a/angular/core/components/group_page/members_card/members_card.scss
+++ b/angular/core/components/group_page/members_card/members_card.scss
@@ -2,6 +2,14 @@
   @include card;
 }
 
+.members-card__avatar-link {
+  color: $primary-text-color;
+  &:hover {
+    color: $primary-text-color;
+    text-decoration: none;
+  }
+}
+
 .members-card__avatar{
   float: left;
   margin: 0 2px 2px 0;

--- a/angular/core/components/user_page/user_page.haml
+++ b/angular/core/components/user_page/user_page.haml
@@ -1,15 +1,16 @@
 .loading-wrapper.container.main-container.lmo-one-column-layout
   %loading{ng-if: "!userPage.user"}
   %main.user-page.main-container.lmo-row{ng-if: "userPage.user"}
-    .user-page__profile
-      .user-page__left
-        %user_avatar{user: "userPage.user", size: "featured"}
-      .user-page__right
-        %h1.user-page__name {{userPage.user.name}}
-        %h4.user-page__username @{{userPage.user.username}}
+    .user-page__top-margin
+      .user-page__profile
+        .user-page__left
+          %user_avatar{user: "userPage.user", size: "featured"}
+        .user-page__right
+          %h1.user-page__name {{userPage.user.name}}
+          %h4.user-page__username @{{userPage.user.username}}
 
-        %h2.lmo-h2.user-page__groups-title{translate: "common.groups"}
-        .user-page__groups{ng-repeat: "group in userPage.user.groups() | orderBy: 'fullName' track by group.id"}
-          %a{lmo-href-for: "group"} {{group.fullName}}
-        %loading{ng-if: "userPage.loadGroupsForExecuting"}
-      .clearfix
+          %h2.lmo-h2.user-page__groups-title{translate: "common.groups"}
+          .user-page__groups{ng-repeat: "group in userPage.user.groups() | orderBy: 'fullName' track by group.id"}
+            %a{lmo-href-for: "group"} {{group.fullName}}
+          %loading{ng-if: "userPage.loadGroupsForExecuting"}
+        .clearfix

--- a/angular/core/components/user_page/user_page.scss
+++ b/angular/core/components/user_page/user_page.scss
@@ -1,3 +1,6 @@
+.user-page__top-margin {
+  margin-top: 62px;
+}
 
 .user-page__name {
   @include lmoH1;


### PR DESCRIPTION
[Trello card](https://trello.com/c/mXqKUhsU/1937-1-i-expect-to-be-able-to-click-faces-on-the-members-card-to-see-their-profiles)

![members-card-link](https://cloud.githubusercontent.com/assets/2882097/19335014/895d8342-915c-11e6-90e4-cfbb02d48708.gif)

Also added a margin to match the current user profile page to the user page:

<img width="1122" alt="screen shot 2016-10-13 at 3 43 56 pm" src="https://cloud.githubusercontent.com/assets/2882097/19335022/925634e4-915c-11e6-9542-29355fe14ccc.png">

