### PR TITLE
Use cache queries instead of has_many for comment serialization

### DIFF
--- a/angular/core/models/comment_model.coffee
+++ b/angular/core/models/comment_model.coffee
@@ -13,6 +13,9 @@ angular.module('loomioApp').factory 'CommentModel', (DraftableModel, AppConfig) 
       usesMarkdown: true
       discussionId: null
       body: ''
+      likerIds:           []
+      attachmentIds:      []
+      mentionedUsernames: []
 
     relationships: ->
       @belongsTo 'author', from: 'users'

--- a/app/controllers/api/notifications_controller.rb
+++ b/app/controllers/api/notifications_controller.rb
@@ -11,8 +11,4 @@ class API::NotificationsController < API::RestfulController
     Notification.includes(event: [:eventable, :user]).where(user_id: current_user.id).order(created_at: :desc)
   end
 
-  def default_scope
-    { skip_comment_relations: true }
-  end
-
 end

--- a/app/models/event_collection.rb
+++ b/app/models/event_collection.rb
@@ -10,6 +10,32 @@ class EventCollection
   end
 
   def serialize!(scope = {})
-    Events::ArraySerializer.new(self, scope: scope).as_json
+    Events::ArraySerializer.new(self, scope: default_scope.merge(scope)).as_json
+  end
+
+  private
+
+  def default_scope
+    { cache: { likers: likers, attachments: attachments, mentions: mentions } }
+  end
+
+  def likers
+    @likers ||= User.joins(:comment_votes)
+                    .select('users.*').select('comment_votes.comment_id')
+                    .where('comment_votes.comment_id': event_comment_ids)
+                    .group_by(&:comment_id)
+  end
+
+  def mentions
+    @mentions ||= Comment.find(event_comment_ids).map { |c| [c.id, c.mentioned_usernames] }.to_h
+  end
+
+  def attachments
+    @attachments ||= Attachment.where(attachable_type: "Comment", attachable_id: event_comment_ids)
+                               .group_by(&:attachable_id)
+  end
+
+  def event_comment_ids
+    @event_comment_ids ||= @events.select { |event| event.kind == 'new_comment' }.map(&:eventable_id)
   end
 end

--- a/app/serializers/comment_serializer.rb
+++ b/app/serializers/comment_serializer.rb
@@ -7,15 +7,29 @@ class CommentSerializer < ActiveModel::Serializer
   has_many :likers, serializer: UserSerializer, root: :users
   has_many :attachments, serializer: AttachmentSerializer, root: :attachments
 
-  def parent_author_name
-    object.parent.author_name if object.parent
+  def likers
+    from_cache :likers
   end
 
-  def include_comment_relations?
-    !Hash(scope)[:skip_comment_relations]
+  def mentioned_usernames
+    from_cache :mentions
   end
-  alias :include_mentioned_usernames? :include_comment_relations?
-  alias :include_likers?              :include_comment_relations?
-  alias :include_attachments?         :include_comment_relations?
+
+  def attachments
+    from_cache :attachments
+  end
+
+  def parent_author_name
+    object.parent&.author_name
+  end
+
+  private
+
+  # pull the specified attributes from the cache passed in via serializer scope
+  # This allows us to make 1 query to fetch all attachments, or likers for a series
+  # of comments, rather than needing to do a separate query for each comment
+  def from_cache(field)
+    Array(Hash(scope).dig(:cache, field, object.id))
+  end
 
 end

--- a/app/serializers/comment_serializer.rb
+++ b/app/serializers/comment_serializer.rb
@@ -19,6 +19,18 @@ class CommentSerializer < ActiveModel::Serializer
     from_cache :attachments
   end
 
+  def include_likers?
+    from_cache(:likers).present?
+  end
+
+  def include_mentioned_usernames?
+    from_cache(:mentions).present?
+  end
+
+  def include_attachments?
+    from_cache(:attachments).present?
+  end
+
   def parent_author_name
     object.parent&.author_name
   end
@@ -29,7 +41,7 @@ class CommentSerializer < ActiveModel::Serializer
   # This allows us to make 1 query to fetch all attachments, or likers for a series
   # of comments, rather than needing to do a separate query for each comment
   def from_cache(field)
-    Array(Hash(scope).dig(:cache, field, object.id))
+    Hash(scope).dig(:cache, field, object.id)
   end
 
 end

--- a/spec/controllers/api/comments_controller_spec.rb
+++ b/spec/controllers/api/comments_controller_spec.rb
@@ -101,7 +101,7 @@ describe API::CommentsController do
         it 'responds with json' do
           post :create, comment: comment_params
           json = JSON.parse(response.body)
-          expect(json.keys).to include *(%w[users attachments comments])
+          expect(json.keys).to include *(%w[users comments])
         end
 
         describe 'mentioning' do


### PR DESCRIPTION
Looking at improving the performance of the events#index route (the one which loads events for the activity card)

Here's a recent extra-long query (this one took 2,700 ms):
![screen shot 2016-10-13 at 1 08 47 am](https://cloud.githubusercontent.com/assets/750477/19337288/cb47d774-90e1-11e6-8ec8-1af921b85a50.png)

A huge chunk of that time was taken querying for attachments and users (likers, in this case)

To combat this, I've added some queries to the EventCollection class, which will allow us to make a single query for all likers, attachments, or mentions (3 queries total) in the specified events, rather than having to do single queries for each of them (this added up to ~50 queries in the request above)