### PR TITLE
Open chargify form in new tab, prevent modal from closing when contact form opens

### DIFF
--- a/angular/core/components/group_page/choose_plan_modal/choose_plan_modal.coffee
+++ b/angular/core/components/group_page/choose_plan_modal/choose_plan_modal.coffee
@@ -8,8 +8,7 @@ angular.module('loomioApp').factory 'ChoosePlanModal', ->
       ModalService.open ConfirmGiftPlanModal, group: -> $scope.group
 
     $scope.choosePaidPlan = (kind) ->
-      $window.location = "#{AppConfig.chargify.host}#{AppConfig.chargify.plans[kind].path}?#{ChargifyService.encodedParams($scope.group)}"
+      $window.open "#{AppConfig.chargify.host}#{AppConfig.chargify.plans[kind].path}?#{ChargifyService.encodedParams($scope.group)}"
 
     $scope.openIntercom = ->
       IntercomService.contactUs()
-      $scope.$close()


### PR DESCRIPTION
Attempt to address:
https://github.com/loomio/loomio/issues/3792
&
https://github.com/loomio/loomio/issues/3793

Could maybe do with a smoke-test on a test env with access to Chargify and Intercom