### PR TITLE
enable data export from admin panel

### DIFF
--- a/app/admin/groups.rb
+++ b/app/admin/groups.rb
@@ -151,6 +151,15 @@ ActiveAdmin.register Group do
       end
     end
 
+    panel 'Data export' do
+      export_enabled = group.features['dataExport']
+      form action: toggle_export_admin_group_path(group), method: :post do |f|
+        f.label "Data Export is enabled" if export_enabled
+        f.label "Data Export is not enabled" unless export_enabled
+        f.input type: :submit, value: 'Toggle data export'
+      end
+    end
+
     active_admin_comments
   end
 
@@ -194,6 +203,20 @@ ActiveAdmin.register Group do
     group = Group.friendly.find(params[:id])
     group.unarchive!
     flash[:notice] = "Unarchived #{group.name}"
+    redirect_to [:admin, :groups]
+  end
+
+  member_action :toggle_export, :method => :post do
+    group = Group.friendly.find(params[:id])
+    export_enabled = group.features.fetch 'dataExport', false
+    if export_enabled
+      group.features['dataExport'] = false
+      flash[:notice] = "data export disabled for #{group.name}"
+    else
+      group.features['dataExport'] = true
+      flash[:notice] = "data export enabled for #{group.name}"
+    end
+    group.save
     redirect_to [:admin, :groups]
   end
 

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -66,8 +66,7 @@ class Ability
     end
 
     can :export, Group do |group|
-      user.is_admin? or
-      (user_is_admin_of?(group.id) && group.enabled_beta_features.include?('export'))
+      user_is_admin_of?(group.id) && group.features['dataExport']
     end
 
     can [:members_autocomplete,

--- a/db/migrate/20161108215035_add_features_to_groups.rb
+++ b/db/migrate/20161108215035_add_features_to_groups.rb
@@ -1,0 +1,7 @@
+class AddFeaturesToGroups < ActiveRecord::Migration
+  def change
+    add_column :groups, :features, :jsonb, null: false, default: {}
+    Group.where("enabled_beta_features like ?", "%export%").update_all(features: {dataExport: true}.to_json)
+    remove_column :groups, :enabled_beta_features, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161106203437) do
+ActiveRecord::Schema.define(version: 20161108215035) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -432,7 +432,6 @@ ActiveRecord::Schema.define(version: 20161106203437) do
     t.string   "discussion_privacy_options",                                  null: false
     t.boolean  "members_can_add_members",            default: true,           null: false
     t.string   "membership_granted_upon",                                     null: false
-    t.text     "enabled_beta_features"
     t.string   "subdomain"
     t.integer  "theme_id"
     t.string   "cover_photo_file_name"
@@ -469,6 +468,7 @@ ActiveRecord::Schema.define(version: 20161106203437) do
     t.integer  "proposal_outcomes_count",            default: 0,              null: false
     t.jsonb    "experiences",                        default: {},             null: false
     t.integer  "pending_invitations_count",          default: 0,              null: false
+    t.jsonb    "features",                           default: {},             null: false
   end
 
   add_index "groups", ["category_id"], name: "index_groups_on_category_id", using: :btree


### PR DESCRIPTION
This adds a "toggle data export" button to the groups show page.

It also adds a features object much like the experiences object, for storing which features are enabled and any details we need about them.