### PR TITLE
Minor frontend performance upgrades

### DIFF
--- a/angular/core/app.coffee
+++ b/angular/core/app.coffee
@@ -84,6 +84,8 @@ angular.module('loomioApp').controller 'ApplicationController', ($scope, $timeou
 
   $scope.$on 'currentComponent', (event, options = {}) ->
     Session.currentGroup = options.group
+    IntercomService.updateWithGroup(Session.currentGroup)
+
     $scope.pageError = null
     $scope.$broadcast('clearBackgroundImageUrl')
     ScrollService.scrollTo(options.scrollTo or 'h1') unless options.skipScroll

--- a/angular/core/app.coffee
+++ b/angular/core/app.coffee
@@ -82,7 +82,7 @@ angular.module('loomioApp').controller 'ApplicationController', ($scope, $timeou
     Session.currentGroup = options.group
     $scope.pageError = null
     $scope.$broadcast('clearBackgroundImageUrl')
-    ScrollService.scrollTo(options.scrollTo or 'h1')
+    ScrollService.scrollTo(options.scrollTo or 'h1') unless options.skipScroll
     $scope.links = options.links or {}
     if AbilityService.requireLoginFor(options.page)
       ModalService.open(SignInForm, preventClose: -> true)

--- a/angular/core/app.coffee
+++ b/angular/core/app.coffee
@@ -57,7 +57,7 @@ angular.module('loomioApp', ['ngNewRouter',
   $analyticsProvider.withAutoBase(true);
 
 # Finally the Application controller lives here.
-angular.module('loomioApp').controller 'ApplicationController', ($scope, $timeout, $location, $router, KeyEventService, MessageChannelService, IntercomService, ScrollService, Session, AppConfig, Records, ModalService, SignInForm, GroupForm, AbilityService, AhoyService, ViewportService) ->
+angular.module('loomioApp').controller 'ApplicationController', ($scope, $timeout, $location, $router, $mdMedia, KeyEventService, MessageChannelService, IntercomService, ScrollService, Session, AppConfig, Records, ModalService, SignInForm, GroupForm, AbilityService, AhoyService, ViewportService) ->
   $scope.isLoggedIn = AbilityService.isLoggedIn
   $scope.currentComponent = 'nothing yet'
 
@@ -71,6 +71,10 @@ angular.module('loomioApp').controller 'ApplicationController', ($scope, $timeou
 
   if document.location.protocol.match(/https/) && navigator.serviceWorker?
     navigator.serviceWorker.register(document.location.origin + '/service-worker.js', scope: './')
+
+  $scope.renderSidebar = $mdMedia('gt-md')
+  $scope.$on 'toggleSidebar', ->
+    $scope.renderSidebar = true
 
   $scope.$on 'loggedIn', (event, user) ->
     $scope.refresh()

--- a/angular/core/components/group_page/group_page_controller.coffee
+++ b/angular/core/components/group_page/group_page_controller.coffee
@@ -1,5 +1,5 @@
 angular.module('loomioApp').controller 'GroupPageController', ($rootScope, $location, $routeParams, $scope, Records, Session, MessageChannelService, AbilityService, AppConfig, LmoUrlService, PaginationService, ModalService, GroupWelcomeModal) ->
-  $rootScope.$broadcast 'currentComponent', {page: 'groupPage', key: $routeParams.key}
+  $rootScope.$broadcast 'currentComponent', {page: 'groupPage', key: $routeParams.key, skipScroll: true }
 
   $scope.$on 'joinedGroup', => @handleWelcomeModal()
 

--- a/angular/core/components/sidebar/sidebar.coffee
+++ b/angular/core/components/sidebar/sidebar.coffee
@@ -3,9 +3,9 @@ angular.module('loomioApp').directive 'sidebar', ->
   restrict: 'E'
   templateUrl: 'generated/components/sidebar/sidebar.html'
   replace: true
-  controller: ($scope, Session, $rootScope, $window, RestfulClient, $mdMedia, ThreadQueryService, UserHelpService, AppConfig, IntercomService, $mdSidenav, LmoUrlService, Records, ModalService, GroupForm) ->
-    $scope.showSidebar = $mdMedia("gt-md")
+  controller: ($scope, Session, $rootScope, $window, RestfulClient, ThreadQueryService, UserHelpService, AppConfig, IntercomService, $mdSidenav, LmoUrlService, Records, ModalService, GroupForm) ->
     $scope.currentState = ""
+    $scope.showSidebar = true
 
     $scope.$on 'toggleSidebar', ->
       $scope.showSidebar = !$scope.showSidebar

--- a/angular/core/components/thread_page/thread_page_controller.coffee
+++ b/angular/core/components/thread_page/thread_page_controller.coffee
@@ -1,5 +1,5 @@
 angular.module('loomioApp').controller 'ThreadPageController', ($scope, $routeParams, $location, $rootScope, $window, $timeout, $mdMedia, Records, MessageChannelService, KeyEventService, ModalService, ScrollService, AbilityService, Session, PaginationService, LmoUrlService, TranslationService, ProposalOutcomeForm) ->
-  $rootScope.$broadcast('currentComponent', { page: 'threadPage'})
+  $rootScope.$broadcast('currentComponent', { page: 'threadPage', skipScroll: true })
 
   @windowIsLarge = $mdMedia('gt-sm')
 
@@ -62,6 +62,7 @@ angular.module('loomioApp').controller 'ThreadPageController', ($scope, $routePa
           rss:         LmoUrlService.discussion(@discussion) + '.xml' if !@discussion.private
           prev:        LmoUrlService.discussion(@discussion, from: @pageWindow.prev) if @pageWindow.prev?
           next:        LmoUrlService.discussion(@discussion, from: @pageWindow.next) if @pageWindow.next?
+        skipScroll: true
 
   @init Records.discussions.find $routeParams.key
   Records.discussions.findOrFetchById($routeParams.key).then @init, (error) ->

--- a/angular/core/services/intercom_service.coffee
+++ b/angular/core/services/intercom_service.coffee
@@ -55,7 +55,7 @@ angular.module('loomioApp').factory 'IntercomService', ($rootScope, $window, App
       $window.Intercom('shutdown')
 
     updateWithGroup: (group) ->
-      return unless @available()
+      return unless group? and @available()
       return if _.isEqual(lastGroup, mapGroup(group))
       return if group.isSubgroup()
       user = Session.user()
@@ -71,13 +71,6 @@ angular.module('loomioApp').factory 'IntercomService', ($rootScope, $window, App
         $window.Intercom('showNewMessage')
       else
         $window.open LmoUrlService.contactForm(), '_blank'
-
-  if $window? and $window.Intercom?
-    $rootScope.$watch ->
-      Session.currentGroup? && mapGroup(Session.currentGroup)
-    , ->
-      Session.currentGroup? && service.updateWithGroup(Session.currentGroup)
-    , true
 
     $rootScope.$on 'logout', (event, group) ->
       service.shutdown()

--- a/app/views/layouts/angular.html.haml
+++ b/app/views/layouts/angular.html.haml
@@ -23,7 +23,7 @@
     %flash
     %navbar
     %md_content.lmo-sidebar-and-main-container{layout: "row", flex: ""}
-      %sidebar{ng_if: "isLoggedIn()"}
+      %sidebar{ng_if: "isLoggedIn() && renderSidebar"}
       %md_content.lmo-main-content{flex: ""}
         .lmo-main-background
           %ng_outlet{'ng-if' => '!refreshing && !pageError'}


### PR DESCRIPTION
A couple of minor performance fixes in here:

- Don't render the sidebar until the user clicks to open it on mobile (it renders normally for desktop)
- Don't scroll multiple times on the thread page (just scroll once we're ready)
- Remove the $watch statement from Intercom service and call it directly when `Session.currentGroup` changes