### PR TITLE
Ensure events are first thing loaded by thread page

### DIFF
--- a/angular/core/components/loading_content/loading_content.coffee
+++ b/angular/core/components/loading_content/loading_content.coffee
@@ -1,0 +1,8 @@
+angular.module('loomioApp').directive 'loadingContent', ->
+  scope: {blockCount: '=?', lineCount: '=?'}
+  restrict: 'E'
+  templateUrl: 'generated/components/loading_content/loading_content.html'
+  replace: true
+  controller: ($scope) ->
+    $scope.blocks = new Array($scope.blockCount or 1)
+    $scope.lines = new Array($scope.lineCount or 3)

--- a/angular/core/components/loading_content/loading_content.haml
+++ b/angular/core/components/loading_content/loading_content.haml
@@ -1,0 +1,3 @@
+.loading-content
+  .loading-content__background-wrapper{ng-repeat: "block in blocks track by $index"}
+    .loading-content__background{ng-repeat: "line in lines track by $index"}

--- a/angular/core/components/loading_content/loading_content.scss
+++ b/angular/core/components/loading_content/loading_content.scss
@@ -1,0 +1,22 @@
+@keyframes loadingWipe {
+  from { background-position: 100% 0; }
+  to   { background-position: -100% 0; }
+}
+
+.loading-content__background-wrapper {
+  padding: 8px 0;
+}
+
+.loading-content__background {
+  animation: loadingWipe 2s ease-in-out infinite;
+  background: $light-grey-on-white;
+  background: linear-gradient(to right, #eeeeee 8%, #dddddd 18%, #eeeeee 33%);
+  background-size: 200% 100%;
+  height: 12px;
+  margin-bottom: 10px;
+  box-sizing: border-box;
+  position: relative;
+  &:nth-child(3n)   { margin-right: 15px; }
+  &:nth-child(3n+1) { margin-right: 5px; }
+  &:nth-child(3n+2) { margin-right: 30px; }
+}

--- a/angular/core/components/thread_page/activity_card/activity_card.coffee
+++ b/angular/core/components/thread_page/activity_card/activity_card.coffee
@@ -1,5 +1,5 @@
 angular.module('loomioApp').directive 'activityCard', ->
-  scope: {discussion: '=', activeCommentId: '=?'}
+  scope: {discussion: '=', loading: '=', activeCommentId: '=?'}
   restrict: 'E'
   templateUrl: 'generated/components/thread_page/activity_card/activity_card.html'
   replace: true

--- a/angular/core/components/thread_page/activity_card/activity_card.haml
+++ b/angular/core/components/thread_page/activity_card/activity_card.haml
@@ -1,13 +1,15 @@
 %section.activity-card{aria-labelledby: "activity-card-title"}
   %h2.lmo-card-heading#activity-card-title{translate: "discussion.activity"}
-  %a.activity-card__load-backwards.lmo-no-print{href: "", ng-show: "canLoadBackwards()", ng-click: "loadEventsBackwards()", tabindex: "0"}
-    %i.fa.fa-refresh>
-    %span{translate: "discussion.load_previous", translate-value-count: "{{beforeCount()}}"}
-  %loading.activity-card__loading.page-loading{ng-show: "loadEventsBackwardsExecuting"}
-  .activity-card__no-activity.lmo-placeholder.align-center{ng-if: "noEvents()", translate: "discussion.activity_placeholder"}
-  %ul.activity-card__activity-list
-    %li.activity-card__activity-list-item{ng_repeat: "event in events() track by event.id", in-view: "($inview&&threadItemVisible(event)) || (!$inview&&threadItemHidden(event))", in-view-options: "{debounce: 100}", aria-labelledby: "event-{{event.id}}"}
-      .activity-card__last-item{ng-if: "$last"}
-      .activity-card-content{id: "sequence-{{event.sequenceId}}", ng-include: "'generated/components/thread_page/activity_card/'+ event.kind + '.html'", ng-if: "!event.deleted"}
-      .activity-card__last-read-activity{ng-if: "event.sequenceId == lastReadSequenceId", ng-class: "{'activity-card__new-activity': hasNewActivity}", translate: "activity_card.new_activity"}
-  %loading.activity-card__loading.page-loading{ng-show: "loadEventsForwardsExecuting"}
+  %loading_content{ng-if: "loading", block-count: 2}
+  .activity-card__content{ng-if: "!loading"}
+    %a.activity-card__load-backwards.lmo-no-print{href: "", ng-show: "canLoadBackwards()", ng-click: "loadEventsBackwards()", tabindex: "0"}
+      %i.fa.fa-refresh>
+      %span{translate: "discussion.load_previous", translate-value-count: "{{beforeCount()}}"}
+    %loading.activity-card__loading.page-loading{ng-show: "loadEventsBackwardsExecuting"}
+    .activity-card__no-activity.lmo-placeholder.align-center{ng-if: "noEvents()", translate: "discussion.activity_placeholder"}
+    %ul.activity-card__activity-list
+      %li.activity-card__activity-list-item{ng_repeat: "event in events() track by event.id", in-view: "($inview&&threadItemVisible(event)) || (!$inview&&threadItemHidden(event))", in-view-options: "{debounce: 100}", aria-labelledby: "event-{{event.id}}"}
+        .activity-card__last-item{ng-if: "$last"}
+        .activity-card-content{id: "sequence-{{event.sequenceId}}", ng-include: "'generated/components/thread_page/activity_card/'+ event.kind + '.html'", ng-if: "!event.deleted"}
+        .activity-card__last-read-activity{ng-if: "event.sequenceId == lastReadSequenceId", ng-class: "{'activity-card__new-activity': hasNewActivity}", translate: "activity_card.new_activity"}
+    %loading.activity-card__loading.page-loading{ng-show: "loadEventsForwardsExecuting"}

--- a/angular/core/components/thread_page/current_proposal_card/current_proposal_card.coffee
+++ b/angular/core/components/thread_page/current_proposal_card/current_proposal_card.coffee
@@ -1,40 +1,5 @@
 angular.module('loomioApp').directive 'currentProposalCard', ->
-  scope: {proposal: '='}
+  scope: {proposal: '=', loading: '='}
   restrict: 'E'
   templateUrl: 'generated/components/thread_page/current_proposal_card/current_proposal_card.html'
   replace: true
-  #controller: ($scope) ->
-    #$scope.proposal = $scope.discussion.activeProposal()
-    #Records.votes.fetchByProposal($scope.proposal)
-    #currentUser = CurrentUser
-    #$scope.showVotes = false
-
-    #$scope.showActionsDropdown = ->
-      #currentUser.canCloseOrExtendProposal($scope.proposal)
-
-    #filteredVotes = ->
-      #return [] unless $scope.proposal
-      #_.filter $scope.proposal.uniqueVotes(), (vote) ->
-        #vote.authorId != currentUser.id
-
-    #$scope.onlyVoterIsYou = ->
-      #return false unless $scope.proposal
-      #uniqueVotes = $scope.proposal.uniqueVotes()
-      #(uniqueVotes.length == 1) and (uniqueVotes[0].authorId == currentUser.id)
-
-    #$scope.noVotesYet = ->
-      #return true unless $scope.proposal
-      #$scope.proposal.votes().length == 0
-
-    #$scope.curatedVotes = ->
-      #positionValues = {yes: 0, abstain: 1, no: 2, block: 3}
-      #_.sortBy filteredVotes(), (vote) ->
-        #positionValues[vote.position]
-
-    #$scope.currentUserHasVoted = ->
-      #return false unless $scope.proposal
-      #$scope.proposal.userHasVoted(currentUser)
-
-    #$scope.currentUserVote = ->
-      #return false unless $scope.proposal
-      #$scope.proposal.lastVoteByUser(currentUser)

--- a/angular/core/components/thread_page/current_proposal_card/current_proposal_card.haml
+++ b/angular/core/components/thread_page/current_proposal_card/current_proposal_card.haml
@@ -1,4 +1,5 @@
 %section.current-proposal-card{aria-labelledby: "current-proposal-card-heading"}
-  .lmo-card-heading-padding
+  .lmo-card-padding
     %h2.lmo-card-heading#current-proposal-card-heading{translate: "common.models.proposal", tabindex: "0"}
-  %proposal_expanded{proposal: "proposal"}
+    %loading_content{ng-if: "loading"}
+  %proposal_expanded{proposal: "proposal", ng-if: "!loading"}

--- a/angular/core/components/thread_page/thread_page.haml
+++ b/angular/core/components/thread_page/thread_page.haml
@@ -22,14 +22,14 @@
     .thread-page__main-content--large{ng-if: "threadPage.windowIsLarge"}
       .lmo-thread-column-left
         %context_panel{discussion: "threadPage.discussion"}
-      .lmo-thread-column-right{ng-if: "threadPage.eventsLoaded"}
-        %outlet{name: "before-thread-page-column-right", model: "threadPage.discussion"}
+      .lmo-thread-column-right
+        %outlet{name: "before-thread-page-column-right", ng-if: "threadPage.eventsLoaded", model: "threadPage.discussion"}
         %start_proposal_card.lmo-no-print{in-view: "threadPage.proposalButtonInView($inview)", in-view-options: "{debounce: 200}", ng-if: "threadPage.canStartProposal()", discussion: "threadPage.discussion"}
-        %current_proposal_card{in-view: "threadPage.proposalInView($inview)", in-view-options: "{debounce: 200}", ng-if: "threadPage.discussion.hasActiveProposal()", proposal: "threadPage.discussion.activeProposal()"}
-        %previous_proposals_card{discussion: "threadPage.discussion"}
-        %members_card{group: "threadPage.discussion.group()"}
+        %current_proposal_card{in-view: "threadPage.proposalInView($inview)", in-view-options: "{debounce: 200}", ng-if: "threadPage.discussion.hasActiveProposal()", proposal: "threadPage.discussion.activeProposal()", loading: "!threadPage.eventsLoaded"}
+        %previous_proposals_card{discussion: "threadPage.discussion", ng-if: "threadPage.eventsLoaded"}
+        %members_card{group: "threadPage.discussion.group()", ng-if: "threadPage.eventsLoaded"}
       .lmo-thread-column-left
-        %activity_card{discussion: "threadPage.discussion", active-comment-id: "threadPage.requestedCommentId"}
+        %activity_card{discussion: "threadPage.discussion", active-comment-id: "threadPage.requestedCommentId", loading: "!threadPage.eventsLoaded"}
       .lmo-thread-column-left{ng-if: "threadPage.eventsLoaded"}
         %comment_form.lmo-no-print{discussion: "threadPage.discussion"}
         %outlet{name: "thread-page-column-right"}

--- a/angular/core/components/thread_page/thread_page.haml
+++ b/angular/core/components/thread_page/thread_page.haml
@@ -5,23 +5,24 @@
     .thread-page__main-content--small{ng-if: "!threadPage.windowIsLarge"}
       .thread-page__context
         %context_panel{discussion: "threadPage.discussion"}
-      .thread-page__proposals
+      .thread-page__proposals{ng-if: "threadPage.eventsLoaded"}
         %start_proposal_card.lmo-no-print{in-view: "threadPage.proposalButtonInView($inview)", in-view-options: "{debounce: 200}", ng-if: "threadPage.canStartProposal()", discussion: "threadPage.discussion"}
         %current_proposal_card{in-view: "threadPage.proposalInView($inview)", in-view-options: "{debounce: 200}", ng-if: "threadPage.discussion.hasActiveProposal()", proposal: "threadPage.discussion.activeProposal()"}
         %previous_proposals_card{discussion: "threadPage.discussion"}
       .thread-page__activity
         %activity_card{discussion: "threadPage.discussion", active-comment-id: "threadPage.requestedCommentId"}
+      .thread-page__comment-form{ng-if: "threadPage.eventsLoaded"}
         %comment_form.lmo-no-print{discussion: "threadPage.discussion"}
         %outlet{name: "thread-page-column-right"}
-      .thread-page__outlet
+      .thread-page__outlet{ng-if: "threadPage.eventsLoaded"}
         %outlet{name: "before-thread-page-column-right", model: "threadPage.discussion"}
-      .thread-page__members
+      .thread-page__members{ng-if: "threadPage.events.Loaded"}
         %members_card{group: "threadPage.discussion.group()"}
 
     .thread-page__main-content--large{ng-if: "threadPage.windowIsLarge"}
       .lmo-thread-column-left
         %context_panel{discussion: "threadPage.discussion"}
-      .lmo-thread-column-right
+      .lmo-thread-column-right{ng-if: "threadPage.eventsLoaded"}
         %outlet{name: "before-thread-page-column-right", model: "threadPage.discussion"}
         %start_proposal_card.lmo-no-print{in-view: "threadPage.proposalButtonInView($inview)", in-view-options: "{debounce: 200}", ng-if: "threadPage.canStartProposal()", discussion: "threadPage.discussion"}
         %current_proposal_card{in-view: "threadPage.proposalInView($inview)", in-view-options: "{debounce: 200}", ng-if: "threadPage.discussion.hasActiveProposal()", proposal: "threadPage.discussion.activeProposal()"}
@@ -29,6 +30,7 @@
         %members_card{group: "threadPage.discussion.group()"}
       .lmo-thread-column-left
         %activity_card{discussion: "threadPage.discussion", active-comment-id: "threadPage.requestedCommentId"}
+      .lmo-thread-column-left{ng-if: "threadPage.eventsLoaded"}
         %comment_form.lmo-no-print{discussion: "threadPage.discussion"}
         %outlet{name: "thread-page-column-right"}
 

--- a/angular/core/components/thread_page/thread_page.scss
+++ b/angular/core/components/thread_page/thread_page.scss
@@ -63,6 +63,7 @@
   .thread-page__proposals,
   .thread-page__activity,
   .thread-page__members,
+  .thread-page__comment-form,
   .thread-page__outlet {
     width: 100%;
   }

--- a/angular/core/components/thread_page/thread_page_controller.coffee
+++ b/angular/core/components/thread_page/thread_page_controller.coffee
@@ -82,7 +82,7 @@ angular.module('loomioApp').controller 'ThreadPageController', ($scope, $routePa
     @discussion.group()
 
   @canStartProposal = ->
-    AbilityService.canStartProposal(@discussion)
+    @eventsLoaded && AbilityService.canStartProposal(@discussion)
 
   @proposalInView = ($inview) ->
     $rootScope.$broadcast 'proposalInView', $inview


### PR DESCRIPTION
Currently events are being loaded after the active proposal, previous proposal page, tags, etc, which is delaying the perceived load time of the page by ~500ms. This makes it so that events are the first query to go out after the thread itself is loaded.