### PR TITLE
Perf improvements for thread preview [WIP / maybe not that useful]

### DIFF
--- a/angular/core/components/thread_preview/thread_preview.coffee
+++ b/angular/core/components/thread_preview/thread_preview.coffee
@@ -1,5 +1,5 @@
 angular.module('loomioApp').directive 'threadPreview', ->
-  scope: {thread: '='}
+  scope: {thread: '=', translations: '='}
   restrict: 'E'
   templateUrl: 'generated/components/thread_preview/thread_preview.html'
   replace: true

--- a/angular/core/components/thread_preview/thread_preview.haml
+++ b/angular/core/components/thread_preview/thread_preview.haml
@@ -1,17 +1,17 @@
 .thread-preview
-  %a.thread-preview__link{lmo-href-for: "thread"}
+  %a.thread-preview__link{lmo-href-for: "::thread"}
     .thread-preview__icon
-      %user_avatar{ng-if: "!thread.activeProposal()", user: "thread.author()", size: "medium"}
+      %user_avatar{ng-if: "!thread.activeProposal()", user: "::thread.author()", size: "medium"}
       .thread-preview__pie-container{ng-if: "thread.activeProposal()"}
         %pie_chart.thread-preview__pie-canvas{votes: "thread.activeProposal().voteCounts", ng-if: "lastVoteByCurrentUser(thread)", title: "{{ 'dashboard_page.thread_preview.you_voted' | translate:translationData(thread) }}"}
-        %pie_chart.thread-preview__pie-canvas{votes: "thread.activeProposal().voteCounts", ng-if: "!lastVoteByCurrentUser(thread)", title: "{{ 'dashboard_page.thread_preview.undecided' | translate }}"}
+        %pie_chart.thread-preview__pie-canvas{votes: "thread.activeProposal().voteCounts", ng-if: "!lastVoteByCurrentUser(thread)", title: "{{ ::translations.undecided }}"}
         .thread-preview__position-icon-container
           .thread-preview__position-icon{ng-if: "lastVoteByCurrentUser(thread)", class: "thread-preview__position-icon--{{lastVoteByCurrentUser(thread).position}} "}
           .thread-preview__undecided-icon{ng-if: "!lastVoteByCurrentUser(thread)"}
             %i.fa.fa-question
 
     .sr-only
-      %span {{thread.authorName()}}: {{thread.title}}.
+      %span {{::thread.authorName()}}: {{::thread.title}}.
       %span{ng-if: "thread.hasUnreadActivity()", translate: "dashboard_page.aria_thread.unread", translate-value-count: "{{ thread.unreadActivityCount() }}"}
       %span{ng-if: "thread.activeProposal()", translate: "dashboard_page.aria_thread.current_proposal", translate-value-name: "{{ thread.activeProposal().name }}"}
       %span{ng-if: "thread.activeProposal() && lastVoteByCurrentUser(thread)", translate: "dashboard_page.aria_thread.you_voted", translate-value-position: " {{lastVoteByCurrentUser(thread).position}} "}
@@ -19,7 +19,7 @@
     .thread-preview__screen-only.screen-only{aria-hidden: "true"}
       .thread-preview__text-container
         .thread-preview__title{ng-class: "{'thread-preview--unread': thread.isUnread() }"}
-          {{thread.title}}
+          {{::thread.title}}
         .thread-preview__unread-count{ng-if: "thread.hasUnreadActivity()"}
           ({{thread.unreadActivityCount()}})
 
@@ -30,7 +30,7 @@
 
       .thread-preview__text-container
         .thread-preview__group-name
-          {{ thread.group().fullName }} ·
+          {{ ::thread.group().fullName }} ·
           %smart_time{time: "thread.lastActivityAt"}>
 
       %outlet{name: "after-thread-preview", model: "thread"}
@@ -39,10 +39,10 @@
     %star_toggle{thread: "thread", aria-hidden: "true"}
 
   .thread-preview__actions.hidden-xs{ng-if: "thread.discussionReaderId"}
-    %button.thread-preview__dismiss{ng-click: "dismiss()", ng-disabled: "!thread.isUnread()", ng-class: "{disabled: !thread.isUnread()}", title: "{{'dashboard_page.dismiss' | translate }}"}>
+    %button.thread-preview__dismiss{ng-click: "dismiss()", ng-disabled: "!thread.isUnread()", ng-class: "{disabled: !thread.isUnread()}", title: "{{ ::translations.dismiss }}"}>
       %i.fa.fa-check>
-    %button.thread-preview__mute{ng-click: "muteThread()", ng-show: "!thread.isMuted()", title: "{{ 'volume_levels.mute' | translate }}", aria-label: "{{ 'volume_levels.mute' | translate }}" }>
+    %button.thread-preview__mute{ng-click: "muteThread()", ng-show: "!thread.isMuted()", title: "{{ ::translations.mute }}", aria-label: "{{ ::translations.mute }}" }>
       %i.fa.fa-volume-off
       %i.fa.fa-times>
-    %button.thread-preview__unmute{ng-click: "unmuteThread()", ng-show: "thread.isMuted()", title: "{{ 'volume_levels.unmute' | translate }}", aria-label: "{{ 'volume_levels.unmute' | translate }}"}>
+    %button.thread-preview__unmute{ng-click: "unmuteThread()", ng-show: "thread.isMuted()", title: "{{ ::translations.unmute }}", aria-label: "{{ ::translations.unmute }}"}>
       %i.fa.fa-volume-down>

--- a/angular/core/components/thread_preview_collection/thread_preview_collection.coffee
+++ b/angular/core/components/thread_preview_collection/thread_preview_collection.coffee
@@ -3,10 +3,16 @@ angular.module('loomioApp').directive 'threadPreviewCollection', ->
   restrict: 'E'
   templateUrl: 'generated/components/thread_preview_collection/thread_preview_collection.html'
   replace: true
-  controller: ($scope) ->
+  controller: ($scope, $translate) ->
     $scope.importance = (thread) ->
       multiplier = if thread.hasActiveProposal() and thread.starred then -100000
       else if         thread.hasActiveProposal() then -10000
       else if         thread.starred then -1000
       else            -1
       multiplier * thread.lastActivityAt
+
+    $scope.translations =
+      dismiss:   $translate.instant('dashboard_page.dismiss')
+      mute:      $translate.instant('volume_levels.mute')
+      unmute:    $translate.instant('volume_levels.unmute')
+      undecided: $translate.instant('dashboard_page.thread_preview.undecided')

--- a/angular/core/components/thread_preview_collection/thread_preview_collection.haml
+++ b/angular/core/components/thread_preview_collection/thread_preview_collection.haml
@@ -1,4 +1,4 @@
 .thread-previews
   %outlet{name: "before-thread-previews", model: "query"}
   .blank{ng-repeat: "thread in query.threads() | limitTo: limit | orderBy:importance track by thread.key"}
-    %thread_preview{thread: "thread"}
+    %thread_preview{thread: "thread", translations: "::translations"}

--- a/angular/core/components/user_avatar/user_avatar.haml
+++ b/angular/core/components/user_avatar/user_avatar.haml
@@ -1,6 +1,6 @@
-.user-avatar{class: "lmo-box--{{size}}", aria-hidden: "true", ng-class: "{'user-avatar--coordinator': coordinator}", title: "{{user.name}}"}
+.user-avatar{class: "lmo-box--{{::size}}", aria-hidden: "true", ng-class: "{'user-avatar--coordinator': coordinator}", title: "{{::user.name}}"}
   %a.user-avatar__profile-link{lmo-href-for: "user"}
-    %div{class: "lmo-box--{{size}} user-avatar__initials user-avatar__initials--{{size}}", aria-hidden: "true", ng-if: "user.avatarKind == 'initials'"}
-      {{user.avatarInitials}}
-    %img{class: "lmo-box--{{size}}", ng-if: "user.avatarKind == 'gravatar'", gravatar-src-once: "user.gravatarMd5", gravatar-size: "{{gravatarSize()}}", alt: "{{::user.name}}"}
-    %img{class: "lmo-box--{{size}}", ng-if: "user.avatarKind == 'uploaded'", alt: "{{user.name}}", ng-src: "{{::user.avatarUrl}}"}
+    %div{class: "lmo-box--{{::size}} user-avatar__initials user-avatar__initials--{{::size}}", aria-hidden: "true", ng-if: "user.avatarKind == 'initials'"}
+      {{::user.avatarInitials}}
+    %img{class: "lmo-box--{{::size}}", ng-if: "user.avatarKind == 'gravatar'", gravatar-src-once: "user.gravatarMd5", gravatar-size: "{{gravatarSize()}}", alt: "{{::user.name}}"}
+    %img{class: "lmo-box--{{::size}}", ng-if: "user.avatarKind == 'uploaded'", alt: "{{::user.name}}", ng-src: "{{::user.avatarUrl}}"}


### PR DESCRIPTION
I loaded up a full dashboard's worth of threads on my development instance, and got 3599 watchers. That's a lot! It's recommended to stay under 2000 to keep the digest loop snappy.

So, I made some improvements:
- A full dashboard with production code right now: 3599 watchers (-0)
- Assume user names and avatar urls will not change: 3331 watchers (- 268)
- Assume groups names and discussion titles will not change: 3181 watchers (-150)
- Translate thread preview translations once per collection, rather than once per thread: 2931 watchers (-250)
- Assume thread URL, and screen reader only information (title, author name) will not change: 2781 watchers (-250)

2781 / 3599 = 23% fewer watchers
However, somewhat disconcertingly, this didn't result in a $digest loop performance improvement (it hovered around 650 - 670ms both with and without these changes applied.)

Soooo... ¯\_(ツ)_/¯ ?