### PR TITLE
Remove unsplash link from cover photo form

### DIFF
--- a/angular/core/components/group_page/cover_photo_form/cover_photo_form.haml
+++ b/angular/core/components/group_page/cover_photo_form/cover_photo_form.haml
@@ -12,7 +12,6 @@
       %span.lmo-option-text{translate: "cover_photo_form.upload_link"}
     .lmo-clearfix
     %input.hidden.cover-photo-form__file-input{type: "file", ng-model: "files", ng-file-select: "upload(files)"}
-    %p{translate: "cover_photo_form.helptext"}
     %p{translate: "cover_photo_form.image_size_helptext"}
 
   .modal-footer.lmo-clearfix

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -421,7 +421,6 @@ en:
     aria_label: 'Change cover photo form'
     heading: 'New cover photo'
     upload_link: 'Upload new cover photo'
-    helptext: 'Looking for inspiration? Check out <a href="https://unsplash.com/">Unsplash</a>, a gallery of beautiful, free images'
     image_size_helptext: 'Ideal image size is 1400 x 320px'
     upload_success: 'Cover photo successfully updated'
 


### PR DESCRIPTION
[Trello card](https://trello.com/c/5ziRHheb/2154-remove-unsplash-link-in-cover-photo-upload)
<img width="500" alt="screen shot 2016-11-23 at 11 01 50 am" src="https://cloud.githubusercontent.com/assets/2882097/20543881/689e9fee-b16c-11e6-9839-b1b90ab38503.png">
