### PR TITLE
Prevent users from editing context when they mean to comment

### DIFF
--- a/angular/core/components/thread_page/context_panel/context_panel.coffee
+++ b/angular/core/components/thread_page/context_panel/context_panel.coffee
@@ -3,7 +3,7 @@ angular.module('loomioApp').directive 'contextPanel', ->
   restrict: 'E'
   replace: true
   templateUrl: 'generated/components/thread_page/context_panel/context_panel.html'
-  controller: ($scope, $rootScope, $window, $timeout, AbilityService, Session, ModalService, ChangeVolumeForm, DiscussionForm, ThreadService, MoveThreadForm, PrintModal, DeleteThreadForm, RevisionHistoryModal) ->
+  controller: ($scope, $rootScope, $window, $timeout, AbilityService, Session, ModalService, ChangeVolumeForm, DiscussionForm, ThreadService, MoveThreadForm, PrintModal, DeleteThreadForm, RevisionHistoryModal, ScrollService) ->
 
     $scope.showContextMenu = ->
       AbilityService.canChangeThreadVolume($scope.discussion)
@@ -19,6 +19,9 @@ angular.module('loomioApp').directive 'contextPanel', ->
 
     $scope.editThread = ->
       ModalService.open DiscussionForm, discussion: => $scope.discussion
+
+    $scope.scrollToCommentForm = ->
+      ScrollService.scrollTo('.comment-form__comment-field')
 
     $scope.muteThread = ->
       ThreadService.mute($scope.discussion)

--- a/angular/core/components/thread_page/context_panel/context_panel.coffee
+++ b/angular/core/components/thread_page/context_panel/context_panel.coffee
@@ -53,3 +53,6 @@ angular.module('loomioApp').directive 'contextPanel', ->
 
     $scope.showRevisionHistory = ->
       ModalService.open RevisionHistoryModal, model: => $scope.discussion
+
+    $scope.canAddComment = ->
+      AbilityService.canAddComment($scope.discussion)

--- a/angular/core/components/thread_page/context_panel/context_panel.haml
+++ b/angular/core/components/thread_page/context_panel/context_panel.haml
@@ -52,5 +52,5 @@
     .context-panel__attachment{ng-repeat: "attachment in discussion.attachments() | orderBy:'createdAt' track by attachment.id"}
       %attachment_preview{attachment: "attachment", mode: "context"}
 
-  %button.context-panel__add-comment.lmo-no-print{ng-click: "scrollToCommentForm()", translate: "thread_context.add_comment"}
+  %button.context-panel__add-comment.lmo-no-print{ng-click: "scrollToCommentForm()", translate: "thread_context.add_comment", ng-if: "canAddComment()"}
   %button.context-panel__edit.lmo-no-print{ng-click: "editThread()", translate: "thread_context.edit_thread", ng-if: "canEditThread()"}

--- a/angular/core/components/thread_page/context_panel/context_panel.haml
+++ b/angular/core/components/thread_page/context_panel/context_panel.haml
@@ -11,7 +11,7 @@
           %li.lmo-dropdown-menu-item{ng-if: "canChangeVolume()"}
             %a.context-panel__dropdown-options--email-settings.lmo-dropdown-menu-item-label{href: "", ng-click: "openChangeVolumeForm()", translate: "thread_context.email_settings"}
           %li.lmo-dropdown-menu-item{ng-if: "canEditThread()"}
-            %a.context-panel__dropdown-options--edit.lmo-dropdown-menu-item-label{href: "", ng-click: "editThread()", translate: "thread_context.edit_thread"}
+            %a.context-panel__dropdown-options--edit.lmo-dropdown-menu-item-label{href: "", ng-click: "editThread()", translate: "thread_context.edit"}
           %li.lmo-dropdown-menu-item{ng-show: "!discussion.isMuted()"}
             %a.context-panel__dropdown-options--mute.lmo-dropdown-menu-item-label{href: "", ng-click: "muteThread()", translate: "volume_levels.mute"}
           %li.lmo-dropdown-menu-item{ng-show: "discussion.isMuted()"}
@@ -52,4 +52,5 @@
     .context-panel__attachment{ng-repeat: "attachment in discussion.attachments() | orderBy:'createdAt' track by attachment.id"}
       %attachment_preview{attachment: "attachment", mode: "context"}
 
-  %a.context-panel__edit-link.lmo-card-minor-action.lmo-no-print{href: "", ng-click: "editThread()", translate: "thread_context.edit_thread", ng-if: "canEditThread()"}
+  %button.context-panel__add-comment.lmo-no-print{ng-click: "scrollToCommentForm()", translate: "thread_context.add_comment"}
+  %button.context-panel__edit.lmo-no-print{ng-click: "editThread()", translate: "thread_context.edit_thread", ng-if: "canEditThread()"}

--- a/angular/core/components/thread_page/context_panel/context_panel.scss
+++ b/angular/core/components/thread_page/context_panel/context_panel.scss
@@ -44,7 +44,7 @@
   margin-right: 30px;
 }
 .context-panel__add-comment {
-  color: #5cb85c;
+  color: $brand-success;
 }
 
 .context-panel__edit {

--- a/angular/core/components/thread_page/context_panel/context_panel.scss
+++ b/angular/core/components/thread_page/context_panel/context_panel.scss
@@ -33,6 +33,20 @@
   margin-top: 16px;
 }
 
-.context-panel__edit-link {
+.context-panel__edit,
+.context-panel__add-comment {
+  @include lmoBtnLink;
+  @include fontHelveticaMedium;
+  @include fontSmall;
   cursor: pointer;
+  text-transform: uppercase;
+  letter-spacing: .3px;
+  margin-right: 30px;
+}
+.context-panel__add-comment {
+  color: #5cb85c;
+}
+
+.context-panel__edit {
+  color: $grey-on-white;
 }

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -963,11 +963,13 @@ en:
     aria_label: 'Thread context'
     thread_options: 'Thread options'
     email_settings: 'Email settings'
-    edit_thread: 'Edit'
+    edit: 'Edit'
+    edit_thread: 'Edit thread'
     mute_thread: 'Mute'
     move_thread: 'Move'
     print_thread: 'Print'
     delete_thread: 'Delete'
+    add_comment: 'Add comment'
 
   delete_thread_form:
     aria_label: 'Delete thread'


### PR DESCRIPTION
[Trello card](https://trello.com/c/CZKcHUX6/2209-users-editing-title-and-context-instead-of-posting-comment-in-intro-thread)

<img width="680" alt="screen shot 2016-12-07 at 11 15 57 am" src="https://cloud.githubusercontent.com/assets/2882097/20947130/a5a86c56-bc72-11e6-89b1-5864e242e2c2.png">


