### PR TITLE
Use multipart/alternative for email encoding

### DIFF
--- a/app/mailers/base_mailer.rb
+++ b/app/mailers/base_mailer.rb
@@ -7,7 +7,8 @@ class BaseMailer < ActionMailer::Base
   add_template_helper(PrettyUrlHelper)
 
   NOTIFICATIONS_EMAIL_ADDRESS = "notifications@#{ENV['SMTP_DOMAIN']}"
-  default :from => "Loomio <#{NOTIFICATIONS_EMAIL_ADDRESS}>"
+  default from: "Loomio <#{NOTIFICATIONS_EMAIL_ADDRESS}>",
+          'Content-Transfer-Encoding' => 'multipart/alternative'
   before_action :utm_hash
 
   protected


### PR DESCRIPTION
I'm not sure why we're using 7bit currently; maybe ahoy email or premailer or something does this?
https://rails-bestpractices.com/posts/2010/08/05/use-multipart-alternative-as-content_type-of-email/