### PR TITLE
Add different helptext for announcement off

### DIFF
--- a/angular/core/components/poll/common/notify_group/poll_common_notify_group.haml
+++ b/angular/core/components/poll/common/notify_group/poll_common_notify_group.haml
@@ -1,5 +1,6 @@
 .md-block.poll-common-notify-group.poll-common-checkbox-option{ng-if: "model.group()"}
   .poll-common-checkbox-option__text.md-list-item-text
     %h3{translate: "poll_common_notify_group.notify_group"}
-    %p.md-caption{translate: "poll_common_notify_group.members_count", translate-value-count: "{{model.communitySize()}}"}
+    %p.md-caption{ng-if: "model.makeAnnouncement", translate: "poll_common_notify_group.members_count", translate-value-count: "{{model.communitySize()}}"}
+    %p.md-caption{ng-if: "!model.makeAnnouncement", translate: "poll_common_notify_group.members_helptext"}
   %md-checkbox{ng-model: "model.makeAnnouncement"}

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1360,6 +1360,7 @@ en:
 
   poll_common_notify_group:
     notify_group: Announcement
+    members_helptext: Your group will not be notified
     members_count: "{{count}} people will be notified"
 
   poll_common_close_form:


### PR DESCRIPTION
It looks off without the helptext imo, so I just swapped out the message to say 'Your group will not be notified' when the option isn't checked