### PR TITLE
link to an explanation of BEM

### DIFF
--- a/docs/en/development_handbook/code_guidelines.md
+++ b/docs/en/development_handbook/code_guidelines.md
@@ -12,11 +12,13 @@ You'll want to use this directive when linking to stuff within the app. it suppo
 
 ## Naming stuff (BEM)
 
-The front end of Loomio is divided into "components" and we have a really simple naming system which helps to keep the codebase easy to use as the application grows. You might have already heard about it, it's called BEM. Here's how we've applied BEM to Loomio:
+The front end of Loomio is divided into "components" and we have a really simple naming system which helps to keep the codebase easy to use as the application grows. You might have already heard about it, it's called [BEM][]. Here's how we've applied BEM to Loomio:
 
 Components each have a unique name and that name is given to a folder with (typically) 3 files in it: code (Coffeescript) + template (HAML) + stylesheet (SCSS).
 
 You can find the components under `lineman/app/components`.
+
+[BEM]: https://stackoverflow.com/tags/bem/info
 
 ### Example: thread_preview component
 


### PR DESCRIPTION
Hi! I just watched the [Design For Developers](https://www.youtube.com/watch?v=1I78I6l1nzI) (great talk!) by @rdbartlett and he mentioned BEM but I'd never heard of it. I thought it might be nice to link to an explanation of what it is.

I settled on linking to https://stackoverflow.com/tags/bem/info after also considering https://en.wikipedia.org/wiki/Block,_element,_modifier which is linked from https://en.wikipedia.org/wiki/BEM but is only a redirect to https://en.wikipedia.org/wiki/Cascading_Style_Sheets#CSS_authoring_methodologies

Personally, I find that neither http://bem.info nor http://getbem.com quickly provide what I'm interested in, which is what the letters in the BEM acronym stand for as well as a short description. The Stack Overflow tag description ticks all the boxes for me.

