### PR TITLE
Changes in environment setup and quickstart documentation

### DIFF
--- a/docs/en/development_handbook/quickstart.md
+++ b/docs/en/development_handbook/quickstart.md
@@ -7,6 +7,12 @@ git clone git@github.com:loomio/loomio.git && cd loomio
 
 If you're on OSX then you can run the following bootstrap task to setup your system with postgresql, npm, bundler and gulp. It will then create an admin user. If you need help installing ruby, or more detail on installing the dependencies, please read [Setup Environment](setup_environment.md)
 
+If you are setting up with PostgreSQL for the first time, you would have to create a superuser.
+
+```
+[sudo] su postgres -c 'createuser -P --superuser <username>'
+```
+
 2. Run the bootstrap task
 ```
 rake bootstrap

--- a/docs/en/development_handbook/setup_environment.md
+++ b/docs/en/development_handbook/setup_environment.md
@@ -28,9 +28,9 @@ You will need PostgreSQL 9.4+ for the `jsonb` data type.
 
 ```
 $ sudo apt-get update
-$ sudo apt-get install git-core postgresql-9.4 postgresql-contrib-9.4 build-essential \
+$ sudo apt-get install git-core postgresql-9.6 postgresql-contrib-9.6 build-essential \
                        libssl-dev libpq-dev libffi-dev libmagickwand-dev \
-                       libreadline-gplv2-dev nodejs imagemagick wget
+                       libreadline-gplv2-dev nodejs imagemagick wget libsqlite3-dev
 ```
 
 ## Install Ruby with rbenv
@@ -41,7 +41,7 @@ From here onwards the instructions apply to both OSX and Linux.
 
 I recommend that you don't use managed (Homebrew, APT etc) versions of ruby, rbenv and ruby-build. They're no easier to use, and they tend to be out of date just when you need the latest version.
 
-First we install [rbenv](https://github.com/sstephenson/rbenv). (Replace ~/.bash_profile with  ~/.zshrc, ~/.profile, or ~/.bashrc depending on what filename you use).
+First we install [rbenv](https://github.com/sstephenson/rbenv). (Replace ```~/.bash_profile``` with  ```~/.zshrc```, ```~/.profile```, or ```~/.bashrc``` depending on what filename you use).
 
 ```
 $ git clone https://github.com/sstephenson/rbenv.git ~/.rbenv
@@ -74,7 +74,7 @@ $ cd ~/.rbenv/plugins/ruby-build
 $ git pull
 ```
 
-### Build and Install Ruby
+### Build and Install Ruby and dependencies
 
 At the time of writing 2.3.0 is the latest version.
 
@@ -82,7 +82,7 @@ At the time of writing 2.3.0 is the latest version.
 $ rbenv install 2.3.0
 $ rbenv global 2.3.0
 $ gem install bundler
-$ rbenv rehash
+$ bundle install
 ```
 
 ## Install Node.js


### PR DESCRIPTION
fixes #4201 
Changes in [```quickstart.md```](https://github.com/loomio/loomio/blob/master/docs/en/development_handbook/quickstart.md) and [```setup_environment.md```](https://github.com/loomio/loomio/blob/master/docs/en/development_handbook/setup_environment.md)

 + ```rbenv rehash``` is now deprecated, as per [official repository](https://github.com/rbenv/rbenv-gem-rehash)
 + dependencies are to be installed (```bundle install```)  before bootstrap task (```rake bootstrap```)
 + for users using postgres for the first, they can directly download postgres 9.6 instead of 9.4

/cc @gdpelican, @robguthrie 