### PR TITLE
User validation messages

### DIFF
--- a/app/models/stance.rb
+++ b/app/models/stance.rb
@@ -75,6 +75,7 @@ class Stance < ActiveRecord::Base
   end
 
   def participant_is_complete
+    return if participant.email_verified
     if participant&.name.blank?
       errors.add(:participant_name, I18n.t(:"activerecord.errors.messages.blank"))
       participant.errors.add(:name, I18n.t(:"activerecord.errors.messages.blank"))

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -33,6 +33,7 @@ class User < ActiveRecord::Base
     content_type: { content_type: /\Aimage/ },
     file_name: { matches: [/png\Z/i, /jpe?g\Z/i, /gif\Z/i] }
 
+  validates_uniqueness_of :email, conditions: -> { where(email_verified: true) }, if: :email_verified?
   validates_uniqueness_of :username
   validates_length_of :username, maximum: 30
   validates_length_of :short_bio, maximum: 500

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -6,6 +6,10 @@ class UserSerializer < ActiveModel::Serializer
              :locale, :location, :city, :region, :country, :created_at, :email_verified, :has_password,
              :last_seen_at
 
+  def name
+    object.name || object.username
+  end
+
   def label
     username
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -98,6 +98,22 @@ describe User do
     user.should have(0).errors_on(:email)
   end
 
+  it "email can be duplicated for non-email verified accounts" do
+    create(:user, email: 'example@example.com', email_verified: false)
+    user = build(:user, email: 'example@example.com', email_verified: false)
+    expect(user).to be_valid
+    user.email_verified = true
+    expect(user).to be_valid
+  end
+
+  it "email cannot be duplicated for email verified accounts" do
+    create(:user, email: 'example@example.com', email_verified: true)
+    user = build(:user, email: 'example@example.com', email_verified: false)
+    expect(user).to be_valid
+    user.email_verified = true
+    expect(user).to_not be_valid
+  end
+
   it "has many groups" do
     group.add_member!(user)
     user.groups.should include(group)


### PR DESCRIPTION
- Allow verified users to vote even if they don't have a name set
- Add a validation message when attempting to change email to one that's already taken