### PR TITLE
Automatically link URLs (Fixes #4196)

### DIFF
--- a/angular/core/config/marked.coffee
+++ b/angular/core/config/marked.coffee
@@ -15,12 +15,15 @@ angular.module('loomioApp').config (markedProvider) ->
       _super.heading(emojione.shortnameToImage(text), level, text)
 
     renderer.link      = (href, title, text) ->
+      if marked.InlineLexer.rules.gfm.url.test(href) and !/^http/.test(href)
+        href = 'http://' + href
       _super.link(href, title, text).replace('<a ', '<a rel="noopener noreferrer" target="_blank" ')
 
     renderer
 
   _parse = marked.parse
   marked.parse = (src, opt, callback) ->
+    marked.InlineLexer.rules.gfm.url = /^((https?:\/\/)?([a-z0-9+!*(),;?&=.-]+(:[a-z0-9+!*(),;?&=.-]+)?@)?([a-z0-9\-\.]*)\.(([a-z]{2,4})|([0-9]{1,3}\.([0-9]{1,3})\.([0-9]{1,3})))(:[0-9]{2,5})?(\/([a-z0-9+%-]\.?)+)*\/?(\?[a-z+&$_.-][a-z0-9;:@&%=+/.-]*)?(#[a-z_.-][a-z0-9+$%_.-]*)?)/i
     src = src.replace(/<img[^>]+\>/ig, "")
     src = src.replace(/<script[^>]+\>/ig, "")
     return _parse(src, opt, callback)


### PR DESCRIPTION
This PR uses the customized Marked `parse` function, already defined in `angular/core/config/marked.coffee`, and modifies the default regular expression for URLs. Previously it was relying on having an `http` or `https` prepending the URL, now it is able to pick up a wide array of URLs, including IPs, with query string, etc. The Marked renderer also is modified to prepend an `http` to found URLs which do not contain the protocol at the beginning of the address. 

There is another PR, https://github.com/loomio/loomio/pull/4342, which aims at doing the same, but it is limited in scope, the regex used here should give a little more functionality.