### PR TITLE
turn off Logging for TEST enviroment

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -29,4 +29,8 @@ Loomio::Application.configure do
 
   config.action_mailer.raise_delivery_errors = true
   config.middleware.use RackSessionAccess::Middleware
+
+  # Turns off logging for test environment, 6% speed up for testsuit
+  config.logger = Logger.new(nil)
+  config.log_level = :fatal
 end


### PR DESCRIPTION
Noticed your testsuite execution times and decided to help you out with it a bit. ;-)

This is a very simple trick -- turn off your Logging and get a 6% speed up to testsuite. 