### PR TITLE
checkout as orphan branch to make deployment faster

### DIFF
--- a/lib/tasks/deploy.rake
+++ b/lib/tasks/deploy.rake
@@ -27,7 +27,7 @@ task :deploy do
   puts "Deploying branch #{branch} to #{remote}..."
   run_commands [
     "git checkout #{branch}",                                                         # move to specified deploy branch
-    "git checkout -b #{temp_branch}",                                                 # cut a new deploy branch based on specified branch
+    "git checkout --orphan #{temp_branch}",                                                 # cut a new deploy branch based on specified branch
     "bundle exec rake deploy:bump_version[#{temp_branch},#{is_production_push}]",     # bump version if this is a production deploy
     "bundle exec rake deploy:build",                                                  # build assets
     "bundle exec rake deploy:commit",                                                 # add deploy commit
@@ -70,7 +70,7 @@ namespace :deploy do
     puts "Committing assets to deployment branch..."
     run_commands [
       "find fetched_plugins -name '*.*' | xargs git add -f",                          # add plugins folder to commit
-      "find public/img/emojis -name '*.png' | xargs git add -f",                      # add emojis to commit    
+      "find public/img/emojis -name '*.png' | xargs git add -f",                      # add emojis to commit
       "rm plugins; ln -s fetched_plugins plugins",                                    # add plugins symlink
       "git add -f plugins",                                                           # add symlink to repo
       "git add public/client/#{Loomio::Version.current} public/client/fonts -f",      # add assets to commit


### PR DESCRIPTION
untested (sorry!) but if the command is correct this will save bandwidth when deploying over mobile connections (which I've been doing recently)