### PR TITLE
fixes incorrect reference to string in locales

### DIFF
--- a/angular/core/components/email_settings_page/email_settings_page.haml
+++ b/angular/core/components/email_settings_page/email_settings_page.haml
@@ -40,4 +40,4 @@
               .email-settings-page__membership-volume{translate: "change_volume_form.{{emailSettingsPage.groupVolume(group)}}_label"}
             .email-settings-page__edit
               %md-button.md-accent.email-settings-page__edit-membership-volume-link{ng-click: "emailSettingsPage.editSpecificGroupVolume(group)", translate: "email_settings_page.edit"}
-        %a.email-settings-page__learn-more-link{href: "https://loomio.gitbooks.io/manual/content/en/keeping_up_to_date.html", target: "_blank", translate: "email_settings.learn_more"}
+        %a.email-settings-page__learn-more-link{href: "https://loomio.gitbooks.io/manual/content/en/keeping_up_to_date.html", target: "_blank", translate: "email_settings_page.learn_more"}


### PR DESCRIPTION
This should allow to display the locale string instead of its name.