### PR TITLE
add seen by count to discussion context

### DIFF
--- a/angular/core/components/thread_page/context_panel/context_panel.haml
+++ b/angular/core/components/thread_page/context_panel/context_panel.haml
@@ -45,9 +45,9 @@
     %span.nowrap.context-panel__discussion-privacy.context-panel__discussion-privacy--public{ng-show: "!discussion.private"}>
       %i.mdi.mdi-earth>
       %span{translate: "common.privacy.public"}>
-    %span{ng-show: "discussion.discussionReadersCount > 0"}>
+    %span{ng-show: "discussion.seenByCount > 0"}>
       %span{aria-hidden: "true"}>·
-      %span.context-panel__seen_by_count{ translate: "thread_context.seen_by_count", translate-value-count: "{{discussion.discussionReadersCount}}"}
+      %span.context-panel__seen_by_count{ translate: "thread_context.seen_by_count", translate-value-count: "{{discussion.seenByCount}}"}
     %outlet{name: "after-thread-title", model: "discussion"}
 
   .context-panel__description.lmo-markdown-wrapper{ng-if: "!translation", marked: "discussion.cookedDescription()", aria-label: "{{ 'thread_context.aria_label' | translate }}" }

--- a/angular/core/components/thread_page/context_panel/context_panel.haml
+++ b/angular/core/components/thread_page/context_panel/context_panel.haml
@@ -41,10 +41,13 @@
     %span{aria-hidden: "true"}·
     %span.nowrap.context-panel__discussion-privacy.context-panel__discussion-privacy--private{ng-show: "discussion.private"}>
       %i.mdi.mdi-lock-outline>
-      %span{translate: "common.privacy.private"}
+      %span{translate: "common.privacy.private"}>
     %span.nowrap.context-panel__discussion-privacy.context-panel__discussion-privacy--public{ng-show: "!discussion.private"}>
       %i.mdi.mdi-earth>
-      %span{translate: "common.privacy.public"}
+      %span{translate: "common.privacy.public"}>
+    %span{ng-show: "discussion.discussionReadersCount > 0"}>
+      %span{aria-hidden: "true"}>·
+      %span.context-panel__seen_by_count{ translate: "thread_context.seen_by_count", translate-value-count: "{{discussion.discussionReadersCount}}"}
     %outlet{name: "after-thread-title", model: "discussion"}
 
   .context-panel__description.lmo-markdown-wrapper{ng-if: "!translation", marked: "discussion.cookedDescription()", aria-label: "{{ 'thread_context.aria_label' | translate }}" }

--- a/angular/core/components/thread_page/thread_item/thread_item.scss
+++ b/angular/core/components/thread_page/thread_item/thread_item.scss
@@ -46,6 +46,11 @@
   text-decoration: underline;
 }
 
+.thread-item__link abbr span {
+  font-weight: normal;
+  color: $grey-on-white;
+}
+
 .thread-item__action {
   @include lmoBtnLink;
   color: $link-color;

--- a/angular/core/css/1_utilities.scss
+++ b/angular/core/css/1_utilities.scss
@@ -135,8 +135,6 @@ textarea .lmo-textarea {
 }
 
 .timeago{
-  @include fontTiny();
-  color: $grey-on-white;
   white-space: nowrap;
 }
 

--- a/app/models/discussion.rb
+++ b/app/models/discussion.rb
@@ -85,10 +85,11 @@ class Discussion < ActiveRecord::Base
 
   after_create :set_last_activity_at_to_created_at
 
-  define_counter_cache(:closed_polls_count)   { |discussion| discussion.polls.closed.count }
-  define_counter_cache(:versions_count)       { |discussion| discussion.versions.where(event: :update).count }
-  define_counter_cache(:items_count)          { |discussion| discussion.items.count }
-  define_counter_cache(:salient_items_count)  { |discussion| discussion.salient_items.count }
+  define_counter_cache(:closed_polls_count)       { |discussion| discussion.polls.closed.count }
+  define_counter_cache(:versions_count)           { |discussion| discussion.versions.where(event: :update).count }
+  define_counter_cache(:items_count)              { |discussion| discussion.items.count }
+  define_counter_cache(:salient_items_count)      { |discussion| discussion.salient_items.count }
+  define_counter_cache(:discussion_readers_count) { |discussion| discussion.discussion_readers.count }
 
   update_counter_cache :group, :discussions_count
   update_counter_cache :group, :public_discussions_count

--- a/app/models/discussion.rb
+++ b/app/models/discussion.rb
@@ -89,7 +89,7 @@ class Discussion < ActiveRecord::Base
   define_counter_cache(:versions_count)           { |discussion| discussion.versions.where(event: :update).count }
   define_counter_cache(:items_count)              { |discussion| discussion.items.count }
   define_counter_cache(:salient_items_count)      { |discussion| discussion.salient_items.count }
-  define_counter_cache(:discussion_readers_count) { |discussion| discussion.discussion_readers.count }
+  define_counter_cache(:seen_by_count)            { |discussion| discussion.discussion_readers.where("last_read_at is not null").count }
 
   update_counter_cache :group, :discussions_count
   update_counter_cache :group, :public_discussions_count

--- a/app/models/discussion_reader.rb
+++ b/app/models/discussion_reader.rb
@@ -7,6 +7,8 @@ class DiscussionReader < ActiveRecord::Base
   delegate :update_importance, to: :discussion
   delegate :importance, to: :discussion
 
+  update_counter_cache :discussion, :discussion_readers_count
+
   def self.for(user:, discussion:)
     if user&.is_logged_in?
       find_or_create_by(user: user, discussion: discussion)

--- a/app/models/discussion_reader.rb
+++ b/app/models/discussion_reader.rb
@@ -7,7 +7,7 @@ class DiscussionReader < ActiveRecord::Base
   delegate :update_importance, to: :discussion
   delegate :importance, to: :discussion
 
-  update_counter_cache :discussion, :discussion_readers_count
+  update_counter_cache :discussion, :seen_by_count
 
   def self.for(user:, discussion:)
     if user&.is_logged_in?

--- a/app/serializers/discussion_reader_serializer.rb
+++ b/app/serializers/discussion_reader_serializer.rb
@@ -6,7 +6,9 @@ class DiscussionReaderSerializer < ActiveModel::Serializer
              :read_items_count,
              :read_salient_items_count,
              :last_read_sequence_id,
-             :last_read_at
+             :last_read_at,
+             :seen_by_count
+
 
   def id
     object.discussion_id
@@ -14,5 +16,9 @@ class DiscussionReaderSerializer < ActiveModel::Serializer
 
    def discussion_reader_id
      object.id
+   end
+
+   def seen_by_count
+     object.discussion.seen_by_count
    end
 end

--- a/app/serializers/discussion_serializer.rb
+++ b/app/serializers/discussion_serializer.rb
@@ -27,6 +27,7 @@ class DiscussionSerializer < ActiveModel::Serializer
              :last_sequence_id,
              :last_comment_at,
              :last_activity_at,
+             :discussion_readers_count,
              :created_at,
              :updated_at,
              :archived_at,

--- a/app/serializers/discussion_serializer.rb
+++ b/app/serializers/discussion_serializer.rb
@@ -27,7 +27,7 @@ class DiscussionSerializer < ActiveModel::Serializer
              :last_sequence_id,
              :last_comment_at,
              :last_activity_at,
-             :discussion_readers_count,
+             :seen_by_count,
              :created_at,
              :updated_at,
              :archived_at,

--- a/app/serializers/mark_as_seen/discussion_serializer.rb
+++ b/app/serializers/mark_as_seen/discussion_serializer.rb
@@ -1,0 +1,4 @@
+class MarkAsSeen::DiscussionSerializer < ActiveModel::Serializer
+  embed :ids, include: true
+  attributes :id, :key, :seen_by_count
+end

--- a/app/services/discussion_service.rb
+++ b/app/services/discussion_service.rb
@@ -75,7 +75,7 @@ class DiscussionService
   def self.mark_as_seen(discussion:, actor:)
     actor.ability.authorize! :mark_as_seen, discussion
     DiscussionReader.for_model(discussion, actor).update_attribute(:last_read_at, discussion.created_at)
-    EventBus.broadcast('discussion_mark_as_seen', discussion, actor)
+    EventBus.broadcast('discussion_mark_as_seen', discussion.reload, actor)
   end
 
   def self.dismiss(discussion:, params:, actor:)

--- a/config/initializers/event_bus.rb
+++ b/config/initializers/event_bus.rb
@@ -68,8 +68,15 @@ EventBus.configure do |config|
 
   config.listen('discussion_reader_viewed!', 'discussion_reader_dismissed!') do |reader|
     MessageChannelService.publish(
-      DiscussionReaderSerializer.new(reader, root: :discussions).as_json,
+      ActiveModel::ArraySerializer.new([reader], each_serializer: DiscussionReaderSerializer, root: :discussions).as_json,
       to: reader.user
+    )
+  end
+
+  config.listen('discussion_mark_as_seen') do |discussion, actor|
+    MessageChannelService.publish(
+      ActiveModel::ArraySerializer.new([discussion], each_serializer: MarkAsSeen::DiscussionSerializer, root: :discussions).as_json,
+      to: discussion.group
     )
   end
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -891,6 +891,7 @@ en:
     print_thread: 'Print'
     delete_thread: 'Delete'
     add_comment: 'Comment'
+    seen_by_count: 'Seen by {{count}}'
 
   pin_thread_modal:
     title: Pin thread

--- a/db/migrate/20171103062211_add_discussion_readers_count.rb
+++ b/db/migrate/20171103062211_add_discussion_readers_count.rb
@@ -1,0 +1,5 @@
+class AddDiscussionReadersCount < ActiveRecord::Migration
+  def change
+    add_column :discussions, :discussion_readers_count, :integer, null: false, default: 0
+  end
+end

--- a/db/migrate/20171103062211_add_discussion_readers_count.rb
+++ b/db/migrate/20171103062211_add_discussion_readers_count.rb
@@ -1,5 +1,6 @@
 class AddDiscussionReadersCount < ActiveRecord::Migration
   def change
-    add_column :discussions, :discussion_readers_count, :integer, null: false, default: 0
+    add_column :discussions, :seen_by_count, :integer, null: false, default: 0
+    add_index :discussion_readers, :last_read_at
   end
 end

--- a/db/migrate/20171103062701_update_discussion_readers_count.rb
+++ b/db/migrate/20171103062701_update_discussion_readers_count.rb
@@ -1,5 +1,5 @@
 class UpdateDiscussionReadersCount < ActiveRecord::Migration
   def change
-    Discussion.find_each(batch_size: 100) { |d| d.update_discussion_readers_count }
+    Discussion.find_each(batch_size: 100) { |d| d.update_seen_by_count }
   end
 end

--- a/db/migrate/20171103062701_update_discussion_readers_count.rb
+++ b/db/migrate/20171103062701_update_discussion_readers_count.rb
@@ -1,0 +1,5 @@
+class UpdateDiscussionReadersCount < ActiveRecord::Migration
+  def change
+    Discussion.find_each(batch_size: 100) { |d| d.update_discussion_readers_count }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -188,6 +188,7 @@ ActiveRecord::Schema.define(version: 20171103062701) do
   end
 
   add_index "discussion_readers", ["discussion_id"], name: "index_motion_read_logs_on_discussion_id", using: :btree
+  add_index "discussion_readers", ["last_read_at"], name: "index_discussion_readers_on_last_read_at", using: :btree
   add_index "discussion_readers", ["participating"], name: "index_discussion_readers_on_participating", using: :btree
   add_index "discussion_readers", ["user_id", "discussion_id"], name: "index_discussion_readers_on_user_id_and_discussion_id", unique: true, using: :btree
   add_index "discussion_readers", ["user_id", "volume"], name: "index_discussion_readers_on_user_id_and_volume", using: :btree
@@ -214,25 +215,25 @@ ActiveRecord::Schema.define(version: 20171103062701) do
     t.integer  "author_id"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "title",                    limit: 255
+    t.string   "title",               limit: 255
     t.datetime "last_comment_at"
     t.text     "description"
-    t.boolean  "uses_markdown",                        default: false, null: false
-    t.boolean  "is_deleted",                           default: false, null: false
-    t.integer  "items_count",                          default: 0,     null: false
+    t.boolean  "uses_markdown",                   default: false, null: false
+    t.boolean  "is_deleted",                      default: false, null: false
+    t.integer  "items_count",                     default: 0,     null: false
     t.datetime "archived_at"
     t.boolean  "private"
-    t.string   "key",                      limit: 255
-    t.string   "iframe_src",               limit: 255
+    t.string   "key",                 limit: 255
+    t.string   "iframe_src",          limit: 255
     t.datetime "last_activity_at"
-    t.integer  "last_sequence_id",                     default: 0,     null: false
-    t.integer  "first_sequence_id",                    default: 0,     null: false
-    t.integer  "salient_items_count",                  default: 0,     null: false
-    t.integer  "versions_count",                       default: 0
-    t.integer  "closed_polls_count",                   default: 0,     null: false
-    t.boolean  "pinned",                               default: false, null: false
-    t.integer  "importance",                           default: 0,     null: false
-    t.integer  "discussion_readers_count",             default: 0,     null: false
+    t.integer  "last_sequence_id",                default: 0,     null: false
+    t.integer  "first_sequence_id",               default: 0,     null: false
+    t.integer  "salient_items_count",             default: 0,     null: false
+    t.integer  "versions_count",                  default: 0
+    t.integer  "closed_polls_count",              default: 0,     null: false
+    t.boolean  "pinned",                          default: false, null: false
+    t.integer  "importance",                      default: 0,     null: false
+    t.integer  "seen_by_count",                   default: 0,     null: false
   end
 
   add_index "discussions", ["author_id"], name: "index_discussions_on_author_id", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170903235705) do
+ActiveRecord::Schema.define(version: 20171103062701) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -214,24 +214,25 @@ ActiveRecord::Schema.define(version: 20170903235705) do
     t.integer  "author_id"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "title",               limit: 255
+    t.string   "title",                    limit: 255
     t.datetime "last_comment_at"
     t.text     "description"
-    t.boolean  "uses_markdown",                   default: false, null: false
-    t.boolean  "is_deleted",                      default: false, null: false
-    t.integer  "items_count",                     default: 0,     null: false
+    t.boolean  "uses_markdown",                        default: false, null: false
+    t.boolean  "is_deleted",                           default: false, null: false
+    t.integer  "items_count",                          default: 0,     null: false
     t.datetime "archived_at"
     t.boolean  "private"
-    t.string   "key",                 limit: 255
-    t.string   "iframe_src",          limit: 255
+    t.string   "key",                      limit: 255
+    t.string   "iframe_src",               limit: 255
     t.datetime "last_activity_at"
-    t.integer  "last_sequence_id",                default: 0,     null: false
-    t.integer  "first_sequence_id",               default: 0,     null: false
-    t.integer  "salient_items_count",             default: 0,     null: false
-    t.integer  "versions_count",                  default: 0
-    t.integer  "closed_polls_count",              default: 0,     null: false
-    t.boolean  "pinned",                          default: false, null: false
-    t.integer  "importance",                      default: 0,     null: false
+    t.integer  "last_sequence_id",                     default: 0,     null: false
+    t.integer  "first_sequence_id",                    default: 0,     null: false
+    t.integer  "salient_items_count",                  default: 0,     null: false
+    t.integer  "versions_count",                       default: 0
+    t.integer  "closed_polls_count",                   default: 0,     null: false
+    t.boolean  "pinned",                               default: false, null: false
+    t.integer  "importance",                           default: 0,     null: false
+    t.integer  "discussion_readers_count",             default: 0,     null: false
   end
 
   add_index "discussions", ["author_id"], name: "index_discussions_on_author_id", using: :btree
@@ -752,7 +753,7 @@ ActiveRecord::Schema.define(version: 20170903235705) do
   add_index "user_deactivation_responses", ["user_id"], name: "index_user_deactivation_responses_on_user_id", using: :btree
 
   create_table "users", force: :cascade do |t|
-    t.citext   "email",                                        default: "",         null: false
+    t.citext   "email",                                        default: "",                    null: false
     t.string   "encrypted_password",               limit: 128, default: ""
     t.string   "reset_password_token",             limit: 255
     t.datetime "reset_password_sent_at"
@@ -767,39 +768,39 @@ ActiveRecord::Schema.define(version: 20170903235705) do
     t.string   "name",                             limit: 255
     t.datetime "deactivated_at"
     t.boolean  "is_admin",                                     default: false
-    t.string   "avatar_kind",                      limit: 255, default: "initials", null: false
+    t.string   "avatar_kind",                      limit: 255, default: "initials",            null: false
     t.string   "uploaded_avatar_file_name",        limit: 255
     t.string   "uploaded_avatar_content_type",     limit: 255
     t.integer  "uploaded_avatar_file_size"
     t.datetime "uploaded_avatar_updated_at"
     t.string   "avatar_initials",                  limit: 255
     t.string   "username",                         limit: 255
-    t.boolean  "email_when_proposal_closing_soon",             default: false,      null: false
+    t.boolean  "email_when_proposal_closing_soon",             default: false,                 null: false
     t.string   "authentication_token",             limit: 255
     t.string   "unsubscribe_token",                limit: 255
-    t.integer  "memberships_count",                            default: 0,          null: false
-    t.boolean  "uses_markdown",                                default: false,      null: false
+    t.integer  "memberships_count",                            default: 0,                     null: false
+    t.boolean  "uses_markdown",                                default: false,                 null: false
     t.string   "selected_locale",                  limit: 255
     t.string   "time_zone",                        limit: 255
     t.string   "key",                              limit: 255
     t.string   "detected_locale",                  limit: 255
-    t.boolean  "email_missed_yesterday",                       default: true,       null: false
+    t.boolean  "email_missed_yesterday",                       default: true,                  null: false
     t.string   "email_api_key",                    limit: 255
-    t.boolean  "email_when_mentioned",                         default: true,       null: false
-    t.boolean  "angular_ui_enabled",                           default: true,       null: false
-    t.boolean  "email_on_participation",                       default: true,       null: false
-    t.integer  "default_membership_volume",                    default: 2,          null: false
+    t.boolean  "email_when_mentioned",                         default: true,                  null: false
+    t.boolean  "angular_ui_enabled",                           default: true,                  null: false
+    t.boolean  "email_on_participation",                       default: true,                  null: false
+    t.integer  "default_membership_volume",                    default: 2,                     null: false
     t.string   "country"
     t.string   "region"
     t.string   "city"
-    t.jsonb    "experiences",                                  default: {},         null: false
+    t.jsonb    "experiences",                                  default: {},                    null: false
     t.integer  "facebook_community_id"
     t.integer  "slack_community_id"
     t.string   "remember_token"
-    t.string   "short_bio",                                    default: "",         null: false
-    t.boolean  "email_verified",                               default: false,      null: false
-    t.string   "location",                                     default: "",         null: false
-    t.datetime "last_seen_at",                                 default: "now()",    null: false
+    t.string   "short_bio",                                    default: "",                    null: false
+    t.boolean  "email_verified",                               default: false,                 null: false
+    t.string   "location",                                     default: "",                    null: false
+    t.datetime "last_seen_at",                                 default: '2017-10-18 21:05:12', null: false
   end
 
   add_index "users", ["deactivated_at"], name: "index_users_on_deactivated_at", using: :btree


### PR DESCRIPTION
Adds a "Seen by " to the metadata line on discussion context panel.

Issues:
I'd like to only update discussion readers count on reader create... how?

And in dev mode, creating a discussion ends up with Seen by 3, including Loomio Bot and Jennifer Grey.. just sometimes. WTF?

![image](https://user-images.githubusercontent.com/486367/32366523-55f26c54-c0e3-11e7-8b95-26929e13a458.png)
