### PR TITLE
adds missing title for explore public group page meta

### DIFF
--- a/angular/core/components/explore_page/explore_page_controller.coffee
+++ b/angular/core/components/explore_page/explore_page_controller.coffee
@@ -1,5 +1,5 @@
 angular.module('loomioApp').controller 'ExplorePageController', (Records, $rootScope, $timeout, AppConfig, LoadingService) ->
-  $rootScope.$broadcast('currentComponent', { page: 'explorePage'})
+  $rootScope.$broadcast('currentComponent', { titleKey: 'explore_page.header', page: 'explorePage'})
 
   @groupIds = []
   @resultsCount = 0


### PR DESCRIPTION
Other pages show "title | Loomio" in the meta, the explore groups page just displayed  "| Loomio"...