### PR TITLE
allow middle/scrollwheel click and right click open in new tab on sidebar and dropdown buttons that open a page

### DIFF
--- a/client/angular/components/navbar/navbar.haml
+++ b/client/angular/components/navbar/navbar.haml
@@ -6,7 +6,7 @@
           %i.mdi.mdi-menu
 
       .navbar__middle.lmo-flex.lmo-flex__horizontal-center
-        %a.lmo-pointer{lmo-href: "/dashboard"}
+        %a.lmo-pointer{lmo-href: "/dashboard", ng-href: "/dashboard"}
           %img{ng-src: "{{logo()}}"}
 
       .navbar__right

--- a/client/angular/components/sidebar/sidebar.haml
+++ b/client/angular/components/sidebar/sidebar.haml
@@ -3,19 +3,19 @@
     .sidebar__divider
     %md_list.sidebar__list.sidebar__threads{layout: "column", aria-label: "{{ 'sidebar.aria_labels.threads_list' | translate }}"}
       %md_list_item
-        %md_button.sidebar__list-item-button.sidebar__list-item-button--decisions{href: "", lmo-href: "/polls", ng-click: "isActive()", aria-label: "{{ 'sidebar.my_decisions' | translate }}", ng-class: "{'sidebar__list-item--selected': onPage('pollsPage')}"}
+        %md_button.sidebar__list-item-button.sidebar__list-item-button--decisions{ng-href: "/polls", lmo-href: "/polls", ng-click: "isActive()", aria-label: "{{ 'sidebar.my_decisions' | translate }}", ng-class: "{'sidebar__list-item--selected': onPage('pollsPage')}"}
           %md_avatar_icon.sidebar__list-item-icon.mdi.mdi-thumbs-up-down
           %span{translate: "common.decisions"}
       %md_list_item
-        %md_button.sidebar__list-item-button.sidebar__list-item-button--recent{href: "", lmo-href: "/dashboard", ng-click: "isActive()", aria-label: "{{ 'sidebar.recent' | translate }}", ng-class: "{'sidebar__list-item--selected': onPage('dashboardPage')}"}
+        %md_button.sidebar__list-item-button.sidebar__list-item-button--recent{ng-href: "/dashboard", lmo-href: "/dashboard", ng-click: "isActive()", aria-label: "{{ 'sidebar.recent' | translate }}", ng-class: "{'sidebar__list-item--selected': onPage('dashboardPage')}"}
           %i.sidebar__list-item-icon.mdi.mdi-forum
           %span{translate: "sidebar.recent_threads"}
       %md_list_item
-        %md_button.sidebar__list-item-button.sidebar__list-item-button--unread{href: "", lmo-href: "/inbox", ng-click: "isActive()", aria-label: "{{ 'sidebar.unread' | translate }}", ng-class: "{'sidebar__list-item--selected': onPage('inboxPage')}"}
+        %md_button.sidebar__list-item-button.sidebar__list-item-button--unread{ng-href: "/inbox", lmo-href: "/inbox", ng-click: "isActive()", aria-label: "{{ 'sidebar.unread' | translate }}", ng-class: "{'sidebar__list-item--selected': onPage('inboxPage')}"}
           %i.sidebar__list-item-icon.mdi.mdi-inbox
           %span{translate: "sidebar.unread_threads", translate-value-count: "{{unreadThreadCount()}}"}
       %md_list_item
-        %md_button.sidebar__list-item-button.sidebar__list-item-button--muted{href: "", lmo-href: "/dashboard/show_muted", ng-click: "isActive()", aria-label: "{{ 'sidebar.muted' | translate }}", ng-class: "{'sidebar__list-item--selected': onPage('dashboardPage', nil, 'show_muted')}"}
+        %md_button.sidebar__list-item-button.sidebar__list-item-button--muted{ng-href: "/dashboard/show_muted", lmo-href: "/dashboard/show_muted", ng-click: "isActive()", aria-label: "{{ 'sidebar.muted' | translate }}", ng-class: "{'sidebar__list-item--selected': onPage('dashboardPage', nil, 'show_muted')}"}
           %i.sidebar__list-item-icon.mdi.mdi-volume-mute
           %span{translate: "sidebar.muted_threads"}
       %md_list_item{ng-if: "canStartThreads()"}
@@ -26,14 +26,14 @@
     %md_list_item.sidebar__list-subhead{translate: "common.groups"}
     %md_list.sidebar__list.sidebar__groups{ng-class: "{'sidebar__no-groups': groups().length < 1}", aria-label: "{{ 'sidebar.aria_labels.groups_list' | translate }}"}
       %md_list_item{ng_repeat: "group in groups() | orderBy: 'fullName' track by group.id"}
-        %md_button.sidebar__list-item-button.sidebar__list-item-button--group{href: "", lmo-href: "{{groupUrl(group)}}", aria-label: "{{group.name}}", ng-if: "group.isParent()", ng-class: "{'sidebar__list-item--selected': onPage('groupPage', group.key)}"}
+        %md_button.sidebar__list-item-button.sidebar__list-item-button--group{ng-href: "{{groupUrl(group)}}", lmo-href: "{{groupUrl(group)}}", aria-label: "{{group.name}}", ng-if: "group.isParent()", ng-class: "{'sidebar__list-item--selected': onPage('groupPage', group.key)}"}
           %img.md-avatar.lmo-box--tiny.sidebar__list-item-group-logo{ng_src: "{{group.logoUrl()}}", alt: ""}
           %span {{group.name}}
-        %md_button.sidebar__list-item-button--subgroup{href: "", lmo-href: "{{groupUrl(group)}}", ng-if: "!group.isParent()", ng-class: "{'sidebar__list-item--selected': onPage('groupPage', group.key)}"}
+        %md_button.sidebar__list-item-button--subgroup{ng-href: "{{groupUrl(group)}}", lmo-href: "{{groupUrl(group)}}", ng-if: "!group.isParent()", ng-class: "{'sidebar__list-item--selected': onPage('groupPage', group.key)}"}
           {{group.name}}
         .sidebar__list-item-padding
       %md_list_item{ng-if: "canViewPublicGroups()"}
-        %md_button.sidebar__list-item-button.sidebar__list-item-button--explore{href: "", lmo-href: "/explore", aria-label: "{{ 'sidebar.explore' | translate }}", ng-class: "{'sidebar__list-item--selected': onPage('explorePage')}"}
+        %md_button.sidebar__list-item-button.sidebar__list-item-button--explore{ng-href: "/explore", lmo-href: "/explore", aria-label: "{{ 'sidebar.explore' | translate }}", ng-class: "{'sidebar__list-item--selected': onPage('explorePage')}"}
           %i.sidebar__list-item-icon.mdi.mdi-earth
           %span{translate: "sidebar.explore"}
       %md_list_item{ng-if: "canStartGroup()"}

--- a/client/angular/components/user/dropdown/user_dropdown.haml
+++ b/client/angular/components/user/dropdown/user_dropdown.haml
@@ -9,15 +9,15 @@
           .user-dropdown__user-username.lmo-truncate @{{user.username}}
         %user_avatar{user: "user", size: "medium"}
     %md-menu-item
-      %md_button.user-dropdown__list-item-button.user-dropdown__list-item-button--profile{href: "", lmo-href: "/profile", aria-label: "{{ 'user_dropdown.edit_profile' | translate }}", ng-class: "{'user_dropdown__list-item--selected': onPage('profilePage')}"}
+      %md_button.user-dropdown__list-item-button.user-dropdown__list-item-button--profile{ng-href: "/profile", lmo-href: "/profile", aria-label: "{{ 'user_dropdown.edit_profile' | translate }}", ng-class: "{'user_dropdown__list-item--selected': onPage('profilePage')}"}
         %i.mdi.mdi-18px.lmo-margin-right.mdi-account
         %span{translate: "user_dropdown.edit_profile"}
     %md-menu-item
-      %md_button.user-dropdown__list-item-button.user-dropdown__list-item-button--email-settings{href:  "", lmo-href: "/email_preferences", aria-label: "{{ 'user_dropdown.email_settings' | translate }}", ng-class: "{'user_dropdown__list-item--selected': onPage('emailSettingsPage')}"}
+      %md_button.user-dropdown__list-item-button.user-dropdown__list-item-button--email-settings{ng-href: "/email_preferences", lmo-href: "/email_preferences", aria-label: "{{ 'user_dropdown.email_settings' | translate }}", ng-class: "{'user_dropdown__list-item--selected': onPage('emailSettingsPage')}"}
         %i.mdi.mdi-18px.lmo-margin-right.mdi-settings
         %span{translate: "user_dropdown.email_settings"}
     %md-menu-item{ng-if: "showHelp()"}
-      %md_button.user-dropdown__list-item-button{href: "{{helpLink()}}", target: "_blank", aria-label: "{{ 'user_dropdown.help' | translate }}"}
+      %md_button.user-dropdown__list-item-button{ng-href: "{{helpLink()}}", target: "_blank", aria-label: "{{ 'user_dropdown.help' | translate }}"}
         %i.mdi.mdi-18px.lmo-margin-right.mdi-help-circle-outline
         %span{translate: "user_dropdown.help"}
     %md-menu-item


### PR DESCRIPTION
In sidebar, navbar and user-dropdown, replaces href attributes with ng-href because lmo-href alone doesn't allow middle/scrollwheel click and right click open.
Buttons opening modals and logout are untouched, middle/scrollwheel click has no effect on them, no open in new tab if right clicked. Cleaned-up the commits and merged with current master.

This should fix #3943 

