### PR TITLE
Fix Duplicate Attachment on Paste

### DIFF
--- a/angular/core/components/attachment/form/attachment_form.coffee
+++ b/angular/core/components/attachment/form/attachment_form.coffee
@@ -41,4 +41,3 @@ angular.module('loomioApp').directive 'attachmentForm', (Records) ->
 
     $scope.$on 'attachmentPasted', (event, file) ->
       $scope.files = [file]
-      

--- a/angular/core/components/attachment/form/attachment_form.coffee
+++ b/angular/core/components/attachment/form/attachment_form.coffee
@@ -41,4 +41,4 @@ angular.module('loomioApp').directive 'attachmentForm', (Records) ->
 
     $scope.$on 'attachmentPasted', (event, file) ->
       $scope.files = [file]
-      $scope.upload()
+      


### PR DESCRIPTION
Thanks to lines 8/9:
```

    $scope.$watch 'files', ->
      $scope.upload($scope.files) 

```
We don't need to call upload, since setting $scope.files will trigger upload anyway.