### PR TITLE
Add keyboard shortcuts to manipulate ranked choice options

### DIFF
--- a/angular/core/components/poll/ranked_choice/vote_form/poll_ranked_choice_vote_form.coffee
+++ b/angular/core/components/poll/ranked_choice/vote_form/poll_ranked_choice_vote_form.coffee
@@ -16,5 +16,28 @@ angular.module('loomioApp').directive 'pollRankedChoiceVoteForm', ->
           poll_option_id: option.id
           score:          $scope.numChoices - index
 
+    $scope.setSelected = (option) ->
+      $scope.selectedOption = option
+
+    $scope.selectedOptionIndex = ->
+      _.findIndex $scope.pollOptions, $scope.selectedOption
+
+    $scope.isSelected = (option) ->
+      $scope.selectedOption == option
+
     MentionService.applyMentions($scope, $scope.stance)
     KeyEventService.submitOnEnter($scope)
+    KeyEventService.registerKeyEvent $scope, 'pressedUpArrow', ->
+      swap($scope.selectedOptionIndex(), $scope.selectedOptionIndex() - 1)
+
+    KeyEventService.registerKeyEvent $scope, 'pressedDownArrow', ->
+      swap($scope.selectedOptionIndex(), $scope.selectedOptionIndex() + 1)
+
+    KeyEventService.registerKeyEvent $scope, 'pressedEsc', ->
+      $scope.selectedOption = null
+
+    swap = (fromIndex, toIndex) ->
+      return unless fromIndex >= 0 and fromIndex < $scope.pollOptions.length and
+                    toIndex   >= 0 and toIndex   < $scope.pollOptions.length
+      $scope.pollOptions[fromIndex]   = $scope.pollOptions[toIndex]
+      $scope.pollOptions[toIndex]     = $scope.selectedOption

--- a/angular/core/components/poll/ranked_choice/vote_form/poll_ranked_choice_vote_form.haml
+++ b/angular/core/components/poll/ranked_choice/vote_form/poll_ranked_choice_vote_form.haml
@@ -9,7 +9,7 @@
         %span{ng-if: "$index < numChoices"} {{$index+1}}
 
     %md-list.lmo-flex.lmo-flex__grow{layout: "column", sv-part: "pollOptions"}
-      %md-list-item.poll-common-vote-form__option.lmo-flex.lmo-pointer.lmo-flex__space-between{sv-element: "true", layout: "row", ng-repeat: "option in pollOptions track by option.id"}
+      %md-list-item.poll-common-vote-form__option.lmo-flex.lmo-pointer.lmo-flex__space-between{ng-click: "setSelected(option)", sv-element: "true", layout: "row", ng-class: "{'poll-common-vote-form__option--selected': isSelected(option)}", ng-repeat: "option in pollOptions track by option.id"}
         .poll-common-vote-form__option-name.poll-common-vote-form__border-chip.lmo-flex__grow{ng-style: "{'border-color': option.color}"}
           {{option.name}}
         %i.mdi.mdi-drag.poll-ranked-choice-vote-form__drag-handle

--- a/angular/core/components/poll/ranked_choice/vote_form/poll_ranked_choice_vote_form.scss
+++ b/angular/core/components/poll/ranked_choice/vote_form/poll_ranked_choice_vote_form.scss
@@ -1,8 +1,12 @@
 .poll-ranked-choice-vote-form {
   .poll-common-vote-form__option {
     width: 100%;
+    padding-right: 0;
     box-shadow: $whiteframe-shadow-2dp;
     background: $card-background-color;
+    &--selected {
+      background: $item-highlight-color
+    }
   }
   .poll-common-vote-form__border-chip {
     min-height: 36px;


### PR DESCRIPTION
Due to some feedback around drag and drop not being very good for accessibility, I've put in a way to manipulate the ranked choice options using only the keyboard, which should be a slightly nicer experience.