### PR TITLE
help users understand we convert timezones correctly

### DIFF
--- a/angular/core/components/poll/common/form_options/poll_common_form_options.coffee
+++ b/angular/core/components/poll/common/form_options/poll_common_form_options.coffee
@@ -1,7 +1,10 @@
-angular.module('loomioApp').directive 'pollCommonFormOptions', (PollService, AbilityService) ->
+angular.module('loomioApp').directive 'pollCommonFormOptions', (PollService, AbilityService, Session, TimeService) ->
   scope: {poll: '='}
   templateUrl: 'generated/components/poll/common/form_options/poll_common_form_options.html'
   controller: ($scope, KeyEventService) ->
+    $scope.currentZone = ->
+      TimeService.nameForZone(Session.user().timeZone)
+
     $scope.existingOptions = _.clone $scope.poll.pollOptionNames
 
     $scope.addOption = ->

--- a/angular/core/components/poll/common/form_options/poll_common_form_options.haml
+++ b/angular/core/components/poll/common/form_options/poll_common_form_options.haml
@@ -2,11 +2,10 @@
   %label.poll-common-form__options-label.md-caption{ng-if: "!datesAsOptions", translate: "poll_common_form.options"}
   .poll-meeting-form__label-and-timezone{ng-if: "datesAsOptions"}
     %label.nowrap.poll-common-form__options-label.md-caption.lmo-flex__grow{translate: "poll_meeting_form.timeslots"}
-    %time_zone_select.lmo-flex__shrink{zone: "poll.customFields.time_zone"}
   %md-list.md-block.poll-common-form__options
     %validation_errors{subject: "poll", field: "pollOptions"}
     %md-list-item{ng-if: "!poll.pollOptionNames.length"}
-      %p.lmo-hint-text{ng-if: "datesAsOptions", translate: "poll_meeting_form.no_options"}
+      %p.lmo-hint-text{ng-if: "datesAsOptions", translate: "poll_meeting_form.no_options", translate-values: "{zone: currentZone()}"}
       %p.lmo-hint-text{ng-if: "!datesAsOptions", translate: "poll_common_form.no_options"}
     %md-list-item.poll-common-form__list-item{ng-repeat: "name in poll.pollOptionNames"}
       %span.poll-poll-form__option-text{ng-if: "!datesAsOptions"} {{name}}

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1399,7 +1399,7 @@ en:
     meeting_created: Time poll created
     meeting_updated: Time poll updated
     timeslots: Time slots
-    no_options: "You haven't added any time slots yet."
+    no_options: Enter times in your current time zone ({{zone}}). Participants see times translated to their local time zone.
     meeting_duration: Meeting duration
     add_option_placeholder: Enter a new time
 


### PR DESCRIPTION
@gdpelican I think we need a translations for timezone/place_name, so we don't just shove english timezones everywhere. 

Any idea on the best way to do this?

Seems similar to translations for language name too