### PR TITLE
Do good things when removing event from thread

### DIFF
--- a/angular/core/components/thread_page/thread_item/thread_item.coffee
+++ b/angular/core/components/thread_page/thread_item/thread_item.coffee
@@ -1,4 +1,4 @@
-angular.module('loomioApp').directive 'threadItem', ($compile, $timeout, $translate, LmoUrlService, EventHeadlineService, Session, AbilityService, Records) ->
+angular.module('loomioApp').directive 'threadItem', ($compile, $timeout, $translate, FormService, LmoUrlService, EventHeadlineService, Session, AbilityService, Records) ->
   scope: {event: '=', eventWindow: '='}
   restrict: 'E'
   templateUrl: 'generated/components/thread_page/thread_item/thread_item.html'
@@ -15,8 +15,10 @@ angular.module('loomioApp').directive 'threadItem', ($compile, $timeout, $transl
           $scope.eventWindow.max = false
           $scope.$broadcast 'showReplyForm', comment
 
-    $scope.canRemove = (event) -> AbilityService.canRemoveEventFromThread(event)
-    $scope.remove    = (event) -> Records.events.removeFromThread(event)
+    $scope.canRemoveEvent = -> AbilityService.canRemoveEventFromThread($scope.event)
+    $scope.removeEvent = FormService.submit $scope, $scope.event,
+      submitFn: $scope.event.removeFromThread
+      flashSuccess: 'thread_item.event_removed'
 
     $scope.mdColors = ->
       obj = {'border-color': 'primary-500'}

--- a/angular/core/components/thread_page/thread_item/thread_item.haml
+++ b/angular/core/components/thread_page/thread_item/thread_item.haml
@@ -1,5 +1,6 @@
 .thread-item{md-colors: "mdColors()", ng-class: "{'thread-item--indent': indent(), 'thread-item--unread': isUnread()}", in-view: "$inview&&event.markAsRead()", in-view-options: "{throttle: 200}"}
   .lmo-flex.lmo-relative.lmo-action-dock-wrapper{layout: "row", id: "sequence-{{event.sequenceId}}"}
+    .lmo-disabled-form{ng-show: "isDisabled"}
     .thread-item__avatar.lmo-margin-right
       %user_avatar{user: "event.actor()", size: "small", ng-if: "event.actor()"}
     .thread-item__body.lmo-flex.lmo-flex__horizontal-center{layout: "column"}
@@ -18,6 +19,6 @@
           %span{aria-hidden: "true"}>·
           %a.thread-item__link.lmo-pointer{href: "{{::link()}}"}
             %timeago.timeago--inline{timestamp: "event.createdAt"}
-        %md-button.md-button--tiny{ng-if: "canRemove(event)", ng-click: "remove(event)"}
+        %md-button.md-button--tiny{ng-if: "canRemoveEvent()", ng-click: "removeEvent()"}
           %i.mdi.mdi-delete
       %thread_item_directive.thread-item__directive{event: "event"}

--- a/angular/core/models/event_model.coffee
+++ b/angular/core/models/event_model.coffee
@@ -57,6 +57,9 @@ angular.module('loomioApp').factory 'EventModel', (BaseModel) ->
     beforeRemove: ->
       _.invoke(@notifications(), 'remove')
 
+    removeFromThread: =>
+      @remote.patchMember(@id, 'remove_from_thread')
+
     next: ->
       @recordStore.events.find(parentId: @parentId, position: @position + 1)[0]
 

--- a/angular/core/models/event_records_interface.coffee
+++ b/angular/core/models/event_records_interface.coffee
@@ -2,9 +2,6 @@ angular.module('loomioApp').factory 'EventRecordsInterface', (BaseRecordsInterfa
   class EventRecordsInterface extends BaseRecordsInterface
     model: EventModel
 
-    removeFromThread: (event) ->
-      @remote.patchMember(event.id, 'remove_from_thread').then -> event.remove()
-
     fetchByDiscussion: (discussionKey, options = {}) ->
       options['discussion_key'] = discussionKey
       @fetch

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1508,7 +1508,7 @@ en:
     poll_edited:                   "<strong><a href='u/{{username}}'>{{author}}</a></strong> edited the {{polltype}}: <strong>{{title}}</strong>"
     poll_expired:                  "{{polltype}} closed: <strong>{{title}}</strong>"
     stance_created:                "<strong><a href='u/{{username}}'>{{author}}</a></strong> voted on: <strong>{{title}}</strong>"
-
+    event_removed:                 "Removed from thread"
 
   poll_admin_page:
     title: Admin - {{title}}


### PR DESCRIPTION
Now removing an event from the thread
- Displays a loading flash
- Displays a success message
- Doesn't allow double clicking
- Dims the event being removed