### PR TITLE
use polyfill for closest on ie11

### DIFF
--- a/angular/core/config/provide.coffee
+++ b/angular/core/config/provide.coffee
@@ -1,4 +1,21 @@
 angular.module('loomioApp').config ($provide) ->
+  # polyfill for closest for ie11
+  # from https://developer.mozilla.org/en-US/docs/Web/API/Element/closest
+  if !Element::matches
+    Element::matches = Element::msMatchesSelector or Element::webkitMatchesSelector
+    
+  if !Element::closest
+    Element::closest = (s) ->
+      el = this
+      if !document.documentElement.contains(el)
+        return null
+      loop
+        if el.matches(s)
+          return el
+        el = el.parentElement or el.parentNode
+        unless el != null
+          break
+      null
   # a decorator to allow mentio to work within modals
   # https://github.com/jeff-collins/ment.io/issues/68#issuecomment-200746901
   $provide.decorator 'mentioMenuDirective', ($delegate) ->


### PR DESCRIPTION
error:
https://errbit.loomio.io/apps/57215524657272000e000001/problems/5a2f83b929e6e20007dce940

polyfill source:
https://developer.mozilla.org/en-US/docs/Web/API/Element/closest

converted via js2coffee