### PR TITLE
keep aspect ratio of group banner at all screen sizes

### DIFF
--- a/angular/core/components/explore_page/explore_page.scss
+++ b/angular/core/components/explore_page/explore_page.scss
@@ -45,8 +45,9 @@
 }
 
 .explore-page__group-cover {
-  height: 100px;
-  background-size: cover;
+  height: 85px;
+  background-size: contain;
+  background-repeat: no-repeat
 }
 
 .explore-page__group-details {

--- a/angular/core/components/group_page/group_theme/group_theme.scss
+++ b/angular/core/components/group_page/group_theme/group_theme.scss
@@ -7,7 +7,6 @@
   left: 0;
   top: 0;
   width: 100%;
-  height: 320px;
   z-index: $z-zero;
   &:hover .group-theme__upload-photo {
     button { background: $background-transparent-color; }
@@ -16,9 +15,10 @@
 }
 
 .group-theme__header{
+  display:flex;
   width: 100%;
   position: relative;
-  min-height: 335px;
+  margin: 0 0 15px;
 }
 
 .group-theme__member-actions button{
@@ -27,7 +27,7 @@
 
 .group-theme__header--compact {
   position: relative;
-  margin: 215px 0 15px;
+  margin: 15px 0 15px;
 }
 
 .group-theme__header--compact img {
@@ -36,8 +36,6 @@
 }
 
 .group-theme__logo{
-  position: relative;
-  top: 215px;
   width: 108px;
   height: 108px;
   background: url('http://placehold.it/100x100') no-repeat top center white;
@@ -55,9 +53,9 @@
 
 .group-theme__name-and-actions{
   display: flex;
+  width: 100%;
   justify-content: space-between;
-  align-items: center;
-  margin-top: 175px;
+  align-items: flex-end;
 }
 
 @media (max-width: $small-max-px){
@@ -70,7 +68,6 @@
 
 .group-theme__actions {
   display: flex;
-  margin-left: auto;
 }
 
 .group-theme__member-actions{
@@ -78,7 +75,7 @@
 }
 
 .group-theme__name {
-  margin-left: 108px + 15px;
+  margin-left: 15px;
   margin-right: 10px;
   a {
     color: $primary-text-color;
@@ -126,3 +123,4 @@
   @include fontTiny;
   color: $primary-text-color;
 }
+

--- a/angular/core/css/1_layout.scss
+++ b/angular/core/css/1_layout.scss
@@ -19,7 +19,6 @@
 
 .lmo-two-column-layout{
   max-width: $max-container-size;
-  padding-top: 48px;
 }
 
 .lmo-row{
@@ -38,10 +37,14 @@
 .lmo-main-background {
   position: absolute;
   width: 100%;
-  background-size: cover;
+}
+
+.lmo-group-background {
+  background-size: contain;
   background-repeat: no-repeat;
   background-position: top center;
-  height: 320px;
+  height: 0;
+  padding-top: 22.85%;
 }
 
 @media(max-width: $tiny-max-px) {
@@ -97,6 +100,9 @@
   }
   .lmo-thread-column-left {
     width: percentage(1 - $large-right-col-ratio);
+  }
+  .lmo-two-column-layout{
+    margin-top: -54px;
   }
 }
 

--- a/angular/core/root_controller.coffee
+++ b/angular/core/root_controller.coffee
@@ -51,7 +51,7 @@ angular.module('loomioApp').controller 'RootController', ($scope, $timeout, $tra
 
   $scope.$on 'setBackgroundImageUrl', (event, group) ->
     url = group.coverUrl(ViewportService.viewportSize())
-    angular.element(document.querySelector('.lmo-main-background')).attr('style', "background-image: url(#{url})")
+    angular.element(document.querySelector('.lmo-main-background')).attr('style', "background-image: url(#{url})").addClass('lmo-group-background')
 
   $scope.$on 'clearBackgroundImageUrl', (event) ->
     angular.element(document.querySelector('.lmo-main-background')).removeAttr('style')


### PR DESCRIPTION
uses background-size: contain and 22.85% padding to maintain aspect ratio and show all of the banner image on all screens