### PR TITLE
Fix Check count results page (#4445)

### DIFF
--- a/angular/core/components/poll/count/chart_panel/poll_count_chart_panel.haml
+++ b/angular/core/components/poll/count/chart_panel/poll_count_chart_panel.haml
@@ -6,5 +6,5 @@
       .poll-count-chart-panel__no{ng-style: "{'flex-basis': percentComplete(1), 'background-color': colors[1]}"}
       .poll-count-chart-panel__yes{ng-style: "{'flex-basis': percentComplete(0), 'background-color': colors[0]}"}
     .poll-count-chart-panel__data
-      .poll-count-chart-panel__numerator {{poll.stanceCounts[0]}}
+      .poll-count-chart-panel__numerator {{poll.stanceCounts[0] + poll.stanceCounts[1]}}
       .poll-count-chart-panel__denominator{translate: "poll_count_chart_panel.out_of", translate-value-goal: "{{poll.goal()}}"}

--- a/angular/core/components/poll/count/chart_panel/poll_count_chart_panel.haml
+++ b/angular/core/components/poll/count/chart_panel/poll_count_chart_panel.haml
@@ -6,5 +6,5 @@
       .poll-count-chart-panel__no{ng-style: "{'flex-basis': percentComplete(1), 'background-color': colors[1]}"}
       .poll-count-chart-panel__yes{ng-style: "{'flex-basis': percentComplete(0), 'background-color': colors[0]}"}
     .poll-count-chart-panel__data
-      .poll-count-chart-panel__numerator {{poll.stanceCounts[0] + poll.stanceCounts[1]}}
+      .poll-count-chart-panel__numerator {{poll.stancesCount}}
       .poll-count-chart-panel__denominator{translate: "poll_count_chart_panel.out_of", translate-value-goal: "{{poll.goal()}}"}

--- a/angular/core/models/poll_model.coffee
+++ b/angular/core/models/poll_model.coffee
@@ -123,7 +123,7 @@ angular.module('loomioApp').factory 'PollModel', (BaseModel, HasDocuments, HasDr
       @closedAt?
 
     goal: ->
-      @customFields.goal or @membersCount().length
+      @customFields.goal or @membersCount()
 
     close: =>
       @remote.postMember(@key, 'close')


### PR DESCRIPTION
Root cause of bug in #4445: membersCount() returns an integer for the total members, whereas in the fallback of goal() it was treated as if it returned a list (of members)

Per discussion in #4445, this PR also updates the numerator of the check poll results to be the total responses, not the Yes responses.