### PR TITLE
displays location and lastSeen on group members page and fixes minor glitches

### DIFF
--- a/angular/core/components/memberships_page/memberships_page_controller.coffee
+++ b/angular/core/components/memberships_page/memberships_page_controller.coffee
@@ -1,5 +1,5 @@
 angular.module('loomioApp').controller 'MembershipsPageController', ($routeParams, $rootScope, Records, LoadingService, ModalService, InvitationModal, RemoveMembershipForm, AbilityService, FlashService, ScrollService) ->
-  $rootScope.$broadcast('currentComponent', { page: 'membershipsPage'})
+  $rootScope.$broadcast('currentComponent', { titleKey: 'memberships_page.members', page: 'membershipsPage'})
 
   @init = (group) =>
     return if @group? or !group?

--- a/angular/core/components/memberships_page/memberships_panel/memberships_panel.haml
+++ b/angular/core/components/memberships_page/memberships_panel/memberships_panel.haml
@@ -2,10 +2,11 @@
   .memberships-panel__membership.lmo-flex.lmo-flex__center{ng-repeat: "membership in memberships() | orderBy: '-admin' track by membership.id", data-username: "{{membership.user().username}}"}
     %user_avatar{user: "membership.user()", size: "medium", coordinator: "membership.admin"}
     .memberships-panel__user.lmo-flex.lmo-flex__grow{layout: "column"}
-      %a{lmo-href-for: "membership.user()"} {{::membership.user().name}}
+      %a{lmo-href-for: "membership.user()"} {{::membership.user().name}} (@{{::membership.user().username}})
       %outlet{name: "after-membership-user", model: "membership"}
       .md-caption
-        %i @{{::membership.user().username}}
+        %div{translate: "user_page.location_field", translate-value-value: "{{::membership.user().location}}", ng-if: "::membership.user().location"}
+        %div{translate: "user_page.online_field", translate-value-value: "{{::membership.user().lastSeenAt | timeFromNowInWords}}", ng-if: "::membership.user().lastSeenAt"}
     .memberships-page__actions{ng-if: "canAdministerGroup()", layout: "row"}
       %md-button.memberships-panel__toggle-coordinator{translate: "memberships_panel.remove_coordinator", ng-if: "membership.admin", ng-click: "toggleAdmin(membership)", ng-disabled: "!canToggleAdmin(membership)"}
       %md-button.md-primary.memberships-panel__toggle-coordinator{translate: "memberships_panel.add_coordinator", ng-if: "!membership.admin", ng-click: "toggleAdmin(membership)"}

--- a/angular/core/components/user_page/user_page_controller.coffee
+++ b/angular/core/components/user_page/user_page_controller.coffee
@@ -7,7 +7,7 @@ angular.module('loomioApp').controller 'UserPageController', ($rootScope, $route
       @loadGroupsFor(@user)
 
   @location = =>
-    @user.location || @user.detectedLocation().join(', ')
+    @user.location
 
   @canContactUser = ->
     AbilityService.canContactUser(@user)

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -497,8 +497,8 @@ en:
     members: 'Members'
     members_placeholder: 'You''re the only one here: invite some people to join you!'
     member_options: Member options
-    see_all_members: 'See all: ({{count}}) members'
-    pending_invitations: '+ ({{count}}) pending'
+    see_all_members: 'See all {{count}} members'
+    pending_invitations: '+ {{count}} pending'
     subgroups: 'Subgroups'
     subgroups_placeholder: 'Subgroups give teams their own space and keep notifications focused to the right people.'
     invite_people: 'Invite'

--- a/config/locales/client.fr.yml
+++ b/config/locales/client.fr.yml
@@ -458,8 +458,8 @@ fr:
     members: 'Les membres'
     members_placeholder: 'Vous êtes le seul membre ici: invitez des personnes à vous rejoindre !'
     member_options: Options des membres
-    see_all_members: 'Voir les ({{count}}) membres'
-    pending_invitations: '+ ({{count}}) en attente'
+    see_all_members: 'Voir les {{count}} membres'
+    pending_invitations: '+ {{count}} en attente'
     subgroups: 'Sous-groupes'
     subgroups_placeholder: 'Les sous-groupes permettent à chaque équipe de disposer de son propre espace et d’envoyer les notifications aux bonnes personnes.'
     invite_people: 'Inviter'


### PR DESCRIPTION
Using Loomio in a large group that doesn't meet IRL, I find that it would be useful to know where members are (if they choose to enter a location, as discussed in #4391) and if they've been active on loomio recently (this can be useful for coordinators to gauge their group engagement too, see [this comment](https://www.loomio.org/d/laZLgn2I/time-poll/13)).

![image](https://user-images.githubusercontent.com/3848493/35003658-bdadf130-faed-11e7-9f39-4d9a8fb7edab.png)


This PR also hides inaccurate detected locations from GUI per #4391, adds page title to group page header and removes unecessary parenthesis from users panel in locales. Sorry for this all-in-one commit :-(

