### PR TITLE
hides domain from email address displayed in pending invitations for better privacy

### DIFF
--- a/angular/core/components/memberships_page/pending_invitations_card/pending_invitations_card.haml
+++ b/angular/core/components/memberships_page/pending_invitations_card/pending_invitations_card.haml
@@ -4,7 +4,7 @@
     .pending-invitations-card__pending-invitations
       .lmo-flex.lmo-flex__center.pending-invitations-card__invitation{layout: "row", ng-repeat: "invitation in group.pendingInvitations() track by invitation.id"}
         .lmo-flex__grow.lmo-flex{layout: "column"}
-          %strong {{invitation.recipientEmail}}
+          %span {{invitation.recipientEmail.split('@')[0]}}
           .lmo-hint-text{translate: "pending_invitations_card.sent_at", translate-value-date: "{{invitationCreatedAt(invitation)}}"}
         .memberships-page__actions
           %loading{ng-if: "invitation.resending"}


### PR DESCRIPTION
fixes #593, by displaying only the email address prefix so that other members have to guess the domain instead of seeing the full email address, in order to protect invited users from spam.