### PR TITLE
start of detecting when thread items are missing

### DIFF
--- a/client/angular/components/thread_page/activity_card/activity_card.haml
+++ b/client/angular/components/thread_page/activity_card/activity_card.haml
@@ -20,13 +20,6 @@
     firstLoaded: {{eventWindow.firstLoaded()}}
     lastLoaded:  {{eventWindow.lastLoaded()}}
     loadedCount: {{eventWindow.numLoaded()}}
-    -# -
-    -# read: {{discussion.readItemsCount()}}
-    -# unread: {{discussion.unreadItemsCount()}}
-    -# firstUnread {{discussion.firstUnreadSequenceId()}}
-    -# initialSequenceId: {{initialSequenceId(initialPosition())}}
-    -# requestedSequenceId:  {{discussion.requestedSequenceId}}
-    -# position: {{initialPosition()}}
 
   %loading_content.lmo-card-left-right-padding{ng-if: "loader.loading", block-count: 2}
   .activity-card__content{ng-if: "!loader.loading"}
@@ -34,11 +27,11 @@
       %i.mdi.mdi-autorenew>
       %span{translate: "discussion.load_previous", translate-value-count: "{{eventWindow.numPrevious()}}"}
     %loading.activity-card__loading.page-loading{ng-show: "eventWindow.loader.loadingPrevious"}
-    -# .activity-card__no-activity.lmo-placeholder.align-center{ng-if: "!eventWindow.anyLoaded()", translate: "discussion.activity_placeholder"}
     %ul.activity-card__activity-list
       %li.activity-card__activity-list-item{ng_repeat: "event in eventWindow.windowedEvents() track by event.id"}
-        -# %div lastInWindow {{eventWindow.isLastInWindow(event) }} anyNext: {{eventWindow.anyNext()}} lastSid: {{event.discussion().lastSequenceId}}
         %thread_item{event: "event", event_window: "eventWindow"}
+        .missing-events{ng-if: "eventWindow.isNested && eventWindow.positionIsMissing(event.position + 1)"}
+          events are missing from here. and we need to show a load more so you can see em.
     .activity-card__load-more-sensor.lmo-no-print{in-view: "$inview && !eventWindow.loader.loadingMore && eventWindow.anyNext() && eventWindow.showNext()", in-view-options: "{throttle: 200}"}
     %loading.activity-card__loading.page-loading{ng-show: "eventWindow.loader.loadingMore"}
 

--- a/client/shared/services/nested_event_window.coffee
+++ b/client/shared/services/nested_event_window.coffee
@@ -49,6 +49,11 @@ module.exports = class NestedEventWindow extends BaseEventWindow
   loadedEvents: ->
     @eventsQuery().simplesort('position').data()
 
+  positionIsMissing: (pos) =>
+    pos >= @min &&
+    ((pos <= @max) || (@max == false)) &&
+    !_.contains(_.pluck(@windowedEvents(), 'position'), pos)
+
   # windowed Events
   windowedEvents: ->
     query =


### PR DESCRIPTION
this is to address #4527, which I don't consider a bug.. it's just a not yet developed feature of the new thread renderer, that you can expand the middle as well as the top, bottom or branch of a thread.

Need to create a test case which loads the thread in the way Rich has demoed