### PR TITLE
limits button width to a fourth of container even on medium screens

### DIFF
--- a/client/angular/components/poll/common/vote_form/poll_common_vote_form.scss
+++ b/client/angular/components/poll/common/vote_form/poll_common_vote_form.scss
@@ -1,6 +1,7 @@
 .poll-common-vote-form__button {
   border: 1px solid $card-background-color;
-  min-width: 22%;
+  min-width: auto;
+  max-width: calc(25% - 8px) !important;
   overflow: visible;
   white-space: normal;
   img {

--- a/client/angular/components/poll/common/vote_form/poll_common_vote_form.scss
+++ b/client/angular/components/poll/common/vote_form/poll_common_vote_form.scss
@@ -1,5 +1,8 @@
 .poll-common-vote-form__button {
   border: 1px solid $card-background-color;
+  min-width: 22%;
+  overflow: visible;
+  white-space: normal;
   img {
     width: 80px;
     padding: 8px;


### PR DESCRIPTION
Looks like PR #4606 min-width reduction was not enough.

fixes #4607 and avoids cut-off text in longer locales...

![image](https://user-images.githubusercontent.com/3848493/38153673-2dfaccb0-346e-11e8-828d-c10bbc8414aa.png)


