### PR TITLE
Re-add new decision button on group page

### DIFF
--- a/client/angular/components/current_polls_card/current_polls_card.coffee
+++ b/client/angular/components/current_polls_card/current_polls_card.coffee
@@ -17,7 +17,11 @@ angular.module('loomioApp').directive 'currentPollsCard', ->
       _.take $scope.model.activePolls(), ($scope.limit or 50)
 
     $scope.startPoll = ->
-      ModalService.open 'PollCommonStartModal', poll: -> Records.polls.build(groupId: $scope.model.id)
+      ModalService.open 'PollCommonStartModal', poll: ->
+        if $scope.model.isA('discussion')
+          Records.polls.build(discussionId: $scope.model.id, groupId: $scope.model.groupId)
+        else if $scope.model.isA('group')
+          Records.polls.build(groupId: $scope.model.id)
 
     $scope.canStartPoll = ->
       AbilityService.canStartPoll($scope.model.group())

--- a/client/angular/components/current_polls_card/current_polls_card.haml
+++ b/client/angular/components/current_polls_card/current_polls_card.haml
@@ -1,6 +1,7 @@
 .current-polls-card.lmo-card
-  .lmo-flex.lmo-flex__space-between
+  .lmo-flex.lmo-flex__space-between.current-polls-card__title
     %h2.lmo-card-heading.lmo-truncate-text{translate: "current_polls_card.title"}
+    %md-button.md-primary.md-raised.current-polls-card__start-poll{ng-click: "startPoll()", translate: "current_polls_card.start_poll"}
   %loading{ng-if: "fetchRecordsExecuting"}
   .current-polls-card__polls{ng-if: "!fetchRecordsExecuting"}
     .current-polls-card__no-polls.lmo-hint-text{ng-if: "!polls().length", translate: "current_polls_card.no_polls"}

--- a/client/angular/components/current_polls_card/current_polls_card.haml
+++ b/client/angular/components/current_polls_card/current_polls_card.haml
@@ -1,8 +1,7 @@
 .current-polls-card.lmo-card
-  .lmo-flex.lmo-flex__space-between.current-polls-card__title
-    %h2.lmo-card-heading.lmo-truncate-text{translate: "current_polls_card.title"}
-    %md-button.md-primary.md-raised.current-polls-card__start-poll{ng-click: "startPoll()", translate: "current_polls_card.start_poll"}
+  %h2.lmo-card-heading.lmo-truncate-text{translate: "current_polls_card.title"}
   %loading{ng-if: "fetchRecordsExecuting"}
+  %plus_button{ng-if: "canStartPoll()", click: "startPoll", message: "current_polls_card.start_poll"}
   .current-polls-card__polls{ng-if: "!fetchRecordsExecuting"}
-    .current-polls-card__no-polls.lmo-hint-text{ng-if: "!polls().length", translate: "current_polls_card.no_polls"}
+    .current-polls-card__no-polls.lmo-hint-text{ng-if: "!canStartPoll() && !polls().length", translate: "current_polls_card.no_polls"}
     %poll_common_preview{poll: "poll", ng-repeat: "poll in polls() track by poll.id"}

--- a/client/angular/components/current_polls_card/current_polls_card.scss
+++ b/client/angular/components/current_polls_card/current_polls_card.scss
@@ -1,0 +1,7 @@
+.current-polls-card__start-poll {
+  margin: 0;
+}
+
+.current-polls-card__title {
+  margin-bottom: 8px;
+}

--- a/client/angular/components/membership/card/membership_card.haml
+++ b/client/angular/components/membership/card/membership_card.haml
@@ -9,7 +9,7 @@
       %md-button.md-button--tiny{ng-if: "searchOpen", ng-click: "toggleSearch()"}
         %i.mdi.mdi-close
 
-  %plus_button.membership-card__membership.membership-card__invite{click: "invite", message: "membership_card.invite_to_{{group.targetModel().constructor.singular}}"}
+  %plus_button.membership-card__membership.membership-card__invite{ng-if: "canAddMembers()", click: "invite", message: "membership_card.invite_to_{{group.targetModel().constructor.singular}}"}
   %loading{ng-if: "loader.loading"}
   .membership-card__membership.lmo-flex.lmo-flex__center{ng-repeat: "membership in memberships() | orderBy: ['-admin', '-createdAt'] | limitTo: loader.numRequested track by membership.id", data-username: "{{membership.user().username}}"}
     %user_avatar.lmo-margin-right{user: "membership.user()", size: "medium", coordinator: "membership.admin", no-link: "!membership.acceptedAt"}

--- a/client/angular/components/membership/card/membership_card.haml
+++ b/client/angular/components/membership/card/membership_card.haml
@@ -9,10 +9,7 @@
       %md-button.md-button--tiny{ng-if: "searchOpen", ng-click: "toggleSearch()"}
         %i.mdi.mdi-close
 
-  .membership-card__membership.membership-card__invite.lmo-flex.lmo-flex__center.lmo-pointer{ng-click: "invite()", ng-if: "canAddMembers() && !pending"}
-    %user_avatar.lmo-margin-right{user: "plusUser", no-link: "true", size: "medium", colors: "{borderColor: 'accent-500', color: 'accent-500'}"}
-    %span{translate: "membership_card.invite_to_{{group.targetModel().constructor.singular}}"}
-
+  %plus_button.membership-card__membership{click: "invite", message: "membership_card.invite_to_{{group.targetModel().constructor.singular}}"}
   %loading{ng-if: "loader.loading"}
   .membership-card__membership.lmo-flex.lmo-flex__center{ng-repeat: "membership in memberships() | orderBy: ['-admin', '-createdAt'] | limitTo: loader.numRequested track by membership.id", data-username: "{{membership.user().username}}"}
     %user_avatar.lmo-margin-right{user: "membership.user()", size: "medium", coordinator: "membership.admin", no-link: "!membership.acceptedAt"}

--- a/client/angular/components/membership/card/membership_card.haml
+++ b/client/angular/components/membership/card/membership_card.haml
@@ -9,7 +9,7 @@
       %md-button.md-button--tiny{ng-if: "searchOpen", ng-click: "toggleSearch()"}
         %i.mdi.mdi-close
 
-  %plus_button.membership-card__membership{click: "invite", message: "membership_card.invite_to_{{group.targetModel().constructor.singular}}"}
+  %plus_button.membership-card__membership.membership-card__invite{click: "invite", message: "membership_card.invite_to_{{group.targetModel().constructor.singular}}"}
   %loading{ng-if: "loader.loading"}
   .membership-card__membership.lmo-flex.lmo-flex__center{ng-repeat: "membership in memberships() | orderBy: ['-admin', '-createdAt'] | limitTo: loader.numRequested track by membership.id", data-username: "{{membership.user().username}}"}
     %user_avatar.lmo-margin-right{user: "membership.user()", size: "medium", coordinator: "membership.admin", no-link: "!membership.acceptedAt"}

--- a/client/angular/components/membership/card/membership_card.scss
+++ b/client/angular/components/membership/card/membership_card.scss
@@ -2,10 +2,6 @@
   padding: 8px 0;
 }
 
-.membership-card__invite {
-  margin: 0;
-}
-
 .membership-card__search {
   margin: 0;
   width: 0;

--- a/client/angular/components/plus_button/plus_button.coffee
+++ b/client/angular/components/plus_button/plus_button.coffee
@@ -1,0 +1,10 @@
+Records = require 'shared/services/records.coffee'
+
+angular.module('loomioApp').directive 'plusButton', ->
+  scope: {click: '=', message: '@'}
+  restrict: 'E'
+  templateUrl: 'generated/components/plus_button/plus_button.html'
+  replace: true
+  controller: ['$scope', ($scope) ->
+    $scope.plusUser = Records.users.build(avatarKind: 'mdi-plus')
+  ]

--- a/client/angular/components/plus_button/plus_button.haml
+++ b/client/angular/components/plus_button/plus_button.haml
@@ -1,0 +1,3 @@
+.plus-button.lmo-flex.lmo-flex__center.lmo-pointer{ng-click: "click()"}
+  %user_avatar.lmo-margin-right{user: "plusUser", no-link: "true", size: "medium", colors: "{borderColor: 'accent-500', color: 'accent-500'}"}
+  %span{translate: "{{message}}"}


### PR DESCRIPTION
Since we've removed the option to set a poll's group from the share form, there's no no way to start a poll within a group, which we've just had a paying customer complain about. I'd like to add this back in as a fix to fill the gap for now.

![screen shot 2018-05-06 at 2 33 00 pm](https://user-images.githubusercontent.com/750477/39669248-6bb7d00a-513a-11e8-9673-339f7f3478e1.png)
