### PR TITLE
Support SSL for SMTP connector

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -103,6 +103,7 @@ module Loomio
         user_name: ENV['SMTP_USERNAME'],
         password: ENV['SMTP_PASSWORD'],
         domain: ENV['SMTP_DOMAIN'],
+        ssl: ENV['SMTP_USE_SSL'],
         openssl_verify_mode: 'none'
       }.compact
     else


### PR DESCRIPTION
When using Amazon Simple Email Service (SES), handshake with the SMTP server fails with:

> Job GroupMailer.invitation_created (id=2224) FAILED (0 prior attempts) with Net::ReadTimeout: Net::ReadTimeout

because of issues with the SSL handshake. Passing `ssl: true` to the ActionMailer config fixes this. This PR adds provides the option to pass 'SMTP_USE_SSL' from the application environment to enable the flag in ActionMailer 