### PR TITLE
fix stance_icon_for within missed yesterady

### DIFF
--- a/app/helpers/email_helper.rb
+++ b/app/helpers/email_helper.rb
@@ -12,6 +12,14 @@ module EmailHelper
     underline:            true
   ].freeze
 
+  def stance_icon_for(poll, stance_choice)
+    case stance_choice&.score.to_i
+      when 0 then "disagree"
+      when 1 then "abstain"
+      when 2 then "agree"
+    end if poll.has_score_icons
+  end
+
   def render_rich_text(text)
     return "" unless text
     Redcarpet::Render::SmartyPants.render(emojify markdownify text).html_safe

--- a/app/models/poll_email_info.rb
+++ b/app/models/poll_email_info.rb
@@ -20,14 +20,6 @@ class PollEmailInfo
     @action_name = action_name
   end
 
-  def stance_icon_for(stance_choice)
-    case stance_choice&.score.to_i
-      when 0 then "disagree"
-      when 1 then "abstain"
-      when 2 then "agree"
-    end if @poll.has_score_icons
-  end
-
   def actor
     @actor ||= if @eventable.is_a?(Stance)
       @eventable.participant_for_client

--- a/app/views/poll_mailer/common/_poll_option.html.haml
+++ b/app/views/poll_mailer/common/_poll_option.html.haml
@@ -14,7 +14,7 @@
     %td= t("poll_#{poll.poll_type}_options.#{poll_option.name}")
 - elsif poll.has_score_icons
   - if stance_choice.present?
-    - icon_name = @info.stance_icon_for(stance_choice)
+    - icon_name = stance_icon_for(poll, stance_choice)
     %td= image_tag "poll_mailer/vote-icon-#{icon_name}.png", alt: "#{icon_name} icon", class: "poll-mailer-meeting__option-icon"
   - else
     %td= render 'poll_mailer/common/chip', color: poll_option.color

--- a/app/views/poll_mailer/meeting/_chart.html.haml
+++ b/app/views/poll_mailer/meeting/_chart.html.haml
@@ -25,5 +25,5 @@
           %td.poll-mailer-meeting__cell
             - stance_choice = stance.stance_choices.find_by(poll_option:option)
             - if stance_choice&.score.to_i > 0
-              - icon_name = @info.stance_icon_for stance_choice
+              - icon_name = stance_icon_for(@info.poll, stance_choice)
               = image_tag "poll_mailer/vote-icon-#{icon_name}.png", alt: "#{icon_name} icon", class: "poll-mailer-meeting__option-icon"


### PR DESCRIPTION
now on top of master!

We've been getting errors for too long about missed yesterday emails raising error on this.

https://sentry.loomio.io/sentry/loomio-6y/issues/4111/

This just moves this little method into a helper so the thing does not blow up. Sorry to add methods to the email helper but it seems like the easiest way to fix this and I'm on a small mission to reduce our error rate.