### PR TITLE
catch recaptcha missing exceptions

### DIFF
--- a/app/controllers/api/registrations_controller.rb
+++ b/app/controllers/api/registrations_controller.rb
@@ -38,7 +38,6 @@ class API::RegistrationsController < Devise::RegistrationsController
   end
 
   def configure_permitted_parameters
-    raise User::RecaptchaMissingError.new if ENV['RECAPTCHA_APP_KEY'] && (!params[:recaptcha] || !pending_membership_is_present?)
     devise_parameter_sanitizer.permit(:sign_up) do |u|
       u.permit(:name, :email, :recaptcha)
     end

--- a/app/controllers/api/registrations_controller.rb
+++ b/app/controllers/api/registrations_controller.rb
@@ -1,5 +1,7 @@
 class API::RegistrationsController < Devise::RegistrationsController
   include LocalesHelper
+  include ErrorRescueHelper
+
   before_action :configure_permitted_parameters
   before_action :permission_check, only: :create
 
@@ -36,8 +38,8 @@ class API::RegistrationsController < Devise::RegistrationsController
   end
 
   def configure_permitted_parameters
+    raise User::RecaptchaMissingError.new if ENV['RECAPTCHA_APP_KEY'] && (!params[:recaptcha] || !pending_membership_is_present?)
     devise_parameter_sanitizer.permit(:sign_up) do |u|
-      u.require(:recaptcha) if !pending_membership_is_present? && ENV['RECAPTCHA_APP_KEY']
       u.permit(:name, :email, :recaptcha)
     end
   end

--- a/app/extras/clients/recaptcha.rb
+++ b/app/extras/clients/recaptcha.rb
@@ -1,6 +1,7 @@
 class Clients::Recaptcha < Clients::Base
   def validate(recaptcha)
-    post "siteverify", params: { response: recaptcha }
+    return true unless self.key
+    post("siteverify", params: { response: recaptcha }).success
   end
 
   private

--- a/app/helpers/error_rescue_helper.rb
+++ b/app/helpers/error_rescue_helper.rb
@@ -1,9 +1,5 @@
 module ErrorRescueHelper
   def self.included(base)
-    base.rescue_from(User::RecaptchaMissingError) do |exception|
-      respond_with_error message: :"user.error.recaptcha", status: 400
-    end
-
     base.rescue_from(ActionView::MissingTemplate)  do |exception|
       raise exception unless %w[txt text gif png].include?(params[:format])
     end

--- a/app/helpers/error_rescue_helper.rb
+++ b/app/helpers/error_rescue_helper.rb
@@ -1,5 +1,9 @@
 module ErrorRescueHelper
   def self.included(base)
+    base.rescue_from(User::RecaptchaMissingError) do |exception|
+      respond_with_error message: :"user.error.recaptcha", status: 400
+    end
+
     base.rescue_from(ActionView::MissingTemplate)  do |exception|
       raise exception unless %w[txt text gif png].include?(params[:format])
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,5 @@
 class User < ApplicationRecord
+  class RecaptchaMissingError < Exception; end
   include CustomCounterCache::Model
   include ReadableUnguessableUrls
   include MessageChannel
@@ -13,7 +14,7 @@ class User < ApplicationRecord
 
   extend  NoSpam
   no_spam_for :name
-  
+
   MAX_AVATAR_IMAGE_SIZE_CONST = 100.megabytes
   BOT_EMAILS = {
     helper_bot: ENV['HELPER_BOT_EMAIL'] || 'contact@loomio.org',

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -331,8 +331,7 @@ class User < ApplicationRecord
   private
 
   def ensure_recaptcha
-    return if !ENV['RECAPTCHA_APP_KEY']
-    return if Clients::Recaptcha.instance.validate(self.recaptcha).success
+    return if Clients::Recaptcha.instance.validate(self.recaptcha)
     self.errors.add(:recaptcha, I18n.t(:"user.error.recaptcha"))
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -52,7 +52,7 @@ class User < ApplicationRecord
 
   validates_length_of :password, minimum: 8, allow_nil: true
   validates :password, nontrivial_password: true, allow_nil: true
-  validate  :ensure_recaptcha, if: ENV['RECAPTCHA_APP_KEY']
+  validate  :ensure_recaptcha
 
   has_many :admin_memberships,
            -> { where('memberships.admin = ? AND memberships.is_suspended = ?', true, false) },
@@ -331,6 +331,7 @@ class User < ApplicationRecord
   private
 
   def ensure_recaptcha
+    return if !ENV['RECAPTCHA_APP_KEY']
     return if Clients::Recaptcha.instance.validate(self.recaptcha).success
     self.errors.add(:recaptcha, I18n.t(:"user.error.recaptcha"))
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,4 @@
 class User < ApplicationRecord
-  class RecaptchaMissingError < Exception; end
   include CustomCounterCache::Model
   include ReadableUnguessableUrls
   include MessageChannel
@@ -53,7 +52,7 @@ class User < ApplicationRecord
 
   validates_length_of :password, minimum: 8, allow_nil: true
   validates :password, nontrivial_password: true, allow_nil: true
-  validate  :ensure_recaptcha, if: :recaptcha
+  validate  :ensure_recaptcha, if: ENV['RECAPTCHA_APP_KEY']
 
   has_many :admin_memberships,
            -> { where('memberships.admin = ? AND memberships.is_suspended = ?', true, false) },
@@ -332,7 +331,7 @@ class User < ApplicationRecord
   private
 
   def ensure_recaptcha
-    return if Clients::Recaptcha.instance.validate(self.recaptcha)
+    return if Clients::Recaptcha.instance.validate(self.recaptcha).success
     self.errors.add(:recaptcha, I18n.t(:"user.error.recaptcha"))
   end
 end

--- a/client/angular/components/auth/signup_form/auth_signup_form.haml
+++ b/client/angular/components/auth/signup_form/auth_signup_form.haml
@@ -11,7 +11,8 @@
     %label{translate: "auth_form.name"}
     %input.lmo-primary-form-input{type: "text", md-autofocus: "true", placeholder: "{{auth_form.name_placeholder | translate}}", ng-model: "vars.name", ng-required: "true"}
     %validation_errors{subject: "user", field: "name"}
-
+    %validation_errors{subject: "user", field: "recaptcha"}
+    
   %div{vc-recaptcha: "true", key: "recaptchaKey", ng-if: "recaptchaKey && !user.hasToken", ng-model: "user.recaptcha"}
 
   .lmo-md-action

--- a/spec/controllers/api/registrations_controller_spec.rb
+++ b/spec/controllers/api/registrations_controller_spec.rb
@@ -34,11 +34,6 @@ describe API::RegistrationsController do
       expect(u.email).to eq registration_params[:email]
     end
 
-    it 'does not create a new user if recaptcha is not present' do
-      registration_params[:recaptcha] = ''
-      expect { post :create, params: { user: registration_params } }.to raise_error { ActionController::ParameterMissing }
-    end
-
     it 'does not create a new user if the recaptcha is invalid' do
       Clients::Recaptcha.any_instance.stub(:validate) { false }
       expect { post :create, params: { user: registration_params } }.to_not change { User.count }


### PR DESCRIPTION
@gdpelican how might I make an error show up on the form?

Either way, this is an improvement over current situation. Tested locally