### PR TITLE
fix for poll edited not gettting correct parent event

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -66,10 +66,11 @@ class Event < ApplicationRecord
       created_at: eventable.created_at
     }.merge(args.slice(
       :user,
+      :parent,
       :discussion,
       :custom_fields,
       :created_at
-    )))
+    ))).tap { |e| byebug }
   end
 
   def should_have_parent?

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -64,13 +64,7 @@ class Event < ApplicationRecord
       kind:       name.demodulize.underscore,
       eventable:  eventable,
       created_at: eventable.created_at
-    }.merge(args.slice(
-      :user,
-      :parent,
-      :discussion,
-      :custom_fields,
-      :created_at
-    ))).tap { |e| byebug }
+    }.merge(args))
   end
 
   def should_have_parent?


### PR DESCRIPTION
I've seen this before, but this time had time to try to address it:

![image](https://user-images.githubusercontent.com/486367/39846637-f55010fe-5426-11e8-9018-27015932ad82.png)

This PR fixes it. And seems like it should have been there all along.