### PR TITLE
use rails logger for failed api requests because they are quite normal

### DIFF
--- a/app/extras/clients/base.rb
+++ b/app/extras/clients/base.rb
@@ -85,7 +85,7 @@ class Clients::Base
 
   def default_failure
     ->(response) {
-      Raven.capture_message "Failed #{self.class.name.demodulize} api request. response: #{response} token: #{@token}"
+      Rails.logger.info "Failed #{self.class.name.demodulize} api request. response: #{response} token: #{@token}"
       response
     }
   end


### PR DESCRIPTION
to manage all the "Failed Facebook api request." messages we get in sentry. Happy to consider using this just for facebook client.