### PR TITLE
Don't set volume by default on group invite

### DIFF
--- a/app/extras/group_inviter.rb
+++ b/app/extras/group_inviter.rb
@@ -49,7 +49,6 @@ class GroupInviter
     Membership.new(inviter: @inviter,
                    user: user,
                    group: @group,
-                   volume: Membership.volumes[:normal],
                    accepted_at: (Time.now if user.email_verified))
   end
 end

--- a/app/extras/queries/users_by_volume_query.rb
+++ b/app/extras/queries/users_by_volume_query.rb
@@ -22,10 +22,8 @@ class Queries::UsersByVolumeQuery
       rel.joins_readers(model)
          .joins_guest_memberships(model)
          .joins_formal_memberships(model)
-         .where("((gm.id IS NOT NULL OR fm.id IS NOT NULL) AND dr.volume #{operator} :volume) OR
-          (dr.volume IS NULL AND gm.volume #{operator} :volume) OR
-          (dr.volume IS NULL AND gm.volume IS NULL AND fm.volume #{operator} :volume)
-          ", volume: volume)
+         .where("gm.id is NOT NULL OR fm.id is NOT NULL")
+         .where("coalesce(dr.volume, gm.volume, fm.volume, 2) #{operator} :volume", volume: volume)
     end
   end
 end


### PR DESCRIPTION
Have to do this because we invite to the group regardless of their group / thread volume, and the guest group setting does (and should) override the formal group setting. 

So, right now:

- Person sets group volume to quiet
- They get invited to a new thread in the group
- They get a membership in that thread with normal volume
- They get emails about that thread (oops.)