### PR TITLE
Groupless threads (WIP)

### DIFF
--- a/app/controllers/dev/scenarios/discussion.rb
+++ b/app/controllers/dev/scenarios/discussion.rb
@@ -5,6 +5,14 @@ module Dev::Scenarios::Discussion
     redirect_to discussion_url(create_discussion)
   end
 
+  def setup_groupless_discussion
+    create_discussion.update(group: nil)
+    sign_in patrick
+    comment = FactoryBot.build(:comment, discussion: create_discussion, body: "welcome to the thread!")
+    CommentService.create comment: comment, actor: jennifer
+    redirect_to discussion_url(create_discussion)
+  end
+
   def setup_discussion_mailer_new_discussion_email
     sign_in jennifer
     @group = FactoryBot.create(:formal_group, name: "Girdy Dancing Shoes", creator: patrick)

--- a/app/helpers/pretty_url_helper.rb
+++ b/app/helpers/pretty_url_helper.rb
@@ -23,7 +23,7 @@ module PrettyUrlHelper
     when GuestGroup                    then polymorphic_url(model.target_model, opts)
     when FormalGroup, GroupIdentity    then group_url(model.group, opts)
     when PaperTrail::Version           then polymorphic_url(model.item, opts)
-    when MembershipRequest             then group_url(model.group, opts.merge(use_key: true))
+    when MembershipRequest             then polymorphic_url(model.group, opts.merge(use_key: true))
     when Outcome                       then poll_url(model.poll, opts)
     when Stance                        then poll_url(model.poll, opts.merge(change_vote: true))
     when Comment                       then comment_url(model.discussion, model, opts)

--- a/app/models/ability/discussion.rb
+++ b/app/models/ability/discussion.rb
@@ -6,7 +6,7 @@ module Ability::Discussion
          :print,
          :dismiss,
          :subscribe_to], ::Discussion do |discussion|
-      !discussion.group.archived_at && (
+      !discussion.group&.archived_at && (
         discussion.public? ||
         discussion.members.include?(user) ||
         discussion.anyone_can_participate ||
@@ -23,11 +23,11 @@ module Ability::Discussion
     end
 
     can :create, ::Discussion do |discussion|
-      (user.email_verified? &&
-       discussion.group.present? &&
-       discussion.group.members_can_start_discussions? &&
-       user_is_member_of?(discussion.group_id)) ||
-      user_is_admin_of?(discussion.group_id)
+      user.email_verified? && (
+        !discussion.group ||
+        user_is_admin_of?(discussion.group_id) ||
+        (discussion.group.members_can_start_discussions && user_is_member_of?(discussion.group_id))
+      )
     end
 
     can [:update, :announce], ::Discussion do |discussion|

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -47,6 +47,7 @@ class Comment < ApplicationRecord
   delegate :groups, to: :discussion
   delegate :guest_group, to: :discussion
   delegate :guest_group_id, to: :discussion
+  delegate :members, to: :discussion
 
   define_counter_cache(:versions_count) { |comment| comment.versions.count }
 

--- a/app/models/concerns/events/notify/mentions.rb
+++ b/app/models/concerns/events/notify/mentions.rb
@@ -26,7 +26,7 @@ module Events::Notify::Mentions
 
   def mention_recipients
     mentionable.mentioned_users
-               .where.not(id: mentionable.group.members.mentioned_in(mentionable)) # avoid re-mentioning users when editing
+               .where.not(id: mentionable.members.mentioned_in(mentionable)) # avoid re-mentioning users when editing
                .where.not(id: mentionable.users_to_not_mention)
   end
 end

--- a/app/models/discussion.rb
+++ b/app/models/discussion.rb
@@ -31,7 +31,7 @@ class Discussion < ApplicationRecord
   scope :is_open, -> { where(closed_at: nil) }
   scope :is_closed, -> { where.not(closed_at: nil) }
 
-  validates_presence_of :title, :group, :author
+  validates_presence_of :title, :author
   validate :private_is_not_nil
   validates :title, length: { maximum: 150 }
   validates :description, length: { maximum: Rails.application.secrets.max_message_length }

--- a/app/models/discussion_reader.rb
+++ b/app/models/discussion_reader.rb
@@ -103,6 +103,6 @@ class DiscussionReader < ApplicationRecord
 
   private
   def membership
-    @membership ||= discussion.group.membership_for(user)
+    @membership ||= discussion.group.membership_for(user) if discussion.group
   end
 end

--- a/app/serializers/metadata/discussion_serializer.rb
+++ b/app/serializers/metadata/discussion_serializer.rb
@@ -9,6 +9,6 @@ class Metadata::DiscussionSerializer < ActiveModel::Serializer
   end
 
   def image_url
-    object.group.logo.url
+    object.group.logo.url if object.group
   end
 end

--- a/client/angular/components/discussion/form/discussion_form.coffee
+++ b/client/angular/components/discussion/form/discussion_form.coffee
@@ -24,6 +24,6 @@ angular.module('loomioApp').directive 'discussionForm', ->
       $scope.discussion.private = $scope.discussion.privateDefaultValue()
 
     $scope.showPrivacyForm = ->
-      return unless $scope.discussion.group()
+      return true unless $scope.discussion.group()
       $scope.discussion.group().discussionPrivacyOptions == 'public_or_private'
   ]

--- a/client/angular/components/discussion/form/discussion_form.haml
+++ b/client/angular/components/discussion/form/discussion_form.haml
@@ -5,6 +5,7 @@
   %md-input-container.md-block{ng-show: "showGroupSelect"}
     %label{for: "discussion-group-field", translate: "discussion_form.group_label"}
     %md-select.discussion-form__group-select#discussion-group-field{ng-model: "discussion.groupId", placeholder: "{{'discussion_form.group_placeholder' | translate}}", ng-required: "true", ng-change: "discussion.fetchAndRestoreDraft(); updatePrivacy()"}
+      %md-option{ng-value: "", translate: "discussion_form.no_group"}
       %md-option{ng-value: "group.id", ng-repeat: "group in availableGroups() | orderBy: 'fullName' track by group.id"}
         {{group.fullName}}
     .md-errors-spacer

--- a/client/angular/components/discussion/privacy_icon/discussion_privacy_icon.coffee
+++ b/client/angular/components/discussion/privacy_icon/discussion_privacy_icon.coffee
@@ -1,6 +1,6 @@
 I18n = require 'shared/services/i18n'
 
-{ discussionPrivacy } = require 'shared/helpers/helptext'
+{ discussionPrivacy, discussionPrivacyFields } = require 'shared/helpers/helptext'
 
 angular.module('loomioApp').directive 'discussionPrivacyIcon', ->
   scope: {discussion: '=', private: '=?'}
@@ -12,7 +12,5 @@ angular.module('loomioApp').directive 'discussionPrivacyIcon', ->
       if $scope.private then 'private' else 'public'
 
     $scope.privacyDescription = ->
-      I18n.t discussionPrivacy($scope.discussion, $scope.private),
-        group:  $scope.discussion.group().name
-        parent: $scope.discussion.group().parentName()
+      I18n.t discussionPrivacy($scope.discussion, $scope.private), discussionPrivacyFields($scope.discussion)
   ]

--- a/client/angular/components/thread_page/add_comment_panel/add_comment_panel.haml
+++ b/client/angular/components/thread_page/add_comment_panel/add_comment_panel.haml
@@ -5,5 +5,5 @@
     .thread-item__body.lmo-flex--column.lmo-flex__horizontal-center
       %comment_form{event-window: "eventWindow"}
   .add-comment-panel__join-actions{ng-if: "!canAddComment()"}
-    %join_group_button{group: "discussion.group()", ng-if: "isLoggedIn()", block: "true"}
+    %join_group_button{group: "discussion.guestGroup()", ng-if: "isLoggedIn()"}
     %md-button.md-primary.md-raised.add-comment-panel__sign-in-btn{translate: "comment_form.sign_in", ng-click: "signIn()", ng-if: "!isLoggedIn()"}

--- a/client/angular/pages/thread_page/thread_page.haml
+++ b/client/angular/pages/thread_page/thread_page.haml
@@ -2,7 +2,7 @@
   %loading{ng-if: "!threadPage.discussion"}
   %main.thread-page.lmo-row{ng-if: "threadPage.discussion"}
     %discussion_fork_actions{discussion: "threadPage.discussion", ng-show: "threadPage.discussion.isForking()"}
-    %group_theme{group: "threadPage.discussion.group()", compact: "true"}
+    %group_theme{ng-if: "threadPage.discussion.group()", group: "threadPage.discussion.group()", compact: "true"}
     .thread-page__main-content{ng-class: "{'thread-page__forking': threadPage.discussion.isForking()}"}
       %outlet.before-column-right.lmo-column-right{name: "before-thread-page-column-right", model: "threadPage.discussion"}
       %poll_common_card.lmo-card--no-padding.lmo-column-right{poll: "poll", ng-repeat: "poll in threadPage.discussion.activePolls() track by poll.id"}

--- a/client/angular/pages/thread_page/thread_page.scss
+++ b/client/angular/pages/thread_page/thread_page.scss
@@ -1,56 +1,9 @@
-.thread-notification-level {
-  display: inline-block;
-}
-
-.thread-group{
-  margin: 14px 22px;
-  padding-top: 10px;
-}
-
-.thread-group__name a{
-  font-weight: bold;
-  color: $grey-on-grey;
-  line-height: 30px;
-}
-
-.thread-group__icon img{
-  @include smallIcon;
+.thread-page {
+  margin-top: $cardPaddingSize;
 }
 
 .thread-page__forking .action-dock {
   visibility: hidden;
-}
-
-.attachments {
-  margin: 0 10px;
-}
-
-.attachment-new {
-  width: 34px;
-  height: 34px;
-  border: 1px solid $border-color;
-  @include roundedCorners;
-}
-
-.attachment-new input {
-  width: 34px;
-  opacity: 0;
-  padding: 5px;
-  cursor: pointer;
-  display: block;
-  overflow: hidden;
-}
-
-.cover-file-upload {
-  pointer-events: none;
-  position: relative;
-  bottom: 38px;
-  padding: 0px;
-  left: 4px;
-}
-
-.progress.active {
-  float: left;
 }
 
 @media (min-width: $small-max-px) {

--- a/client/shared/helpers/helptext.coffee
+++ b/client/shared/helpers/helptext.coffee
@@ -84,10 +84,19 @@ module.exports =
   discussionPrivacy: (discussion, is_private = null) ->
     if is_private == false
       'discussion_form.privacy_public'
-    else if discussion.group().parentMembersCanSeeDiscussions
+    else if discussion.group() && discussion.group().parentMembersCanSeeDiscussions
       'discussion_form.privacy_organisation'
-    else
+    else if discussion.group()
       'discussion_form.privacy_private'
+    else
+      'discussion_form.privacy_groupless_private'
+
+  discussionPrivacyFields: (discussion) ->
+    if discussion.group()
+      group:  discussion.group().name
+      parent: discussion.group().parentName()
+    else
+      {}
 
 newCommentKey = (event, useNesting) ->
   if event.isNested() && !useNesting

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -428,6 +428,7 @@ en:
     fork_discussion_title: 'Fork a thread'
     edit_discussion_title: 'Edit thread'
     group_label: 'Group'
+    no_group: '(No group)'
     group_placeholder: 'Select a group'
     title_label: 'Title'
     title_placeholder: 'What is the topic you want to discuss?'
@@ -436,6 +437,7 @@ en:
     privacy_label: 'Privacy'
     privacy_public: 'Anyone can see the thread. Only members can participate.'
     privacy_private: 'The thread will only be visible to members of {{group}}.'
+    privacy_groupless_private: 'The thread will only be visible to invited members.'
     privacy_organisation: 'The thread will be visible to members of {{parent}} and members of {{group}}.'
     fork_notice: 'A new thread will be created with {{count}} items from {{title}}'
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -145,11 +145,11 @@ FactoryBot.define do
     body 'body of the comment'
 
     after(:build) do |comment|
-      comment.discussion.group.parent.add_member!(comment.user) if comment.discussion.group.parent
-      comment.discussion.group.add_member!(comment.user)
+      comment.groups.first.parent&.add_member!(comment.user)
+      comment.groups.first.add_member!(comment.user)
     end
     after(:create) do |comment|
-      comment.discussion.group.save
+      comment.groups.first.save
     end
   end
 


### PR DESCRIPTION
This allows you to create a thread without a group, invite people into its guest group, and request membership to a thread if it's membership_on_request.

I haven't put much UX thinking into this yet, nor tested through many full workflows, but it's a good start.

This includes the mention-freely branch, because mentions need to work slightly differently with standalone discussions.