### PR TITLE
Allow setting of title on membership

### DIFF
--- a/app/controllers/dev/scenarios/membership.rb
+++ b/app/controllers/dev/scenarios/membership.rb
@@ -3,4 +3,10 @@ module Dev::Scenarios::Membership
     sign_in jennifer
     redirect_to group_url(create_group)
   end
+
+  def setup_membership_with_title
+    sign_in patrick
+    create_group.memberships.find_by(user: patrick).update(title: "Suzerain!")
+    redirect_to group_url(create_group)
+  end
 end

--- a/app/models/permitted_params.rb
+++ b/app/models/permitted_params.rb
@@ -54,7 +54,7 @@ class PermittedParams < Struct.new(:params)
   end
 
   def membership_attributes
-    [:volume, :apply_to_all, :set_default]
+    [:title, :volume, :apply_to_all, :set_default]
   end
 
   def discussion_reader_attributes

--- a/app/serializers/membership_serializer.rb
+++ b/app/serializers/membership_serializer.rb
@@ -3,7 +3,7 @@ class MembershipSerializer < ActiveModel::Serializer
   has_one :group, serializer: GroupSerializer, root: :groups
 
   embed :ids, include: true
-  attributes :id, :volume, :admin, :experiences, :created_at, :accepted_at
+  attributes :id, :volume, :admin, :experiences, :title, :created_at, :accepted_at
 
   has_one :user, serializer: UserSerializer, root: :users
   has_one :inviter, serializer: UserSerializer, root: :users

--- a/app/services/membership_service.rb
+++ b/app/services/membership_service.rb
@@ -7,6 +7,16 @@ class MembershipService
     Events::InvitationAccepted.publish!(membership)
   end
 
+  def self.update(membership:, params:, actor:)
+    actor.ability.authorize! :update, membership
+
+    membership.assign_attributes(params.slice(:title))
+    return false unless membership.valid?
+    membership.save!
+
+    EventBus.broadcast 'membership_update', membership, params, actor
+  end
+
   def self.set_volume(membership:, params:, actor:)
     actor.ability.authorize! :update, membership
     if params[:apply_to_all]

--- a/client/angular/components/membership/card/membership_card.haml
+++ b/client/angular/components/membership/card/membership_card.haml
@@ -14,7 +14,7 @@
   .membership-card__membership.lmo-flex.lmo-flex__center{ng-repeat: "membership in memberships() | orderBy: ['-admin', '-createdAt'] | limitTo: loader.numRequested track by membership.id", data-username: "{{membership.user().username}}"}
     %user_avatar.lmo-margin-right{user: "membership.user()", size: "medium", coordinator: "membership.admin", no-link: "!membership.acceptedAt"}
     .membership-card__user.lmo-flex.lmo-flex__grow.lmo-truncate{layout: "column"}
-      %span {{membership.user().name || membership.user().email }}
+      %span> {{membership.userName() || membership.user().email }}
       %outlet{name: "after-membership-user", model: "membership"}
       .membership-card__last-seen.md-caption{translate: "user_page.online_field", translate-value-value: "{{::membership.user().lastSeenAt | timeFromNowInWords}}", ng-if: "::membership.user().lastSeenAt"}
       .membership-card__last-seen.md-caption{translate: "user_page.invited", translate-value-value: "{{::membership.user().createdAt | timeFromNowInWords}}", ng-if: "!membership.acceptedAt"}

--- a/client/angular/components/membership/dropdown/membership_dropdown.coffee
+++ b/client/angular/components/membership/dropdown/membership_dropdown.coffee
@@ -11,8 +11,16 @@ angular.module('loomioApp').directive 'membershipDropdown', ->
   templateUrl: 'generated/components/membership/dropdown/membership_dropdown.html'
   controller: ['$scope', ($scope) ->
     $scope.canPerformAction = ->
+      $scope.canSetTitle()         or
       $scope.canRemoveMembership() or
+      $scope.canResendMembership() or
       $scope.canToggleAdmin()
+
+    $scope.canSetTitle = ->
+      AbilityService.canSetMembershipTitle($scope.membership)
+
+    $scope.setTitle = ->
+      ModalService.open 'MembershipModal', membership: -> $scope.membership
 
     $scope.canResendMembership = ->
       AbilityService.canResendMembership($scope.membership)

--- a/client/angular/components/membership/dropdown/membership_dropdown.haml
+++ b/client/angular/components/membership/dropdown/membership_dropdown.haml
@@ -4,7 +4,10 @@
       .sr-only{translate: "membership_dropdown.membership_options"}
       %i.mdi.mdi-24px.mdi-dots-horizontal.md-button--tiny
     %md-menu-content.group-actions-dropdown__menu-content
-      %md-menu-item.membership-dropdown__remove{ng-if: "canResendMembership()"}
+      %md-menu-item.membership-dropdown__set-title{ng-if: "canSetTitle()"}
+        %md-button{ng-click: "setTitle()"}
+          %span{translate: "membership_dropdown.set_title"}
+      %md-menu-item.membership-dropdown__resend{ng-if: "canResendMembership()"}
         %md-button{ng-click: "resendMembership()", ng-disabled: "membership.resent"}
           %span{translate: "membership_dropdown.resend", ng-if: "!membership.resent"}
           %span{translate: "membership_dropdown.invitation_resent", ng-if: "membership.resent"}

--- a/client/angular/components/membership/form/membership_form.coffee
+++ b/client/angular/components/membership/form/membership_form.coffee
@@ -1,0 +1,3 @@
+angular.module('loomioApp').directive 'membershipForm', ->
+  scope: {membership: '='}
+  templateUrl: 'generated/components/membership/form/membership_form.html'

--- a/client/angular/components/membership/form/membership_form.haml
+++ b/client/angular/components/membership/form/membership_form.haml
@@ -1,0 +1,7 @@
+.membership-form
+  %p.lmo-hint-text.membership-form__helptext{translate: "membership_form.title_helptext.{{membership.target().constructor.singular}}", translate-value-title: "{{membership.target().name || membership.target().title}}"}
+  %md-input-container.md-block.md-no-errors
+    %label{for: "membership-title", translate: "membership_form.title_label"}
+    .lmo-relative
+      %input.membership-form__title-input.lmo-primary-form-input#membership-title{placeholder: "{{ 'membership_form.title_placeholder' | translate }}", md-autofocus: "true", ng-model: "membership.title", maxlength: "255"}
+    %validation_errors{subject: "discussion", field: "title"}

--- a/client/angular/components/membership/form/membership_form.haml
+++ b/client/angular/components/membership/form/membership_form.haml
@@ -4,4 +4,4 @@
     %label{for: "membership-title", translate: "membership_form.title_label"}
     .lmo-relative
       %input.membership-form__title-input.lmo-primary-form-input#membership-title{placeholder: "{{ 'membership_form.title_placeholder' | translate }}", md-autofocus: "true", ng-model: "membership.title", maxlength: "255"}
-    %validation_errors{subject: "discussion", field: "title"}
+    %validation_errors{subject: "membership", field: "title"}

--- a/client/angular/components/membership/form/membership_form.haml
+++ b/client/angular/components/membership/form/membership_form.haml
@@ -1,5 +1,5 @@
 .membership-form
-  %p.lmo-hint-text.membership-form__helptext{translate: "membership_form.title_helptext.{{membership.target().constructor.singular}}", translate-value-title: "{{membership.target().name || membership.target().title}}"}
+  %p.lmo-hint-text.membership-form__helptext{translate: "membership_form.title_helptext.{{membership.target().constructor.singular}}", translate-value-poll-type: "{{membership.target().pollType}}", translate-value-name: "{{membership.user().name}}"}
   %md-input-container.md-block.md-no-errors
     %label{for: "membership-title", translate: "membership_form.title_label"}
     .lmo-relative

--- a/client/angular/components/membership/form/membership_form.scss
+++ b/client/angular/components/membership/form/membership_form.scss
@@ -1,0 +1,3 @@
+.membership-form__helptext {
+  margin-bottom: 36px;
+}

--- a/client/angular/components/membership/form_actions/membership_form_actions.coffee
+++ b/client/angular/components/membership/form_actions/membership_form_actions.coffee
@@ -1,0 +1,11 @@
+{ submitMembership } = require 'shared/helpers/form'
+{ submitOnEnter }    = require 'shared/helpers/keyboard'
+
+angular.module('loomioApp').directive 'membershipFormActions', ->
+  scope: {membership: '='}
+  replace: true
+  templateUrl: 'generated/components/membership/form_actions/membership_form_actions.html'
+  controller: ['$scope', ($scope) ->
+    $scope.submit = submitMembership $scope, $scope.membership
+    submitOnEnter $scope
+  ]

--- a/client/angular/components/membership/form_actions/membership_form_actions.haml
+++ b/client/angular/components/membership/form_actions/membership_form_actions.haml
@@ -1,0 +1,2 @@
+.membership-form-actions.lmo-md-action
+  %md-button.md-primary.md-raised.membership-form__submit{ng-click: "submit()", ng-disabled: "submitIsDisabled", translate: "common.action.save"}

--- a/client/angular/components/membership/modal/membership_modal.coffee
+++ b/client/angular/components/membership/modal/membership_modal.coffee
@@ -1,0 +1,5 @@
+angular.module('loomioApp').factory 'MembershipModal', ->
+  templateUrl: 'generated/components/membership/modal/membership_modal.html'
+  controller: ['$scope', 'membership', ($scope, membership) ->
+    $scope.membership = membership.clone()
+  ]

--- a/client/angular/components/membership/modal/membership_modal.haml
+++ b/client/angular/components/membership/modal/membership_modal.haml
@@ -3,7 +3,7 @@
   %md-toolbar
     .md-toolbar-tools.lmo-flex__space-between
       %i.mdi.mdi-account-settings
-      %h1.lmo-h1{translate: "membership_form.title"}
+      %h1.lmo-h1{translate: "membership_form.modal_title.{{membership.target().constructor.singular}}", translate-value-poll-type: "{{membership.target().pollType}}"}
       %dismiss_modal_button
   %md-dialog-content
     %membership_form{membership: "membership"}

--- a/client/angular/components/membership/modal/membership_modal.haml
+++ b/client/angular/components/membership/modal/membership_modal.haml
@@ -1,0 +1,11 @@
+%md-dialog.membership-modal.lmo-modal__narrow
+  .lmo-disabled-form{ng-show: "isDisabled"}
+  %md-toolbar
+    .md-toolbar-tools.lmo-flex__space-between
+      %i.mdi.mdi-account-settings
+      %h1.lmo-h1{translate: "membership_form.title"}
+      %dismiss_modal_button
+  %md-dialog-content
+    %membership_form{membership: "membership"}
+  %md-dialog-actions
+    %membership_form_actions{membership: "membership"}

--- a/client/angular/components/poll/common/collapsed/poll_common_collapsed.haml
+++ b/client/angular/components/poll/common/collapsed/poll_common_collapsed.haml
@@ -5,6 +5,6 @@
       %strong> {{formattedPollType(poll.pollType)}}:
       %span> {{poll.title}}
     .md-caption.lmo-grey-on-white
-      %span{translate: "poll_common_collapsed.by_who", translate-value-name: "{{poll.author().name}}"}>
+      %span{translate: "poll_common_collapsed.by_who", translate-value-name: "{{poll.authorName()}}"}>
       %span>·
       %poll_common_closing_at{poll: "poll"}

--- a/client/angular/components/poll/common/details_panel/poll_common_details_panel.haml
+++ b/client/angular/components/poll/common/details_panel/poll_common_details_panel.haml
@@ -1,7 +1,7 @@
   .poll-common-details-panel.lmo-action-dock-wrapper
     %h3.lmo-card-subheading{translate: "poll_common.details", ng-if: "poll.outcome()"}
     .poll-common-details-panel__started-by
-      %span{translate: "poll_card.started_by", translate-value-name: "{{poll.author().name}}"}
+      %span{translate: "poll_card.started_by", translate-value-name: "{{poll.authorName()}}"}
       %span{aria-hidden: "true"}>·
       %poll_common_closing_at{poll: "poll"}
       %span{ng-if: "poll.anonymous"}>·

--- a/client/angular/components/poll/common/outcome_panel/poll_common_outcome_panel.haml
+++ b/client/angular/components/poll/common/outcome_panel/poll_common_outcome_panel.haml
@@ -1,7 +1,7 @@
 .poll-common-outcome-panel.lmo-action-dock-wrapper{ng-if: "poll.outcome()"}
   %h3.lmo-card-subheading{translate: "poll_common.outcome"}
   .poll-common-outcome-panel__authored-by
-    %span{translate: "poll_common_outcome_panel.authored_by", translate-value-name: "{{poll.outcome().author().name}}"}
+    %span{translate: "poll_common_outcome_panel.authored_by", translate-value-name: "{{poll.outcome().authorName()}}"}
     %timeago{timestamp: "::poll.outcome().createdAt" }>
   %p.lmo-markdown-wrapper{marked: "poll.outcome().statement", ng-if: "!poll.outcome().translation"}
   %translation{model: "poll.outcome()", field: "statement", ng-if: "poll.outcome().translation"}

--- a/client/angular/components/poll/common/preview/poll_common_preview.haml
+++ b/client/angular/components/poll/common/preview/poll_common_preview.haml
@@ -5,6 +5,6 @@
       %span> {{poll.title}}
     .md-caption.lmo-grey-on-white.lmo-truncate-text
       %span{ng-if: "showGroupName()"} {{ poll.group().fullName }}
-      %span{ng-if: "!showGroupName()", translate: "poll_common_collapsed.by_who", translate-value-name: "{{poll.author().name}}"}>
+      %span{ng-if: "!showGroupName()", translate: "poll_common_collapsed.by_who", translate-value-name: "{{poll.authorName()}}"}>
       %span>·
       %poll_common_closing_at{poll: "poll"}

--- a/client/angular/components/poll/common/votes_panel_stance/poll_common_votes_panel_stance.coffee
+++ b/client/angular/components/poll/common/votes_panel_stance/poll_common_votes_panel_stance.coffee
@@ -1,16 +1,10 @@
-I18n = require 'shared/services/i18n'
-
 { listenForTranslations } = require 'shared/helpers/listen'
+{ participantName }       = require 'shared/helpers/poll'
 
 angular.module('loomioApp').directive 'pollCommonVotesPanelStance', ->
   scope: {stance: '='}
   templateUrl: 'generated/components/poll/common/votes_panel_stance/poll_common_votes_panel_stance.html'
   controller: ['$scope', ($scope) ->
     listenForTranslations $scope
-
-    $scope.participantName = ->
-      if $scope.stance.participant()
-        $scope.stance.participant().name
-      else
-        I18n.t('common.anonymous')
+    $scope.participantName = -> participantName($scope.stance)
   ]

--- a/client/angular/components/poll/dot_vote/votes_panel_stance/poll_dot_vote_votes_panel_stance.coffee
+++ b/client/angular/components/poll/dot_vote/votes_panel_stance/poll_dot_vote_votes_panel_stance.coffee
@@ -1,5 +1,6 @@
 RecordLoader = require 'shared/services/record_loader'
-I18n         = require 'shared/services/i18n'
+
+{ participantName } = require 'shared/helpers/poll'
 
 angular.module('loomioApp').directive 'pollDotVoteVotesPanelStance', ->
   scope: {stance: '='}
@@ -8,11 +9,7 @@ angular.module('loomioApp').directive 'pollDotVoteVotesPanelStance', ->
     $scope.barTextFor = (choice) ->
       "#{choice.score} - #{choice.pollOption().name}".replace(/\s/g, '\u00a0')
 
-    $scope.participantName = ->
-      if $scope.stance.participant()
-        $scope.stance.participant().name
-      else
-        I18n.t('common.anonymous')
+    $scope.participantName = -> participantName($scope.stance)
 
     percentageFor = (choice) ->
       # max = _.max(_.map($scope.stance.stanceChoices(), (choice) -> choice.score))

--- a/client/angular/components/poll/meeting/votes_panel_stance/poll_meeting_votes_panel_stance.coffee
+++ b/client/angular/components/poll/meeting/votes_panel_stance/poll_meeting_votes_panel_stance.coffee
@@ -1,16 +1,10 @@
-I18n = require 'shared/services/i18n'
-
 { listenForTranslations } = require 'shared/helpers/listen'
+{ participantName }       = require 'shared/helpers/poll'
 
 angular.module('loomioApp').directive 'pollMeetingVotesPanelStance', ->
   scope: {stance: '='}
   templateUrl: 'generated/components/poll/meeting/votes_panel_stance/poll_meeting_votes_panel_stance.html'
   controller: ['$scope', ($scope) ->
     listenForTranslations $scope
-
-    $scope.participantName = ->
-      if $scope.stance.participant()
-        $scope.stance.participant().name
-      else
-        I18n.t('common.anonymous')
+    $scope.participantName = -> participantName($scope.stance)
   ]

--- a/client/angular/components/revision_history/modal/revision_history_modal.haml
+++ b/client/angular/components/revision_history/modal/revision_history_modal.haml
@@ -12,7 +12,7 @@
       .revision-history-modal__user.lmo-flex--row.lmo-flex__center.lmo-grey-on-white.md-body-1{ng-if: "!loading"}
         %user_avatar.lmo-margin-right--small{user:"version.author()" , size:"small"}>
         %span
-          %strong.lmo-truncate> {{ version.author().name }}
+          %strong.lmo-truncate> {{ version.authorName() }}
           %span>·
           %timeago.lmo-margin-right--small{timestamp: "version.createdAt"}
       %revision_history_content{ng-if:"!loading", model: "model", version:"version"}

--- a/client/angular/components/thread_page/comment_form/comment_form.coffee
+++ b/client/angular/components/thread_page/comment_form/comment_form.coffee
@@ -25,7 +25,7 @@ angular.module('loomioApp').directive 'commentForm', ->
 
     $scope.commentPlaceholder = ->
       if $scope.comment.parentId
-        I18n.t('comment_form.in_reply_to', name: $scope.comment.parent().author().name)
+        I18n.t('comment_form.in_reply_to', name: $scope.comment.parent().authorName())
       else
         I18n.t('comment_form.aria_label')
 

--- a/client/angular/test/nightwatch/core/membership.js
+++ b/client/angular/test/nightwatch/core/membership.js
@@ -60,5 +60,21 @@ module.exports = {
     page.click('.membership-dropdown__button')
     page.pause()
     page.expectNoText('.membership-dropdown', 'Demote coordinator')
+  },
+
+  'can_set_membership_title': (test) => {
+    page = pageHelper(test)
+
+    page.loadPath('setup_group')
+    page.click('.membership-card__search-button')
+    page.fillIn('.membership-card__filter', 'Patrick')
+    page.pause()
+    page.click('.membership-dropdown__button')
+    page.pause()
+    page.click('.membership-dropdown__set-title')
+    page.fillIn('.membership-form__title-input', 'Suzerain')
+    page.click('.membership-form__submit')
+    page.expectText('.flash-root__message', 'Membership title updated')
+    page.expectText('.membership-card', 'Patrick Swayze · Suzerain')
   }
 }

--- a/client/angular/test/nightwatch/core/membership.js
+++ b/client/angular/test/nightwatch/core/membership.js
@@ -50,13 +50,15 @@ module.exports = {
     page.expectNoElement('.user-avatar--coordinator')
   },
 
-  'cannot remove privileges for last coordinator': (test) => {
+  'cannot_remove_privileges_for_last_coordinator': (test) => {
     page = pageHelper(test)
 
     page.loadPath('setup_group')
     page.click('.membership-card__search-button')
     page.fillIn('.membership-card__filter', 'Patrick')
     page.pause()
-    page.expectNoElement('.membership-dropdown__button')
+    page.click('.membership-dropdown__button')
+    page.pause()
+    page.expectNoText('.membership-dropdown', 'Demote coordinator')
   }
 }

--- a/client/shared/helpers/form.coffee
+++ b/client/shared/helpers/form.coffee
@@ -76,6 +76,12 @@ module.exports =
         EventBus.emit scope, 'doneProcessing'
     , options))
 
+  submitMembership: (scope, model, options = {}) ->
+    submit(scope, model, _.merge(
+      flashSuccess: "membership_form.#{actionName(model)}"
+      successCallback: -> EventBus.emit scope, '$close'
+    , options))
+
   upload: (scope, model, options = {}) ->
     upload(scope, model, options)
 

--- a/client/shared/helpers/poll.coffee
+++ b/client/shared/helpers/poll.coffee
@@ -1,5 +1,6 @@
 AppConfig     = require 'shared/services/app_config'
 Records       = require 'shared/services/records'
+I18n          = require 'shared/services/i18n'
 
 # A series of helpers for interacting with polls, such as template values for a
 # particular poll or getting the last stance from a given user
@@ -26,6 +27,13 @@ module.exports =
       pollId: poll.id
       participantId: AppConfig.currentUserId
     ), 'createdAt')
+
+  participantName: (stance) ->
+    if stance.participant()
+      stance.participant().nameWithTitle(stance.poll())
+    else
+      I18n.t('common.anonymous')
+
 
 fieldFromTemplate = (pollType, field) ->
   (AppConfig.pollTemplates[pollType] or {})[field]

--- a/client/shared/models/comment_model.coffee
+++ b/client/shared/models/comment_model.coffee
@@ -61,7 +61,7 @@ module.exports = class CommentModel extends BaseModel
     @recordStore.users.find(_.pluck(@reactions(), 'userId'))
 
   authorName: ->
-    @author().name
+    @author().nameWithTitle(@discussion()) if @author()
 
   authorUsername: ->
     @author().username

--- a/client/shared/models/discussion_model.coffee
+++ b/client/shared/models/discussion_model.coffee
@@ -65,7 +65,7 @@ module.exports = class DiscussionModel extends BaseModel
     groupName: @groupName()
 
   authorName: ->
-    @author().name if @author()
+    @author().nameWithTitle(@)
 
   groupName: ->
     @group().name if @group()

--- a/client/shared/models/document_model.coffee
+++ b/client/shared/models/document_model.coffee
@@ -23,7 +23,7 @@ module.exports = class DocumentModel extends BaseModel
       when 'Poll'       then @model().title
 
   authorName: ->
-    @author().name if @author()
+    @author().nameWithTitle(@model()) if @author()
 
   isAnImage: ->
     @icon == 'image'

--- a/client/shared/models/event_model.coffee
+++ b/client/shared/models/event_model.coffee
@@ -39,7 +39,7 @@ module.exports = class EventModel extends BaseModel
     @deleted = true
 
   actorName: ->
-    @actor().name if @actor()
+    @actor().nameWithTitle(@discussion()) if @actor()
 
   actorUsername: ->
     @actor().username if @actor()

--- a/client/shared/models/membership_model.coffee
+++ b/client/shared/models/membership_model.coffee
@@ -14,7 +14,7 @@ module.exports = class MembershipModel extends BaseModel
     @belongsTo 'inviter', from: 'users'
 
   userName: ->
-    @user().name
+    @user().nameWithTitle(@group()) if @user()
 
   userUsername: ->
     @user().username
@@ -24,6 +24,11 @@ module.exports = class MembershipModel extends BaseModel
 
   groupName: ->
     @group().name
+
+  target: ->
+    (@group() if @group().type == "FormalGroup")             or
+    @recordStore.discussions.find(guestGroupId: @groupId)[0] or
+    @recordStore.polls.find(guestGroupId: @groupId)[0]
 
   saveVolume: (volume, applyToAll = false) ->
     @remote.patchMember(@keyOrId(), 'set_volume',

--- a/client/shared/models/outcome_model.coffee
+++ b/client/shared/models/outcome_model.coffee
@@ -25,6 +25,9 @@ module.exports = class OutcomeModel extends BaseModel
     @belongsTo 'author', from: 'users'
     @belongsTo 'poll'
 
+  authorName: ->
+    @author().nameWithTitle(@poll()) if @author()
+
   group: ->
     @poll().group() if @poll()
 

--- a/client/shared/models/poll_model.coffee
+++ b/client/shared/models/poll_model.coffee
@@ -65,6 +65,9 @@ module.exports = class PollModel extends BaseModel
     @hasMany   'pollDidNotVotes'
     @hasMany   'versions', sortBy: 'createdAt'
 
+  authorName: ->
+    @author().nameWithTitle(@)
+
   discussionGuestGroupId: ->
     @discussion().guestGroupId if @discussion()
 

--- a/client/shared/models/user_model.coffee
+++ b/client/shared/models/user_model.coffee
@@ -120,7 +120,7 @@ module.exports = class UserModel extends BaseModel
   titleFor: (model) ->
     return unless model
     if model.isA('group')
-      @membershipFor(model).title
+      (@membershipFor(model) or {}).title
     else if model.isA('discussion')
       @titleFor(model.guestGroup()) or @titleFor(model.group())
     else if model.isA('poll')

--- a/client/shared/models/user_model.coffee
+++ b/client/shared/models/user_model.coffee
@@ -114,5 +114,17 @@ module.exports = class UserModel extends BaseModel
     return @avatarUrl if typeof @avatarUrl is 'string'
     @avatarUrl[size]
 
+  nameWithTitle: (model) ->
+    _.compact([@name, @titleFor(model)]).join(' · ')
+
+  titleFor: (model) ->
+    return unless model
+    if model.isA('group')
+      @membershipFor(model).title
+    else if model.isA('discussion')
+      @titleFor(model.guestGroup()) or @titleFor(model.group())
+    else if model.isA('poll')
+      @titleFor(model.guestGroup()) or @titleFor(model.discussion()) or @titleFor(model.group())
+
   belongsToPayingGroup: ->
     _.any @groups(), (group) -> group.subscriptionKind == 'paid'

--- a/client/shared/models/version_model.coffee
+++ b/client/shared/models/version_model.coffee
@@ -18,6 +18,9 @@ module.exports = class VersionModel extends BaseModel
   attributeEdited: (name) ->
      _.include(_.keys(@changes), name)
 
+  authorName: ->
+    @author().nameWithTitle(@model()) if @author()
+
   model: ->
     @recordStore["#{@itemType.toLowerCase()}s"].find(@itemId)
 
@@ -27,9 +30,8 @@ module.exports = class VersionModel extends BaseModel
   isOriginal: ->
     @index == 0
 
-
   authorOrEditorName: ->
     if @isOriginal()
       @model().authorName()
     else
-      @author().name
+      @authorName()

--- a/client/shared/services/ability_service.coffee
+++ b/client/shared/services/ability_service.coffee
@@ -164,6 +164,10 @@ module.exports = new class AbilityService
     (!membership.admin or membership.group().adminIds().length > 1) and
     (membership.user() == Session.user() or @canAdministerGroup(membership.group()))
 
+  canSetMembershipTitle: (membership) ->
+    Session.user() == membership.user() or
+    @canAdministerGroup(membership.group())
+
   canResendMembership: (membership) ->
     membership and
     !membership.acceptedAt and

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -344,6 +344,7 @@ en:
     invitations: "Invitations"
 
   membership_dropdown:
+    set_title: "Set title"
     resend: "Resend invitation"
     invitation_resent: "Invitation resent"
     make_coordinator: 'Make coordinator'
@@ -855,6 +856,16 @@ en:
   memberships_panel:
     add_coordinator: Make coordinator
     remove_coordinator: Demote coordinator
+
+  membership_form:
+    title: Set title for membership
+    title_helptext:
+      group:      This title will be visible for all threads, decisions, comments, and stances in <strong>{{title}}</strong>
+      discussion: This title will be visible for all decisions, comments, and stances in <strong>{{title}}</strong>
+      poll:       This title will be visible with this user's stance in <strong>{{title}}</strong>
+    title_label: title
+    title_placeholder: E.g. 'Coordinator', or 'Facilitator'
+    updated: Membership title updated
 
   pending_invitations_card:
     heading: Pending invitations

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -858,11 +858,14 @@ en:
     remove_coordinator: Demote coordinator
 
   membership_form:
-    title: Set title for membership
+    modal_title:
+      group:      Set group title
+      discussion: Set thread title
+      poll:       Set {{pollType}} title
     title_helptext:
-      group:      This title will be visible for all threads, decisions, comments, and stances in <strong>{{title}}</strong>
-      discussion: This title will be visible for all decisions, comments, and stances in <strong>{{title}}</strong>
-      poll:       This title will be visible with this user's stance in <strong>{{title}}</strong>
+      group:      This title will appear beside {{name}}'s name within this group. Use it to let people know their role.
+      discussion: This title will appear beside {{name}}'s name within this thread. Use it to let people know their role.
+      poll:       This title will appear beside {{name}}'s name within this {{pollType}}. Use it to let people know their role.
     title_label: title
     title_placeholder: E.g. 'Coordinator', or 'Facilitator'
     updated: Membership title updated

--- a/db/migrate/20180519045039_add_title_to_membership.rb
+++ b/db/migrate/20180519045039_add_title_to_membership.rb
@@ -1,0 +1,5 @@
+class AddTitleToMembership < ActiveRecord::Migration[5.1]
+  def change
+    add_column :memberships, :title, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180513222241) do
+ActiveRecord::Schema.define(version: 20180519045039) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -411,6 +411,7 @@ ActiveRecord::Schema.define(version: 20180513222241) do
     t.integer "invitation_id"
     t.string "token"
     t.datetime "accepted_at"
+    t.string "title"
     t.index ["created_at"], name: "index_memberships_on_created_at"
     t.index ["group_id", "user_id", "is_suspended", "archived_at"], name: "active_memberships"
     t.index ["group_id", "user_id"], name: "index_memberships_on_group_id_and_user_id", unique: true


### PR DESCRIPTION
This one could use some eyes at this point @robguthrie 

Because our membership structure is so awesome, this functionality is massively flexible and cascades nicely (ie, for a stance, we'd do
```
<poll guest group membership title> or
<discussion guest group membership title> or
<formal group membership title> or
nothing!
```
I see potential for several interesting use cases:

- People in the group want to know 'who's in the room', without having to wade through an introductions thread. This makes it really easy for folks to apply titles to themselves within a group to help identify themselves; this could be fun, informative, or even used as a 'what's my status' (ala 'I'm away from the keyboard for the next 2 hours'), 'what country / time zone I'm in right now', etc., depending on how the facilitator guides the group

- A close knit group of people may be disconcerted if someone they don't know is invited into a private thread or poll; a title ("Ben Knight · Loomio Member", or "Angie Welsh · Chairman of our board" <-- read: BE NICE) can help instantly identify who this stranger is and why they might be here for this particular thread or poll

- This opens some doors to the role-based approaches to discussion that Holacracy and maybe Percolab-type folks are interested in; there may be particular discussions for which the Scrum Master is the facilitator (like 'What to do in sprint 25?'), whereas that person may have a different role in a different discussion; this allows folks to granularly pick who gets called what, for any conversation or decision.

Here's some screencaps:
![screen shot 2018-05-20 at 11 24 31 pm](https://user-images.githubusercontent.com/750477/40278515-3603be9a-5c86-11e8-85f0-3b98f86b2d44.png)
![screen shot 2018-05-20 at 11 25 16 pm](https://user-images.githubusercontent.com/750477/40278510-2c0c5898-5c86-11e8-947a-cf42612f885c.png)
![screen shot 2018-05-20 at 11 25 42 pm](https://user-images.githubusercontent.com/750477/40278511-2c36baa2-5c86-11e8-862e-de73bdb3c26e.png)
![screen shot 2018-05-20 at 11 25 51 pm](https://user-images.githubusercontent.com/750477/40278512-2c613c3c-5c86-11e8-8f8c-98c2c533a95d.png)
![screen shot 2018-05-20 at 11 26 01 pm](https://user-images.githubusercontent.com/750477/40278513-2c8d8de6-5c86-11e8-81e6-2c9bd5347f1d.png)



