### PR TITLE
fix missing thread items problem

### DIFF
--- a/app/models/discussion.rb
+++ b/app/models/discussion.rb
@@ -57,7 +57,7 @@ class Discussion < ApplicationRecord
   has_many :poll_documents,    through: :polls,    source: :documents
   has_many :comment_documents, through: :comments, source: :documents
 
-  has_many :items, -> { includes(:user).thread_events.order('events.id ASC') }, class_name: 'Event', dependent: :destroy
+  has_many :items, -> { includes(:user).thread_events }, class_name: 'Event', dependent: :destroy
 
   has_many :discussion_readers, dependent: :destroy
 


### PR DESCRIPTION
Order has been effectively ignored and users have been reporting missing thread items.

without this fix the 
a request for:
```
https://www.loomio.org/api/v1/events?from=1&per=10&order=sequence_id&discussion_id=1
```

produces query which looks like this..
```
Event Load (4.0ms)  SELECT  DISTINCT "events".* FROM "events" WHERE "events"."discussion_id" = $1 AND ("events"."kind" NOT IN ('motion_closed', 'motion_outcome_updated', 'motion_outcome_created', 'new_vote', 'new_motion', 'motion_closed_by_user', 'motion_edited')) AND (sequence_id >= '1') ORDER BY events.id ASC, sequence_id LIMIT $2 
```

and we do not get results ordered by sequence id, so we miss items out.

This fixes it. yay.
