### PR TITLE
allow self promote to coordinator when no coordinators

### DIFF
--- a/app/controllers/dev/scenarios/group.rb
+++ b/app/controllers/dev/scenarios/group.rb
@@ -83,7 +83,8 @@ module Dev::Scenarios::Group
   end
 
   def setup_group_with_no_coordinators
-    create_group.memberships.update_all(admin: false)
+    create_group
+    @group.admin_memberships.each{|m| m.update(admin: false)}
     sign_in patrick
     redirect_to group_url(create_group)
   end

--- a/app/controllers/dev/scenarios/group.rb
+++ b/app/controllers/dev/scenarios/group.rb
@@ -82,6 +82,12 @@ module Dev::Scenarios::Group
     redirect_to group_url(create_group)
   end
 
+  def setup_group_with_no_coordinators
+    create_group.memberships.update_all(admin: false)
+    sign_in patrick
+    redirect_to group_url(create_group)
+  end
+
   def setup_group_with_restrictive_settings
     sign_in max
     create_stance

--- a/app/controllers/dev/scenarios/membership.rb
+++ b/app/controllers/dev/scenarios/membership.rb
@@ -1,5 +1,6 @@
 module Dev::Scenarios::Membership
   def setup_group_as_member
+    create_group.update_admin_memberships_count
     sign_in jennifer
     redirect_to group_url(create_group)
   end

--- a/app/models/ability/membership.rb
+++ b/app/models/ability/membership.rb
@@ -10,7 +10,9 @@ module Ability::Membership
 
     can [:make_admin], ::Membership do |membership|
       user_is_admin_of?(membership.group_id) ||
-      (membership.user == user && membership.group.admin_memberships_count == 0)
+      (user_is_member_of?(membership.group_id) &&
+       membership.user == user &&
+       membership.group.admin_memberships.count == 0)
     end
 
     can :resend, ::Membership do |membership|

--- a/app/models/ability/membership.rb
+++ b/app/models/ability/membership.rb
@@ -9,7 +9,8 @@ module Ability::Membership
     end
 
     can [:make_admin], ::Membership do |membership|
-      user_is_admin_of?(membership.group_id)
+      user_is_admin_of?(membership.group_id) ||
+      (membership.user == user && membership.group.admin_memberships_count == 0)
     end
 
     can :resend, ::Membership do |membership|
@@ -17,8 +18,6 @@ module Ability::Membership
     end
 
     can [:remove_admin, :destroy], ::Membership do |membership|
-      (membership.group.members.size > 1) &&
-      (!membership.admin? or membership.group.admin_memberships_count > 1) &&
       (membership.user == user ||
        user_is_admin_of?(membership.group_id) ||
        (membership.inviter == user && !membership.accepted_at?))

--- a/app/serializers/group_serializer.rb
+++ b/app/serializers/group_serializer.rb
@@ -38,7 +38,7 @@ class GroupSerializer < Simple::GroupSerializer
              :membership_granted_upon,
              :discussion_privacy_options,
              :has_discussions,
-             :has_multiple_admins,
+             :admin_memberships_count,
              :archived_at
 
   attributes_for_formal :cover_urls,
@@ -93,9 +93,4 @@ class GroupSerializer < Simple::GroupSerializer
   def has_discussions
     object.discussions_count > 0
   end
-
-  def has_multiple_admins
-    object.admin_memberships_count > 1
-  end
-
 end

--- a/client/angular/components/fragments/only_coordinator.haml
+++ b/client/angular/components/fragments/only_coordinator.haml
@@ -1,6 +1,0 @@
-.fragment.fragment__only-coordinator
-  %p{translate: "only_coordinator_modal.explanation"}
-  %ul.only-coordinator-modal__list
-    %li.only-coordinator-modal__list-item{ng-repeat: "group in user.onlyAdminGroups() track by group.id"}
-      %a.lmo-link{ng-click: "submit(group)"} {{group.fullName}}
-  %p{translate: "only_coordinator_modal.instructions"}

--- a/client/angular/components/membership/dropdown/membership_dropdown.coffee
+++ b/client/angular/components/membership/dropdown/membership_dropdown.coffee
@@ -49,6 +49,7 @@ angular.module('loomioApp').directive 'membershipDropdown', ->
         redirect:   ('dashboard' if $scope.membership.user() == Session.user())
 
     $scope.canToggleAdmin = ->
+      ($scope.membership.group().adminMembershipsCount == 0 and $scope.membership.user() == Session.user()) or
       AbilityService.canAdministerGroup($scope.membership.group()) and
       (!$scope.membership.admin or $scope.canRemoveMembership($scope.membership))
 

--- a/client/angular/pages/profile_page/profile_page_controller.coffee
+++ b/client/angular/pages/profile_page/profile_page_controller.coffee
@@ -45,34 +45,22 @@ $controller = ($scope, $rootScope) ->
       submit: -> ModalService.open 'ConfirmModal', confirm: confirm
 
   @deleteUser = ->
-    if AbilityService.canDeactivateUser()
-      ModalService.open 'ConfirmModal', confirm: ->
-        text:
-          title: 'delete_user_modal.title'
-          submit: 'delete_user_modal.submit'
-          fragment: 'delete_user_modal'
-        submit: -> Records.users.destroy()
-        successCallback: hardReload
-    else
-      ModalService.open 'ConfirmModal', confirm: confirm
+    ModalService.open 'ConfirmModal', confirm: ->
+      text:
+        title: 'delete_user_modal.title'
+        submit: 'delete_user_modal.submit'
+        fragment: 'delete_user_modal'
+      submit: -> Records.users.destroy()
+      successCallback: hardReload
 
   confirm = ->
-    if AbilityService.canDeactivateUser()
-      scope: {user: Session.user()}
-      submit: -> Records.users.deactivate(Session.user())
-      text:
-        title:    'deactivate_user_form.title'
-        submit:   'deactivate_user_form.submit'
-        fragment: 'deactivate_user_confirmation'
-      successCallback: hardReload
-    else
-      scope: {user: Session.user()}
-      submit: -> Promise.resolve(true)
-      successCallback: (group) ->
-        LmoUrlService.goTo LmoUrlService.group(group) if group
-      text:
-        title:    'deactivate_user_form.title'
-        fragment: 'only_coordinator'
+    scope: {user: Session.user()}
+    submit: -> Records.users.deactivate(Session.user())
+    text:
+      title:    'deactivate_user_form.title'
+      submit:   'deactivate_user_form.submit'
+      fragment: 'deactivate_user_confirmation'
+    successCallback: hardReload
 
   return
 

--- a/client/angular/test/nightwatch/core/group.js
+++ b/client/angular/test/nightwatch/core/group.js
@@ -333,13 +333,6 @@ module.exports = {
     page.expectText('.dashboard-page__no-groups', "Start or join a group to see threads")
   },
 
-  'prevents last coordinator from leaving the group': (test) => {
-    page = pageHelper(test)
-    page.loadPath('setup_group')
-    page.click('.group-page-actions__button')
-    page.expectNoElement('.group-page-actions__leave-group')
-  },
-
   'allows a coordinator to archive a group': (test) => {
     page = pageHelper(test)
 

--- a/client/angular/test/nightwatch/core/membership.js
+++ b/client/angular/test/nightwatch/core/membership.js
@@ -36,7 +36,7 @@ module.exports = {
     page.expectElement('.membership-card__invite')
   },
 
-  'can remove coordinator privileges when there is more than one coordinator': (test) => {
+  'can remove coordinator privileges': (test) => {
     page = pageHelper(test)
 
     page.loadPath('setup_group_with_multiple_coordinators')
@@ -50,10 +50,22 @@ module.exports = {
     page.expectNoElement('.user-avatar--coordinator')
   },
 
-  'cannot_remove_privileges_for_last_coordinator': (test) => {
+  'can_self_promote_when_no_coordinators': (test) => {
     page = pageHelper(test)
 
-    page.loadPath('setup_group')
+    page.loadPath('setup_group_with_no_coordinators')
+    page.click('.membership-card__search-button')
+    page.fillIn('.membership-card__filter', 'Patrick')
+    page.pause()
+    page.click('.membership-dropdown__button')
+    page.click('.membership-dropdown__toggle-admin')
+    page.expectText('.flash-root__message', 'Patrick Swayze is now a coordinator')
+  },
+
+  'cannot_self_promote_when_coordinators': (test) => {
+    page = pageHelper(test)
+
+    page.loadPath('setup_group_as_member')
     page.click('.membership-card__search-button')
     page.fillIn('.membership-card__filter', 'Patrick')
     page.pause()

--- a/client/angular/test/nightwatch/core/membership.js
+++ b/client/angular/test/nightwatch/core/membership.js
@@ -67,10 +67,9 @@ module.exports = {
 
     page.loadPath('setup_group_as_member')
     page.click('.membership-card__search-button')
-    page.fillIn('.membership-card__filter', 'Patrick')
+    page.fillIn('.membership-card__filter', 'Jennifer')
     page.pause()
     page.click('.membership-dropdown__button')
-    page.pause()
     page.expectNoText('.membership-dropdown', 'Demote coordinator')
   },
 

--- a/client/angular/test/nightwatch/core/profile.js
+++ b/client/angular/test/nightwatch/core/profile.js
@@ -96,19 +96,6 @@ module.exports = {
     page.expectText('.flash-root__message', 'Your password has been updated')
   },
 
-  'prevents you from deactivating the account': (test) => {
-    page = pageHelper(test)
-
-    page.loadPath('setup_discussion')
-    page.click('.user-dropdown__dropdown-button')
-    page.click('.user-dropdown__list-item-button--profile')
-    page.click('.profile-page__deactivate')
-    page.expectText('.confirm-modal', 'When you deactivate your account:')
-    page.click('.confirm-modal__submit')
-    page.pause()
-    page.expectText('.confirm-modal', 'A group must have at least one coordinator. You are the only coordinator of the following groups:')
-  },
-
   'successfully_deactivates_the_account': (test) => {
     page = pageHelper(test)
 

--- a/client/shared/models/user_model.coffee
+++ b/client/shared/models/user_model.coffee
@@ -43,9 +43,6 @@ module.exports = class UserModel extends BaseModel
   adminGroupIds: ->
     _.invoke @adminMemberships(), 'groupId'
 
-  onlyAdminGroups: ->
-    _.filter @adminGroups(), (g) -> g.adminMembershipsCount == 1
-
   parentGroups: ->
     _.filter @groups(), (group) -> group.isParent()
 

--- a/client/shared/models/user_model.coffee
+++ b/client/shared/models/user_model.coffee
@@ -44,7 +44,7 @@ module.exports = class UserModel extends BaseModel
     _.invoke @adminMemberships(), 'groupId'
 
   onlyAdminGroups: ->
-    _.filter @adminGroups(), (g) -> !g.hasMultipleAdmins
+    _.filter @adminGroups(), (g) -> g.adminMembershipsCount == 1
 
   parentGroups: ->
     _.filter @groups(), (group) -> group.isParent()

--- a/client/shared/services/ability_service.coffee
+++ b/client/shared/services/ability_service.coffee
@@ -160,8 +160,6 @@ module.exports = new class AbilityService
 
   canRemoveMembership: (membership) ->
     membership and
-    membership.group().memberIds().length > 1 and
-    (!membership.admin or membership.group().adminIds().length > 1) and
     (membership.user() == Session.user() or @canAdministerGroup(membership.group()))
 
   canSetMembershipTitle: (membership) ->
@@ -172,10 +170,6 @@ module.exports = new class AbilityService
     membership and
     !membership.acceptedAt and
     membership.inviter() == Session.user()
-
-  canDeactivateUser: ->
-   _.all Session.user().memberships(), (membership) ->
-     !membership.admin or membership.group().hasMultipleAdmins
 
   canManageMembershipRequests: (group) ->
     (group.membersCanAddMembers and Session.user().isMemberOf(group)) or @canAdministerGroup(group)

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -968,11 +968,6 @@ en:
     placeholder: 'Answering this question is optional. Any information you share will help us to improve :)'
     submit: 'Deactivate account'
 
-  only_coordinator_modal:
-    aria_label: 'Unable to proceed'
-    explanation: 'A group must have at least one coordinator. You are the only coordinator of the following groups:'
-    instructions: 'In order to deactivate your account, you need to visit each of the groups listed above and either make someone else a coordinator, or deactivate the group.'
-
   email_settings_page:
     header: Email settings
     all_groups: Settings for all groups

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -266,11 +266,6 @@ describe "User abilities" do
 
     it { should be_able_to(:show, user_comment) }
 
-    it "cannot remove themselves if they are the only member of the group" do
-      group.memberships.where("memberships.id != ?", @membership.id).destroy_all
-      should_not be_able_to(:destroy, @membership)
-    end
-
     context "members can add members" do
       before { group.update_attribute(:members_can_add_members, true) }
       it { should     be_able_to(:add_members, group) }

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -315,9 +315,15 @@ describe "User abilities" do
     it { should     be_able_to(:destroy, own_pending_membership) }
     it { should     be_able_to(:destroy, other_members_pending_membership) }
 
-    it "should not be able to delete the only admin of a group" do
-      group.admin_memberships.where("memberships.id != ?", @membership.id).destroy_all
-      should_not be_able_to(:destroy, @membership)
+    it "should be able to become admin if no admins" do
+      @membership.update(admin: false)
+      group.admin_memberships.destroy_all
+      should be_able_to(:make_admin, @membership)
+    end
+
+    it "should not be able to become admin if other admins" do
+      @membership.update(admin: false)
+      should_not be_able_to(:make_admin, @membership)
     end
 
     context "group members invitable by admins" do


### PR DESCRIPTION
rather than this big task of ensuring there are coordinators, and checks and rules.. let's just allow groups to have no coordinators, and if that is the case, a member can self promote to coordinator.