### PR TITLE
fix for cannot login by password when unverified emails exist

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -206,6 +206,10 @@ class User < ApplicationRecord
     verified_first.find_by(email: email)&.email_status || :unused
   end
 
+  def self.find_for_database_authentication(warden_conditions)
+    super(warden_conditions.merge(email_verified: true))
+  end
+
   define_counter_cache(:memberships_count) {|user| user.memberships.formal.count }
 
   def associate_with_identity(identity)


### PR DESCRIPTION
a fix for #4734 

@gdpelican can you double check this? I only want to apply it for sign_in's initiated by the user, so if this breaks signing_in an unverified user just after creation then it's no good.