### PR TITLE
Add translation for poll mailer reminder. Fixes #4737

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -354,6 +354,7 @@ en:
     resend: 'REMINDER: %{member} is waiting for you to join %{group_name}'
 
   poll_mailer:
+    resend: '%{actor} is reminding you to vote in: %{title}'
     common:
       or: or
       why_send_this: You are receiving this email because %{reason}


### PR DESCRIPTION
Hi friends! Hope you are all doing well.

I got a weird email as per #4737 and thought I might be able to fix it. 

As far as I can tell the translation is invoked here:

https://github.com/loomio/loomio/blob/bfc7628441d7dd91196e9d5b678296baa52b14ed/app/models/events/announcement_resend.rb#L18

I think it should have access to `%{title}` and `%{actor}` based on:

https://github.com/loomio/loomio/blob/master/app/mailers/poll_mailer.rb#L44

Just editing this on the web so not sure if tests pass or if any new tests are necessary.