### PR TITLE
fix for contact request button not showing on many profile pages

### DIFF
--- a/app/controllers/api/memberships_controller.rb
+++ b/app/controllers/api/memberships_controller.rb
@@ -30,7 +30,7 @@ class API::MembershipsController < API::RestfulController
     same_group_ids   = current_user.formal_group_ids & @user.formal_group_ids
     public_group_ids = @user.formal_groups.visible_to_public.pluck(:id)
     instantiate_collection do |collection|
-      collection = Membership.joins(:group).where(group_id: same_group_ids + public_group_ids).active.formal.order('groups.full_name')
+      collection = Membership.joins(:group).where(group_id: same_group_ids + public_group_ids, user_id: @user.id).active.formal.order('groups.full_name')
     end
     respond_with_collection serializer: Simple::MembershipSerializer
   end

--- a/app/controllers/api/memberships_controller.rb
+++ b/app/controllers/api/memberships_controller.rb
@@ -27,7 +27,11 @@ class API::MembershipsController < API::RestfulController
 
   def for_user
     load_and_authorize :user
-    instantiate_collection { |collection| collection.active.formal.where(user_id: @user.id).order('groups.full_name') }
+    same_group_ids   = current_user.formal_group_ids & @user.formal_group_ids
+    public_group_ids = @user.formal_groups.visible_to_public.pluck(:id)
+    instantiate_collection do |collection|
+      collection = Membership.joins(:group).where(group_id: same_group_ids + public_group_ids).active.formal.order('groups.full_name')
+    end
     respond_with_collection serializer: Simple::MembershipSerializer
   end
 


### PR DESCRIPTION
Had a report that the contact request button on user profile page was not showing. And indeed it was not for many users, but it passes in tests. I found it too complex going through accessible_records and in this case and feel this is a simpler way to return the desired records.
