### PR TITLE
allow configuring SMTP SSL verification

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -104,7 +104,7 @@ module Loomio
         password: ENV['SMTP_PASSWORD'],
         domain: ENV['SMTP_DOMAIN'],
         ssl: ENV['SMTP_USE_SSL'],
-        openssl_verify_mode: 'none'
+        openssl_verify_mode: ENV['SMTP_SSL_VERIFY_MODE']
       }.compact
     else
       config.action_mailer.delivery_method = :test

--- a/config/application.rb
+++ b/config/application.rb
@@ -104,7 +104,7 @@ module Loomio
         password: ENV['SMTP_PASSWORD'],
         domain: ENV['SMTP_DOMAIN'],
         ssl: ENV['SMTP_USE_SSL'],
-        openssl_verify_mode: ENV['SMTP_SSL_VERIFY_MODE']
+        openssl_verify_mode: ENV.fetch('SMTP_SSL_VERIFY_MODE', 'none')
       }.compact
     else
       config.action_mailer.delivery_method = :test


### PR DESCRIPTION
Not verifying the SMTP server's certs is not a great idea, allowing a MITM to obtain auth credentials.