### PR TITLE
chore: add exit option to bash

### DIFF
--- a/docker_start.sh
+++ b/docker_start.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 if [ "$TASK" = "worker" ];
 then
   bundle exec rake jobs:work;


### PR DESCRIPTION
Exit immediately when one command fails on startup. This should make it more easy to catch memory issues or any other kind of configuration problems on startup.