### PR TITLE
Add standalone boolean to method call

### DIFF
--- a/lib/plugins/README.md
+++ b/lib/plugins/README.md
@@ -320,7 +320,7 @@ _NB: that this will compile files with extensions `js`, or `coffee` into `applic
 If you want to include assets in the asset pipeline without including them in the default manifest files (`application.js` and `application.css`, you can use the 'standalone' option.
 
 ```ruby
-  plugin.use_static_asset 'assets', 'kickflip.scss'
+  plugin.use_static_asset 'assets', 'kickflip.scss', true
 ```
 
 This means the file won't be included in the manifests, but still exist in the asset pipeline and can be included in individual views by writing


### PR DESCRIPTION
It was missing from the example

```ruby
    def use_static_asset(path, filename, standalone: false)
      @static_assets.add StaticAsset.new(path_prefix(path), filename, standalone)
    end
```