### PR TITLE
Add reference to application.css in head

### DIFF
--- a/app/views/application/index.html.haml
+++ b/app/views/application/index.html.haml
@@ -18,6 +18,8 @@
     %link{rel: "apple-touch-icon", href: AppConfig.theme[:icon_src]}
 
     %link{rel: "stylesheet", href: client_asset_path(:"angular.min.css")}
+    %link{rel: "stylesheet", href: asset_path(:"application.css")}
+
     %link{rel: 'manifest',   href: '/manifest.json'}
 
     = action_cable_meta_tag


### PR DESCRIPTION
I couldn't find where the application.scss.erb file was being loaded in the front-end, so it's very possible that I'm missing something here, but to be able to load assets in plugins [as described here](https://github.com/loomio/loomio/blob/master/lib/plugins/README.md#add-assets-to-the-asset-pipeline) the [application.scss.erb](https://github.com/loomio/loomio/blob/master/app/assets/stylesheets/application.scss.erb#L1) loads things from [the repository in plugins](https://github.com/loomio/loomio/blob/master/lib/plugins/repository.rb#L43), but if that file isn't loaded, than the assets aren't loaded either. 

So, maybe something changed in how this should be done, but this seemed like a fairly straightforward fix to me. 

One alternative that I thought of doing was creating a component with just a `.scss` file, but that seemed like overkill.