### PR TITLE
Add score poll title for decisions card

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1312,6 +1312,7 @@ en:
     proposal_title: Proposal
     count_title: Check
     poll_title: Poll
+    score_title: Score poll
     dot_vote_title: Dot Vote
     meeting_title: Time poll
     ranked_choice_title: Ranked choice


### PR DESCRIPTION
Looks like the decision tools card is missing a score translation!

Repro: visit https://www.loomio.org/p/new on loomio.org:
<img width="813" alt="captura de pantalla 2019-02-21 a la s 16 43 58" src="https://user-images.githubusercontent.com/750477/53142204-e95ea900-35f7-11e9-9e5a-58184f053392.png">
