### PR TITLE
require accepted membership to access a group

### DIFF
--- a/app/models/ability/base.rb
+++ b/app/models/ability/base.rb
@@ -29,20 +29,27 @@ module Ability
 
     private
 
+    # expect to replace this with proper accept membership modal soon
+    def accept_pending_membership_for!(group)
+      if membership = group.memberships.pending.find_by(user: @user)
+        MembershipService.redeem!(membership)
+      end
+    end
+
     def user_is_member_of?(group_id)
-      @user.group_ids.include?(group_id)
+      @user.memberships.active.find_by(group_id: group_id)
     end
 
     def user_is_admin_of?(group_id)
-      @user.adminable_group_ids.include?(group_id)
+      @user.admin_memberships.active.find_by(group_id: group_id)
     end
 
     def user_is_member_of_any?(groups)
-      @user.memberships.find_by(group: groups)
+      @user.memberships.active.find_by(group: groups)
     end
 
     def user_is_admin_of_any?(groups)
-      @user.admin_memberships.find_by(group: groups)
+      @user.admin_memberships.active.find_by(group: groups)
     end
 
     def user_is_author_of?(object)

--- a/app/models/ability/group.rb
+++ b/app/models/ability/group.rb
@@ -8,6 +8,7 @@ module Ability::Group
       else
         group.is_visible_to_public? or
         user_is_member_of?(group.id) or
+        accept_pending_membership_for!(group) or 
         (group.is_visible_to_parent_members? and user_is_member_of?(group.parent_id))
       end
     end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -18,7 +18,7 @@ class Group < ApplicationRecord
 
   has_many :all_memberships, dependent: :destroy, class_name: 'Membership'
   has_many :all_members, through: :all_memberships, source: :user
-  
+
   has_many :memberships, -> { where archived_at: nil }
   has_many :members, through: :memberships, source: :user
 
@@ -61,10 +61,6 @@ class Group < ApplicationRecord
 
   def guest_group
     self
-  end
-
-  def headcount
-    memberships_count + pending_memberships_count
   end
 
   def mailer

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -283,7 +283,7 @@ class User < ApplicationRecord
 
   # Provide can? and cannot? as methods for checking permissions
   def ability
-    @ability ||= Ability::Base.new(self)
+    @ability ||= ::Ability::Base.new(self)
   end
 
   delegate :can?, :cannot?, :to => :ability

--- a/spec/controllers/api/groups_controller_spec.rb
+++ b/spec/controllers/api/groups_controller_spec.rb
@@ -9,7 +9,7 @@ describe API::GroupsController do
   let(:another_group) { create :guest_group }
 
   before do
-    group.admins << user
+    group.add_admin! user
     sign_in user
   end
 
@@ -71,7 +71,6 @@ describe API::GroupsController do
         expect(response.status).to eq 403
       end
     end
-
   end
 
   describe 'update' do

--- a/spec/controllers/api/search_controller_spec.rb
+++ b/spec/controllers/api/search_controller_spec.rb
@@ -8,7 +8,7 @@ describe API::SearchController do
 
   describe 'index' do
     before do
-      group.admins << user
+      group.add_admin! user
       sign_in user
     end
 


### PR DESCRIPTION
we were allowing pending membership to grant access to groups, which isn't a security flaw, but it's stupid