### PR TITLE
Sanitize group description text from  HTML or Markdown

### DIFF
--- a/vue/src/components/explore/page.vue
+++ b/vue/src/components/explore/page.vue
@@ -6,6 +6,7 @@ import UrlFor    from '@/mixins/url_for'
 import _truncate from 'lodash/truncate'
 import _map      from 'lodash/map'
 import _sortBy   from 'lodash/sortBy'
+import marked    from 'marked'
 
 import { debounce } from 'lodash'
 
@@ -45,7 +46,12 @@ export default
       { 'background-image': "url(#{group.coverUrl('small')})" }
 
     groupDescription: (group) ->
-      _truncate group.description, {length: 100} if group.description
+      description = group.description || ''
+      if group.descriptionFormat == 'md'
+        description = marked(description)
+      parser = new DOMParser()
+      doc = parser.parseFromString(description, 'text/html')
+      _truncate doc.body.textContent, {length: 100}
   computed:
     showMessage: ->
       !@searching &&


### PR DESCRIPTION
Closes #6140. Cleans up group description from HTML or Markdown based on `description_format` field. Loofah is added to the Gemfile, but it's already a sub-dependency so this isn't really adding anything new.

I'm using Loofah instead of [`strip_tags`](https://apidock.com/rails/ActionView/Helpers/SanitizeHelper/strip_tags) because its `to_text` method adds whitespace between tags for clarity. With `strip_tags` this HTML:

```html
<p>Line one</p><p>Line two</p>
``` 

becomes "LineoneLinetwo", while Loofah will return "Line one Line two". Let me know if there's anything I should fix!