### PR TITLE
Add support for using nextcloud as identity provider

### DIFF
--- a/app/controllers/identities/nextcloud_controller.rb
+++ b/app/controllers/identities/nextcloud_controller.rb
@@ -1,0 +1,20 @@
+class Identities::NextcloudController < Identities::BaseController
+
+  private
+
+  def oauth_host
+    ENV['NEXTCLOUD_HOST']
+  end
+
+  def oauth_url
+    "#{oauth_host}#{oauth_authorize_path}?#{oauth_params.to_query}"
+  end
+
+  def oauth_authorize_path
+    '/index.php/apps/oauth2/authorize'.freeze
+  end
+
+  def oauth_params
+    { client.client_key_name => client.key, redirect_uri: redirect_uri, response_type: :code }
+  end
+end

--- a/app/extras/clients/nextcloud.rb
+++ b/app/extras/clients/nextcloud.rb
@@ -1,0 +1,36 @@
+class Clients::Nextcloud < Clients::Base
+
+  def fetch_access_token(code, uri)
+    post 'index.php/apps/oauth2/api/v1/token', params: { code: code, redirect_uri: uri, grant_type: :authorization_code }
+  end
+
+  def fetch_user_info
+    get 'ocs/v2.php/cloud/user', params: { format: :json }
+  end
+
+  private
+
+  def default_params
+    { client_id: @key, client_secret: @secret }.delete_if { |k,v| v.nil? }
+  end
+
+  def authorization_headers
+    { 'Authorization' => "Bearer #{@token}" }
+  end
+
+  def common_headers
+    { 'Content-Type' => 'application/x-www-form-urlencoded; charset=UTF-8' }
+  end
+
+  def default_headers
+    if @token
+      common_headers.merge(authorization_headers)
+    else
+      common_headers
+    end
+  end
+
+  def default_host
+    ENV['NEXTCLOUD_HOST']
+  end
+end

--- a/app/models/identities/nextcloud.rb
+++ b/app/models/identities/nextcloud.rb
@@ -1,0 +1,11 @@
+class Identities::Nextcloud < Identities::Base
+  include Identities::WithClient
+  set_identity_type :nextcloud
+
+  def apply_user_info(payload)
+    payload = payload['ocs']['data']
+    self.uid    ||= payload['id']
+    self.name   ||= payload['id']
+    self.email  ||= payload['email']
+  end
+end

--- a/config/providers.yml
+++ b/config/providers.yml
@@ -5,6 +5,7 @@ identity:
   - slack
   - microsoft
   - saml
+  - nextcloud
 
 # for providers which provide additional API access
 community:


### PR DESCRIPTION
Loomio must be registered in nextcloud as oauth 2.0 client using https://loomio.example.com/nextcloud/authorize as redirection URL.

In loomio the NEXTCLOUD_HOST environment variable must point to the nextcloud instance, for example https://nextcloud.example.com. NEXTCLOUD_APP_KEY and NEXTCLOUD_APP_SECRET must be set to the client identifier and secret set by nextcloud.