### PR TITLE
Revert "Bump sentry-ruby from 4.0.1 to 4.1.0"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -485,8 +485,7 @@ GEM
     sentry-rails (4.0.0)
       rails (>= 5.0)
       sentry-ruby (>= 4.0.0)
-    sentry-ruby (4.1.0)
-      concurrent-ruby
+    sentry-ruby (4.0.1)
       faraday (>= 1.0)
     sentry-sidekiq (4.0.0)
       sentry-ruby (>= 4.0.0)


### PR DESCRIPTION
Reverts loomio/loomio#7198