### PR TITLE
Allow 'none' smtp authentication

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -106,7 +106,7 @@ module Loomio
       config.action_mailer.smtp_settings = {
         address: ENV['SMTP_SERVER'],
         port: ENV['SMTP_PORT'],
-        authentication: ENV['SMTP_AUTH'],
+        authentication: ENV['SMTP_AUTH'] == 'none' ? nil : ENV['SMTP_AUTH'] || :plain,
         user_name: ENV['SMTP_USERNAME'],
         password: ENV['SMTP_PASSWORD'],
         domain: ENV['SMTP_DOMAIN'],


### PR DESCRIPTION
To use smtp without authentication, we need to set "authentication" to nil. 
I copied the solution from other projects:
https://github.com/huginn/huginn/pull/1942/files
https://github.com/tootsuite/mastodon/pull/1597/files