### PR TITLE
Use created_at to order notifications

### DIFF
--- a/app/controllers/api/v1/notifications_controller.rb
+++ b/app/controllers/api/v1/notifications_controller.rb
@@ -12,6 +12,6 @@ class API::V1::NotificationsController < API::V1::RestfulController
   end
 
   def accessible_records
-    current_user.notifications.includes(:actor, :event).order(id: :desc)
+    current_user.notifications.includes(:actor, :event).order(created_at: :desc)
   end
 end


### PR DESCRIPTION
See #8579 for context

This was the only instance of "order(id" I could find in the code base.

I haven't tested this as I don't have the development environment set up.