### PR TITLE
Ability to switch to previously uploaded avatar

### DIFF
--- a/app/controllers/api/v1/profile_controller.rb
+++ b/app/controllers/api/v1/profile_controller.rb
@@ -62,7 +62,7 @@ class API::V1::ProfileController < API::V1::RestfulController
   end
 
   def avatar_uploaded
-    render json: {avatar_uploaded: current_user.uploaded_avatar_url_if_any}
+    render json: {avatar_uploaded: current_user.uploaded_avatar_url}
   end
 
   def destroy

--- a/app/controllers/api/v1/profile_controller.rb
+++ b/app/controllers/api/v1/profile_controller.rb
@@ -61,6 +61,10 @@ class API::V1::ProfileController < API::V1::RestfulController
     respond_with_resource
   end
 
+  def avatar_uploaded
+    render json: {avatar_uploaded: current_user.uploaded_avatar_url}
+  end
+
   def destroy
     service.deactivate(user: current_user)
     respond_with_resource

--- a/app/controllers/api/v1/profile_controller.rb
+++ b/app/controllers/api/v1/profile_controller.rb
@@ -62,7 +62,7 @@ class API::V1::ProfileController < API::V1::RestfulController
   end
 
   def avatar_uploaded
-    render json: {avatar_uploaded: current_user.uploaded_avatar_url}
+    render json: {avatar_uploaded: current_user.uploaded_avatar_url_if_any}
   end
 
   def destroy

--- a/app/models/concerns/has_avatar.rb
+++ b/app/models/concerns/has_avatar.rb
@@ -54,6 +54,12 @@ module HasAvatar
     )
   end
 
+  def uploaded_avatar_url_if_any(size = 512)
+    uploaded_avatar_url(size)
+  rescue
+    nil
+  end
+
   def has_gravatar?(options = {})
     return false if Rails.env.test?
     hash = Digest::MD5.hexdigest(email.to_s.downcase)

--- a/app/models/concerns/has_avatar.rb
+++ b/app/models/concerns/has_avatar.rb
@@ -48,16 +48,11 @@ module HasAvatar
   end
 
   def uploaded_avatar_url(size = 512)
+    return unless uploaded_avatar.attached?
     Rails.application.routes.url_helpers.rails_representation_path(
         uploaded_avatar.representation(resize_to_limit: [size,size], saver: {quality: 80, strip: true}),
         only_path: true
     )
-  end
-
-  def uploaded_avatar_url_if_any(size = 512)
-    uploaded_avatar_url(size)
-  rescue
-    nil
   end
 
   def has_gravatar?(options = {})

--- a/app/models/concerns/has_avatar.rb
+++ b/app/models/concerns/has_avatar.rb
@@ -38,16 +38,20 @@ module HasAvatar
     when 'gravatar'
       gravatar_url(size: size, secure: true, default: 'retro')
     when 'uploaded'
-      Rails.application.routes.url_helpers.rails_representation_path(
-        uploaded_avatar.representation(resize_to_limit: [size,size], saver: {quality: 80, strip: true}),
-        only_path: true
-      )
+      uploaded_avatar_url(size)
     else
       nil
     end
   rescue ActiveStorage::UnrepresentableError
     update_columns(avatar_kind: :initials)
     nil
+  end
+
+  def uploaded_avatar_url(size = 512)
+    Rails.application.routes.url_helpers.rails_representation_path(
+        uploaded_avatar.representation(resize_to_limit: [size,size], saver: {quality: 80, strip: true}),
+        only_path: true
+    )
   end
 
   def has_gravatar?(options = {})

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1381,6 +1381,7 @@ en:
     use_initials: 'Use initials'
     use_gravatar: 'Use Gravatar'
     use_uploaded: 'Upload new photo'
+    reuse_uploaded: 'Restore previous upload'
     use_provider: 'Use {{provider}} photo'
 
   change_password_form:

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1381,7 +1381,7 @@ en:
     use_initials: 'Use initials'
     use_gravatar: 'Use Gravatar'
     use_uploaded: 'Upload new photo'
-    reuse_uploaded: 'Restore previous upload'
+    existing_upload: 'Existing upload'
     use_provider: 'Use {{provider}} photo'
 
   change_password_form:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -128,6 +128,7 @@ Rails.application.routes.draw do
           get  :email_exists
           get  :send_merge_verification_email
           get  :contactable
+          get  :avatar_uploaded
           post :update_profile
           post :set_volume
           post :upload_avatar

--- a/vue/src/components/profile/change_picture_form.vue
+++ b/vue/src/components/profile/change_picture_form.vue
@@ -54,7 +54,8 @@ export default
 
   created: ->
     Records.users.saveExperience("changePicture")
-    Records.users.getAvatarUploaded()
+    Records.users.fetch
+      path: 'avatar_uploaded'
     .then (res) => @previous_uploaded_avatar = res.avatar_uploaded
 
 </script>

--- a/vue/src/components/profile/change_picture_form.vue
+++ b/vue/src/components/profile/change_picture_form.vue
@@ -15,6 +15,7 @@ export default
     providers: AppConfig.identityProviders
     uploading: false
     progress: 0
+    previous_uploaded_avatar: undefined
   methods:
     capitalize: capitalize
     iconClass: (provider) ->
@@ -53,6 +54,8 @@ export default
 
   created: ->
     Records.users.saveExperience("changePicture")
+    Records.users.getAvatarUploaded()
+    .then (res) => @previous_uploaded_avatar = res.avatar_uploaded
 
 </script>
 <template lang="pug">
@@ -71,10 +74,10 @@ v-card.change-picture-form
           v-icon mdi-camera
         v-list-item-title(v-t="'change_picture_form.use_uploaded'")
           input.hidden.change-picture-form__file-input(type="file" ref="fileInput" @change='uploadFile' accept="image/png, image/jpeg, image/webp")
-      v-list-item.change-picture-form__option(v-if="user.avatarKind !== 'uploaded'" @click="submit('uploaded')")
+      v-list-item.change-picture-form__option(v-if="previous_uploaded_avatar" @click="submit('uploaded')")
         v-list-item-avatar
-          v-icon mdi-file-undo
-        v-list-item-title(v-t="'change_picture_form.reuse_uploaded'")
+          img(:src="previous_uploaded_avatar")
+        v-list-item-title(v-t="'change_picture_form.existing_upload'")
       v-list-item(v-for="provider in providers" :key="provider.id" @click="selectProvider(provider)")
         v-list-item-avatar
           v-icon {{ iconClass(provider.name) }}

--- a/vue/src/components/profile/change_picture_form.vue
+++ b/vue/src/components/profile/change_picture_form.vue
@@ -71,6 +71,10 @@ v-card.change-picture-form
           v-icon mdi-camera
         v-list-item-title(v-t="'change_picture_form.use_uploaded'")
           input.hidden.change-picture-form__file-input(type="file" ref="fileInput" @change='uploadFile' accept="image/png, image/jpeg, image/webp")
+      v-list-item.change-picture-form__option(v-if="user.avatarKind !== 'uploaded'" @click="submit('uploaded')")
+        v-list-item-avatar
+          v-icon mdi-file-undo
+        v-list-item-title(v-t="'change_picture_form.reuse_uploaded'")
       v-list-item(v-for="provider in providers" :key="provider.id" @click="selectProvider(provider)")
         v-list-item-avatar
           v-icon {{ iconClass(provider.name) }}

--- a/vue/src/shared/interfaces/user_records_interface.coffee
+++ b/vue/src/shared/interfaces/user_records_interface.coffee
@@ -38,6 +38,10 @@ export default class UserRecordsInterface extends BaseRecordsInterface
   uploadAvatar: (file) =>
     @remote.upload 'upload_avatar', file
 
+  getAvatarUploaded: ->
+    @fetch
+      path: 'avatar_uploaded'
+
   changePassword: (user) =>
     user.processing = true
     @remote.post('change_password', user.serialize()).finally ->

--- a/vue/src/shared/interfaces/user_records_interface.coffee
+++ b/vue/src/shared/interfaces/user_records_interface.coffee
@@ -38,10 +38,6 @@ export default class UserRecordsInterface extends BaseRecordsInterface
   uploadAvatar: (file) =>
     @remote.upload 'upload_avatar', file
 
-  getAvatarUploaded: ->
-    @fetch
-      path: 'avatar_uploaded'
-
   changePassword: (user) =>
     user.processing = true
     @remote.post('change_password', user.serialize()).finally ->


### PR DESCRIPTION
Presently, if a user switches to gravatar after uploading their image, they will not be able to switch back from the front-end.

Screenshot:
![image](https://user-images.githubusercontent.com/945777/169547645-9c80eeaf-e928-4f36-986f-03781547b8eb.png)


There are a couple of problems with this PR:

1. When a user chooses something else, say gravatar. For a brief second the "Restore previous upload" shows up. This is a bit ugly.
2. I'm not sure if I'm doing translations correctly. Should I add the key to all the translation files?
3.  What happens if the user doesn't already have an uploaded image?

The problem with 3 is that if the user is having "initials" or "gravatar", there is no way for the frontend to know if an upload already exists. Maybe once an API is built for that we can use that to check if this option should be made visible or not.

I'm not sure if the vue is good either.

Feel free to suggest modifications or alternate approaches.