### PR TITLE
Display if user has no pending polls to vote

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1443,6 +1443,7 @@ en:
   dashboard_page:
     aria_label: 'Dashboard'
     polls_to_vote_on: "Polls to vote on"
+    no_polls_to_vote_on: "You don't have any pending polls."
     recent_polls: "Recent polls"
     current_polls: "Current polls"
     recent_threads: "Recent threads"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1443,7 +1443,7 @@ en:
   dashboard_page:
     aria_label: 'Dashboard'
     polls_to_vote_on: "Polls to vote on"
-    no_polls_to_vote_on: "You don't have any pending polls."
+    no_polls_to_vote_on: "There are no polls you need to vote on"
     recent_polls: "Recent polls"
     current_polls: "Current polls"
     recent_threads: "Recent threads"

--- a/vue/src/components/dashboard/polls_panel.vue
+++ b/vue/src/components/dashboard/polls_panel.vue
@@ -53,13 +53,22 @@ export default
 .polls-panel(v-if='otherPolls.length || votePolls.length || loader.loading')
   v-card.mb-2
     v-list(two-line avatar)
-      template(v-if="votePolls.length")
-        v-subheader(v-t="'dashboard_page.polls_to_vote_on'")
-        poll-common-preview(:poll='poll' v-for='poll in votePolls' :key='poll.id')
+      template
+        v-card-title(v-t="'dashboard_page.polls_to_vote_on'")
+        poll-common-preview(
+          v-if="votePolls.length",
+          :poll="poll",
+          v-for="poll in votePolls",
+          :key="poll.id"
+        )
+        v-card-text(
+          v-if="votePolls.length == 0",
+          v-t="'dashboard_page.no_polls_to_vote_on'"
+        )
       template(v-if="otherPolls.length")
-        v-subheader(v-t="'dashboard_page.recent_polls'")
+        v-card-title(v-t="'dashboard_page.recent_polls'")
         poll-common-preview(:poll='poll' v-for='poll in otherPolls' :key='poll.id')
       template(v-if='!votePolls.length && !otherPolls.length && loader.loading')
-        v-subheader(v-t="'group_page.polls'")
+        v-card-title(v-t="'group_page.polls'")
         loading-content(:lineCount='2' v-for='(item, index) in [1]' :key='index' )
 </template>


### PR DESCRIPTION
We were facing an issue where people checked their dashboards and after seeing only the "Recent polls" section didn't understand that there were no pending polls to vote.

This change shows the Pending Polls section even if the user has no pending polls, but instead of the polls list it shows the message "You don't have any pending polls.".

It also changes the sections titles to the component  `v-card-title` to give them more emphasis.

<img width="507" alt="Screen Shot 2022-06-01 at 10 33 22" src="https://user-images.githubusercontent.com/333447/171362766-b1bce7b7-3779-48d9-b085-36ed0146406c.png">

