### PR TITLE
Add vendor folder to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,6 @@ yarn-error.log*
 *.njsproj
 *.sln
 *.sw*
+
+# Ruby bundle and gems
+/vendor


### PR DESCRIPTION
When running the application locally the vendor folder keeps appearing as unstaged changes, so better to ignore it to avoid pushing by mistake and also make easier to track the unstaged changes.