### PR TITLE
add meaning support to dotvote and score poll_types

### DIFF
--- a/app/models/poll.rb
+++ b/app/models/poll.rb
@@ -221,7 +221,7 @@ class Poll < ApplicationRecord
     when 'ranked_choice'
       %w[chart name rank score_percent score average]
     when 'dot_vote'
-      %w[chart name score_percent score average voter_count voters]
+      %w[chart name score_percent score average voter_count]
     when 'score'
       %w[chart name score average voter_count]
     when 'poll'

--- a/config/poll_types.yml
+++ b/config/poll_types.yml
@@ -203,7 +203,7 @@ dot_vote:
   validate_min_score: true
   validate_dots_per_person: true
   order_results_by: total_score_desc
-  options_have_meaning: false
+  options_have_meaning: true
   defaults:
     poll_option_name_format: plain
     process_name_i18n: decision_tools_card.dot_vote_title
@@ -222,7 +222,7 @@ score:
   validate_min_score: true
   validate_max_score: true
   order_results_by: total_score_desc
-  options_have_meaning: false
+  options_have_meaning: true
   defaults:
     poll_option_name_format: plain
     process_name_i18n: decision_tools_card.score_title

--- a/vue/src/components/poll/common/chart/table.vue
+++ b/vue/src/components/poll/common/chart/table.vue
@@ -59,10 +59,10 @@ export default
             pie-icon.ma-2(:slices="slices", :size='128')
           td.pr-2.py-2(
             v-if="col == 'chart' && poll.chartType == 'bar'"
-            style="width: 128px; padding: 0 8px 0 0"
+            style="width: 128px; min-width: 128px; padding: 0 8px 0 0"
           )
             div.rounded(:style="{width: clampPercent(option[poll.chartColumn])+'%', height: '24px', 'background-color': option.color}")
-          td(v-if="col == 'name' ", :style="poll.chartType == 'pie' ? {'border-left': '4px solid ' + option.color} : {}")
+          td.table-expand(v-if="col == 'name' ", :style="poll.chartType == 'pie' ? {'border-left': '4px solid ' + option.color} : {}")
             span(v-if="option.name_format == 'plain'") {{option.name}}
             span(v-if="option.name_format == 'i18n'" v-t="option.name")
             // poll-meeting-time(:name='option.name')
@@ -79,6 +79,9 @@ export default
               user-avatar.float-left(v-for="id in option.voter_ids", :key="id", :user="users[id]", :size="24" no-link)
 </template>
 <style lang="sass">
+.table-expand
+  width: 90%
+
 .v-data-table > .v-data-table__wrapper > table > tbody > tr:hover:not(.v-data-table__expanded__content):not(.v-data-table__empty-wrapper)
   background: none !important
   

--- a/vue/src/components/poll/common/poll_option_form.vue
+++ b/vue/src/components/poll/common/poll_option_form.vue
@@ -15,7 +15,7 @@ export default
       {text: 'Thumbs down', value: 'disagree'},
       {text: 'Thumbs sideways', value: 'abstain'},
       {text: 'Hand up', value: 'block'}
-    ]
+    ],
 
   computed:
     hasOptionIcon: -> @poll.config().has_option_icon
@@ -35,9 +35,15 @@ v-card.poll-common-option-form
     v-spacer
     dismiss-modal-button
   v-card-text
-    v-text-field(:label="$t('poll_option_form.option_name')" v-model="clone.name", :hint="$t('poll_option_form.option_name_hint')")
-    v-select(v-if="hasOptionIcon", :label="$t('poll_option_form.icon')" v-model="clone.icon", :items="icons")
     v-text-field(
+      :label="$t('poll_option_form.option_name')"
+      v-model="clone.name"
+      :hint="$t('poll_option_form.option_name_hint')"
+      :rules="nameRules"
+      counter="85"
+    )
+    v-select(v-if="hasOptionIcon", :label="$t('poll_option_form.icon')" v-model="clone.icon", :items="icons")
+    v-textarea(
       v-if="hasOptionMeaning"
       :label="$t('poll_option_form.meaning')"
       :hint="$t('poll_option_form.meaning_hint')"

--- a/vue/src/components/poll/dot_vote/vote_form.vue
+++ b/vue/src/components/poll/dot_vote/vote_form.vue
@@ -74,34 +74,50 @@ export default
 </script>
 
 <template lang="pug">
-.poll-dot-vote-vote-form
-  v-alert.poll-dot-vote-vote-form__dots-remaining(dense :color="alertColor" v-t="{ path: 'poll_dot_vote_vote_form.dots_remaining', args: { count: dotsRemaining } }")
-  .poll-dot-vote-vote-form__options
-    .poll-dot-vote-vote-form__option(v-for='choice in stanceChoices', :key='choice.option.id')
-      v-subheader.poll-dot-vote-vote-form__option-label {{ choice.option.name }}
-      v-layout(row align-center)
-        v-slider.poll-dot-vote-vote-form__slider.mr-4(
-          :disabled="!poll.isVotable()"
-          v-model='choice.score'
-          :rules="rulesForChoice(choice)"
-          :color="choice.option.color"
-          :thumb-color="choice.option.color"
-          :track-color="choice.option.color"
-          :height="4"
-          :thumb-size="24"
-          :thumb-label="(choice.score > 0) ? 'always' : true"
-          :min="0"
-          :max="dotsPerPerson"
-          :readonly="false")
-    validation-errors(:subject='stance' field='stanceChoices')
-  poll-common-stance-reason(:stance='stance', :poll='poll')
-  v-card-actions.poll-common-form-actions
-    v-btn.poll-common-vote-form__submit(
-      block
-      @click="submit()"
-      :disabled="(dotsRemaining < 0) || !poll.isVotable()"
-      :loading="stance.processing"
-      color="primary"
-    )
-      span(v-t="stance.castAt? 'poll_common.update_vote' : 'poll_common.submit_vote'")
+div
+  v-form.poll-dot-vote-vote-form(ref="form")
+    v-banner.poll-dot-vote-vote-form__dots-remaining(sticky rounded dense :color="alertColor" )
+      span(v-t="{ path: 'poll_dot_vote_vote_form.dots_remaining', args: { count: dotsRemaining } }")
+    .poll-dot-vote-vote-form__options
+      v-list-item.poll-dot-vote-vote-form__option(v-for='choice in stanceChoices', :key='choice.option.id')
+        v-list-item-content
+          v-list-item-title {{ choice.option.name }}
+          v-list-item-subtitle(style="white-space: inherit") {{ choice.option.meaning }}
+          v-slider.poll-dot-vote-vote-form__slider.mt-4(
+            :disabled="!poll.isVotable()"
+            v-model='choice.score'
+            :color="choice.option.color"
+            track-color="grey"
+            :height="4"
+            :min="0"
+            :max="dotsPerPerson"
+            :readonly="false")
+        v-list-item-action(style="max-width: 128px")
+          v-text-field(
+            type="number"
+            max-width="20px"
+            filled
+            rounded
+            dense
+            v-model="choice.score"
+          )
+      validation-errors(:subject='stance' field='stanceChoices')
+    poll-common-stance-reason(:stance='stance', :poll='poll')
+    v-card-actions.poll-common-form-actions
+      v-btn.poll-common-vote-form__submit(
+        block
+        @click="submit()"
+        :disabled="(dotsRemaining < 0) || !poll.isVotable()"
+        :loading="stance.processing"
+        color="primary"
+      )
+        span(v-t="stance.castAt? 'poll_common.update_vote' : 'poll_common.submit_vote'")
 </template>
+
+<style lang="css">
+.poll-dot-vote-vote-form__option-label {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+</style>

--- a/vue/src/components/poll/score/vote_form.vue
+++ b/vue/src/components/poll/score/vote_form.vue
@@ -40,20 +40,28 @@ export default
 <template lang='pug'>
 form.poll-score-vote-form(@submit.prevent='submit()')
   .poll-score-vote-form__options
-    .poll-score-vote-form__option(v-for='choice in stanceChoices', :key='choice.option.id')
-      v-subheader.poll-score-vote-form__option-label {{ choice.option.name }}
-      v-slider.poll-score-vote-form__score-slider(
-        :disabled="!poll.isVotable()"
-        v-model='choice.score'
-        :color="choice.option.color"
-        :thumb-color="choice.option.color"
-        :track-color="choice.option.color"
-        :height="4"
-        :thumb-size="24"
-        :thumb-label="(choice.score > 0) ? 'always' : true"
-        :min="poll.minScore"
-        :max="poll.maxScore"
-      )
+    v-list-item.poll-dot-vote-vote-form__option(v-for='choice in stanceChoices', :key='choice.option.id')
+      v-list-item-content
+        v-list-item-title {{ choice.option.name }}
+        v-list-item-subtitle(style="white-space: inherit") {{ choice.option.meaning }}
+        v-slider.poll-score-vote-form__score-slider.mt-4(
+          :disabled="!poll.isVotable()"
+          v-model='choice.score'
+          :color="choice.option.color"
+          :height="4"
+          :min="poll.minScore"
+          :max="poll.maxScore"
+        )
+      v-list-item-action(style="max-width: 128px")
+        v-text-field.text-right(
+          type="number"
+          max-width="20px"
+          filled
+          rounded
+          dense
+          v-model="choice.score"
+        )
+
   validation-errors(:subject='stance', field='stanceChoices')
   poll-common-stance-reason(:stance='stance', :poll='poll')
   v-card-actions.poll-common-form-actions


### PR DESCRIPTION
- enabled the "meaning" field on dot vote and score poll options.
- added a character counter to help indicate the appropriate length for a poll option name
- updated the vote forms, so that it shows the meaning text while you're voting
- added a number input to the right, and taken the floating number off the slider
- fixed the dot_vote validation messages "you've used too many dots"

