### PR TITLE
generic oauth provider

### DIFF
--- a/app/controllers/identities/oauth_controller.rb
+++ b/app/controllers/identities/oauth_controller.rb
@@ -1,0 +1,16 @@
+class Identities::OauthController < Identities::BaseController
+
+  private
+
+  def oauth_url
+    "#{oauth_auth_url}?#{oauth_params.to_query}"
+  end
+
+  def oauth_auth_url
+    ENV.fetch('OAUTH_AUTH_URL')
+  end
+
+  def oauth_params
+    { client.client_key_name => client.key, redirect_uri: redirect_uri, scope: ENV.fetch('OAUTH_SCOPE'),  response_type: :code }
+  end
+end

--- a/app/extras/clients/oauth.rb
+++ b/app/extras/clients/oauth.rb
@@ -1,0 +1,44 @@
+class Clients::Oauth < Clients::Base
+
+  def fetch_access_token(code, uri)
+    post ENV.fetch('OAUTH_TOKEN_URL'), params: { code: code, redirect_uri: uri, grant_type: :authorization_code }
+  end
+
+  def fetch_user_info
+    get ENV.fetch('OAUTH_PROFILE_URL')
+  end
+
+  private
+  def perform(method, url, params, headers, options)
+    options.reverse_merge!(
+      success:    default_success,
+      failure:    default_failure,
+      is_success: default_is_success
+    )
+    Clients::Request.new(method, url, {
+      options[:params_field] => params_for(params),
+      :"headers"             => headers_for(headers)
+    }).tap { |request| request.perform!(options) }
+  end
+
+
+  def default_params
+    { client_id: @key, client_secret: @secret }.delete_if { |k,v| v.nil? }
+  end
+
+  def authorization_headers
+    { 'Authorization' => "Bearer #{@token}" }
+  end
+
+  def common_headers
+    { 'Content-Type' => 'application/x-www-form-urlencoded; charset=UTF-8' }
+  end
+
+  def default_headers
+    if @token
+      common_headers.merge(authorization_headers)
+    else
+      common_headers
+    end
+  end
+end

--- a/app/models/identities/oauth.rb
+++ b/app/models/identities/oauth.rb
@@ -1,0 +1,12 @@
+class Identities::Oauth < Identities::Base
+  include Identities::WithClient
+  set_identity_type :oauth
+
+  def apply_user_info(payload)
+    # need to make this dynamic based on ENVs with some defaults
+    payload = payload['ocs']['data']
+    self.uid    ||= payload['id']
+    self.name   ||= payload['id']
+    self.email  ||= payload['email']
+  end
+end

--- a/app/models/identities/oauth.rb
+++ b/app/models/identities/oauth.rb
@@ -3,10 +3,8 @@ class Identities::Oauth < Identities::Base
   set_identity_type :oauth
 
   def apply_user_info(payload)
-    # need to make this dynamic based on ENVs with some defaults
-    payload = payload['ocs']['data']
-    self.uid    ||= payload['id']
-    self.name   ||= payload['id']
-    self.email  ||= payload['email']
+    self.uid    ||= payload.dig(ENV.fetch('OAUTH_ATTR_UID'))
+    self.name   ||= payload.dig(ENV.fetch('OAUTH_ATTR_NAME'))
+    self.email  ||= payload.dig(ENV.fetch('OAUTH_ATTR_EMAIL'))
   end
 end

--- a/config/providers.yml
+++ b/config/providers.yml
@@ -6,8 +6,4 @@ identity:
   - microsoft
   - saml
   - nextcloud
-
-# for providers which provide additional API access
-community:
-  - facebook
-  - slack
+  - oauth

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -380,19 +380,6 @@ Rails.application.routes.draw do
     end
   end
 
-  # scope :facebook do
-  #   get :webhook,                         to: 'identities/facebook#verify',   as: :facebook_verify
-  #   post :webhook,                        to: 'identities/facebook#webhook',  as: :facebook_webhook
-  #   get :webview,                         to: 'identities/facebook#webview',  as: :facebook_webview
-  # end
-
-  # scope :slack do
-  #   get  :install,                        to: 'identities/slack#install',     as: :slack_install
-  #   get  :authorized,                     to: 'identities/slack#authorized',  as: :slack_authorized
-  #   post :participate,                    to: 'identities/slack#participate', as: :slack_participate
-  #   post :initiate,                       to: 'identities/slack#initiate',    as: :slack_initiate
-  # end
-
   scope :saml do
     post :oauth,                          to: 'identities/saml#create',   as: :saml_oauth_callback
     get :metadata,                        to: 'identities/saml#metadata', as: :saml_metadata


### PR DESCRIPTION
all the oauth providers have hard coded specifics, this one should be fully configurable via ENV's
So far here are the ENV's with example data

OAUTH envs with examples
OAUTH_AUTH_URL=https://login.microsoftonline.com/token/oauth2/v2.0/authorize
OAUTH_TOKEN_URL=https://login.microsoftonline.com/token/oauth2/v2.0/token    
OAUTH_PROFILE_URL=https://graph.microsoft.com/v1.0/me 
OAUTH_SCOPE=https://graph.microsoft.com/.default
OAUTH_APP_KEY=clientid
OAUTH_APP_SECRET=secret key
OAUTH_ATTR_UID=id
OAUTH_ATTR_NAME=displayName
OAUTH_ATTR_EMAIL=mail