### PR TITLE
Fixed forever loading in the Invite-only threads page

### DIFF
--- a/vue/src/components/threads/page.vue
+++ b/vue/src/components/threads/page.vue
@@ -10,7 +10,7 @@ import { subDays, addDays, subWeeks, subMonths } from 'date-fns'
 
 export default
   data: ->
-    threads: []
+    threads: null
     loader: null
 
   created: ->
@@ -55,10 +55,10 @@ v-main
     v-layout.mb-3
       //- v-text-field(clearable solo hide-details :value="$route.query.q" @input="onQueryInput" :placeholder="$t('navbar.search_all_threads')" append-icon="mdi-magnify")
 
-    v-card.mb-3.dashboard-page__loading(v-if='!threads.length' aria-hidden='true')
+    v-card.mb-3.dashboard-page__loading(v-if='!threads' aria-hidden='true')
       v-list(two-line)
         loading-content(:lineCount='2' v-for='(item, index) in [1,2,3]' :key='index' )
-    div(v-if="threads.length")
+    div(v-if="threads")
       section.threads-page__loaded
         .threads-page__empty(v-if='threads.length == 0')
           p(v-t="'threads_page.no_invite_only_threads'")


### PR DESCRIPTION
I just deployed a staging version of loomio for our org and I noticed that the invite-only threads page is slightly broken:

If the backend responds with an empty list the page just stays there loading forever.

Please try if this PR actually works I don't know much vue, and I couldn't check if this actually works.