### PR TITLE
Mark notifications as read when the user replies to a comment, and wh…

### DIFF
--- a/app/models/events/new_comment.rb
+++ b/app/models/events/new_comment.rb
@@ -5,6 +5,10 @@ class Events::NewComment < Event
   include Events::LiveUpdate
 
   def self.publish!(comment)
+    if comment.parent.present?
+      NotificationService.delay.mark_as_read(comment.parent_type, comment.parent_id, comment.author_id)
+    end
+
     super comment,
           user: comment.author,
           discussion: comment.discussion,

--- a/app/models/events/stance_created.rb
+++ b/app/models/events/stance_created.rb
@@ -6,6 +6,8 @@ class Events::StanceCreated < Event
   include Events::Notify::Chatbots
 
   def self.publish!(stance)
+    NotificationService.delay.mark_as_read("Poll", stance.poll_id, stance.participant_id)
+
     super stance,
           user: stance.participant.presence,
           discussion: stance.add_to_discussion? ? stance.poll.discussion : nil

--- a/app/services/notification_service.rb
+++ b/app/services/notification_service.rb
@@ -1,12 +1,43 @@
 class NotificationService
-  def self.viewed_events(actor_id:, discussion_id: , sequence_ids: )
-    events = Event.includes(:eventable).where(discussion_id: discussion_id, sequence_id: sequence_ids)
-    reactions = Reaction.where(reactable: events.map(&:eventable))
+  def self.mark_as_read(eventable_type, eventable_id, actor_id)
+    ids = Notification.joins(:event)
+      .where(user_id: actor_id, viewed: false)
+      .where('events.eventable_type': eventable_type, 'events.eventable_id': eventable_id).pluck(:id)
 
-    event_ids = events.pluck(:id).concat Event.where(eventable: reactions).pluck(:id)
+    notifications = Notification.where(user_id: actor_id, id: ids, 'viewed': false)
+    notifications.update_all(viewed: true)
+    notifications.reload
+    MessageChannelService.publish_models(notifications, user_id: actor_id)
+  end
+
+  def self.viewed_events(actor_id:, discussion_id: , sequence_ids: )
+    event_ids = []
+
+    events = Event.includes(:eventable).where(discussion_id: discussion_id, sequence_id: sequence_ids)
+
+    reactions = Reaction.where(reactable: events.map(&:eventable))
+    event_ids.concat Event.where(eventable: reactions).pluck(:id)
+
+    eventable_ids = {}
+
+    %w[Comment Discussion Poll Stance Outcome].each do |type|
+      eventable_ids[type] = Event.where(
+        discussion_id: discussion_id,
+        sequence_id: sequence_ids,
+        eventable_type: type).pluck(:eventable_id) 
+    end
+
+    
+    eventable_ids.each_pair do |type, ids|
+      event_ids.concat Notification.joins(:event).where(
+        user_id: actor_id,
+        viewed: false,
+        'events.eventable_type': type,
+        'events.eventable_id': ids).pluck('events.id')
+    end
 
     notifications = Notification.where(user_id: actor_id).
-      where(event_id: event_ids).
+      where(event_id: event_ids.uniq).
       where('viewed': false)
     notifications.update_all(viewed: true)
     notifications.reload

--- a/spec/services/comment_service_spec.rb
+++ b/spec/services/comment_service_spec.rb
@@ -82,6 +82,38 @@ describe 'CommentService' do
         expect { CommentService.create(comment: comment, actor: user) }.to change { Event.where(kind: 'user_mentioned').count }
         expect(comment.mentioned_users).to include comment.parent.author
       end
+
+      it "marks notification as read on reply" do
+        notifications = Notification.joins(:event).where('events.kind': 'user_mentioned', viewed: false, user_id: user)
+        expect(notifications.count).to eq 0
+
+        comment = create(:comment,
+           author: another_user,
+           discussion: discussion,
+           body: "hi @#{user.username}",
+           body_format: "md")
+
+        CommentService.create(comment: comment, actor: another_user)
+
+        expect(notifications.count).to eq 1
+
+        reply_comment = create(:comment,
+           parent: comment,
+           author: user,
+           discussion: discussion,
+           body: "gidday",
+           body_format: "md")
+
+        CommentService.create(comment: reply_comment, actor: user)
+
+        expect(notifications.count).to eq 0
+
+        # reply_comment = 
+        # comment.body = "A mention for @#{another_user.username}!"
+
+        # expect { CommentService.create(comment: comment, actor: user) }.to change { Event.where(kind: 'user_mentioned').count }
+        # expect(comment.mentioned_users).to include comment.parent.author
+      end
     end
 
     context 'comment is invalid' do


### PR DESCRIPTION
…en someone views a model that has notifications waiting for them