### PR TITLE
If a user changes their position, we create a new stance record

### DIFF
--- a/app/controllers/api/v1/stances_controller.rb
+++ b/app/controllers/api/v1/stances_controller.rb
@@ -10,8 +10,9 @@ class API::V1::StancesController < API::V1::RestfulController
   end
 
   def uncast
-    @stance = current_user.stances.find(params[:id])
+    @stance = current_user.stances.latest.find(params[:id])
     StanceService.uncast(stance: @stance, actor: current_user)
+    @stance = @stance.poll.stances.latest.find_by(participant_id: current_user.id)
     respond_with_resource
   end
 

--- a/spec/controllers/api/v1/stances_controller_spec.rb
+++ b/spec/controllers/api/v1/stances_controller_spec.rb
@@ -170,10 +170,11 @@ describe API::V1::StancesController do
       end
 
       it 'sets cast_at to nil' do
-        stance = poll.stances.where(participant_id: voter.id).last
+        stance = poll.stances.latest.find_by(participant_id: voter.id)
         put :uncast, params: {id: stance.id}
         expect(response.status).to eq 200
-        expect(stance.reload.cast_at).to eq nil
+        stance = poll.stances.latest.find_by(participant_id: voter.id)
+        expect(stance.cast_at).to eq nil
       end
     end
 


### PR DESCRIPTION
If a user changes their position, we create a new stance record, so that replies to the existing stance still make sense, and new discussion can happen branching from the new stance