### PR TITLE
Copy template title to poll title as well

### DIFF
--- a/vue/src/shared/models/poll_template_model.coffee
+++ b/vue/src/shared/models/poll_template_model.coffee
@@ -63,7 +63,7 @@ export default class PollTemplateModel extends BaseModel
         poll['titlePlaceholder'] = @[attr]
       else
         poll[attr] = @[attr]
-      
+
 
     poll.pollTemplateId = @id
     poll.pollTemplateKey = @key

--- a/vue/src/shared/models/poll_template_model.coffee
+++ b/vue/src/shared/models/poll_template_model.coffee
@@ -61,6 +61,7 @@ export default class PollTemplateModel extends BaseModel
     Object.keys(@defaultValues()).forEach (attr) =>
       if attr == 'title'
         poll['titlePlaceholder'] = @[attr]
+        poll['title'] = @[attr]
       else
         poll[attr] = @[attr]
 


### PR DESCRIPTION
When using a template, the expected behavior is that it will prefill
the template values to the poll so it saves time when creating
similar proposals. Having the value only in the placeholder is not
as useful as copying the value to the title since the user would
need to manually type the whole title every time they use the template.

This is a regression from the previous behavior, so this patch
makes it behave as before.