### PR TITLE
Wrap txt and remove text-truncate from poll option

### DIFF
--- a/vue/src/components/poll/common/stance_choice.vue
+++ b/vue/src/components/poll/common/stance_choice.vue
@@ -41,7 +41,7 @@ export default
 </script>
 
 <template lang="pug">
-span.poll-common-stance-choice.text-truncate(:class="'poll-common-stance-choice--' + pollType" row)
+span.poll-common-stance-choice(:class="'poll-common-stance-choice--' + pollType" row)
   v-avatar(tile :size="size" v-if='poll.config().has_option_icon')
     img(:src="'/img/' + pollOption.icon + '.svg'", :alt='optionName')
   v-chip(v-if='poll.pollOptionNameFormat == "iso8601"'

--- a/vue/src/components/poll/common/stance_choices.vue
+++ b/vue/src/components/poll/common/stance_choices.vue
@@ -28,7 +28,7 @@ export default
   span.caption(v-if='stance.castAt && stance.totalScore() == 0' v-t="'poll_common_votes_panel.none_of_the_above'" )
   template(v-else)
     template(v-if="!datesAsOptions")
-      .poll-common-stance-choice.text-truncate(
+      .poll-common-stance-choice(
         v-for="choice in choices"
         v-if="choice.score > 0 || pollType == 'score'"
         :key="choice.id"

--- a/vue/src/components/poll/common/vote_form.vue
+++ b/vue/src/components/poll/common/vote_form.vue
@@ -130,7 +130,7 @@ form.poll-common-vote-form(@keyup.ctrl.enter="submit()", @keydown.meta.enter.sto
             v-icon(v-if="!singleChoice && !isSelected(option)", :color="option.color") mdi-checkbox-blank-outline
             v-icon(v-if="!singleChoice && isSelected(option)", :color="option.color") mdi-checkbox-marked
         v-list-item-content
-          v-list-item-title.poll-common-vote-form__button-text {{option.optionName()}}
+          v-list-item-title.poll-common-vote-form__button-text(style="white-space: normal") {{option.optionName()}}
           v-list-item-subtitle.poll-common-vote-form__allow-wrap {{option.meaning}}
 
   poll-common-stance-reason(


### PR DESCRIPTION
The layout completely breaks for polls that have options with long text.

Without the patch, the vote reason overflows and can't be read entirely.

![Screenshot from 2023-08-30 11-55-24](https://github.com/loomio/loomio/assets/333447/f4479f8d-69db-4511-ad7f-2fdbefd329cc)

With the patch the text wraps correctly:

![Screenshot from 2023-08-30 12-16-59](https://github.com/loomio/loomio/assets/333447/373f0740-d56d-4e8f-a2b2-80df70e0e458)

This patch also displays the full option before the user can vote, so the user can read the whole text:

![Screenshot from 2023-08-30 12-16-47](https://github.com/loomio/loomio/assets/333447/c24368dd-c253-49da-99e6-6be1b4966da5)

Without the patch, the option that overflows will be hidden and the user only see one part of the option:

![Screenshot from 2023-08-30 11-56-35](https://github.com/loomio/loomio/assets/333447/4a55d70d-5872-43e7-bdc6-339e25ec0255)
