### PR TITLE
Change 'add option' ui from a name field, to a button that opens the poll_option_form

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1764,11 +1764,12 @@ en:
     edit_option: Edit option
     option_name: Option name
     option_name_hint: A short name for this option
+    option_name_validation: It's best to keep the name short and put detail in the 'Meaning' field
     icon: Icon
     meaning: Meaning
-    meaning_hint: A sentence that explains what choosing this option means
+    meaning_hint: A sentence or two explaining what choosing this option means. Optional
     prompt: Reason prompt
-    prompt_hint: A question to prompt voters to provide their reasoning or reconsider their position.
+    prompt_hint: A question to prompt voters to share their reasoning or reconsider their position. Optional
 
   poll_common:
     superseded: Superseded

--- a/vue/src/components/poll/common/form.vue
+++ b/vue/src/components/poll/common/form.vue
@@ -1,7 +1,7 @@
 <script lang="coffee">
 import AppConfig from '@/shared/services/app_config'
 import Session from '@/shared/services/session'
-import { compact, without, kebabCase, snakeCase, some } from 'lodash'
+import { compact, without, some, pick } from 'lodash'
 import Flash from '@/shared/services/flash'
 import Records from '@/shared/services/records'
 import EventBus from '@/shared/services/event_bus'
@@ -65,6 +65,7 @@ export default
       {text: 'pie', value: 'pie'}
       {text: 'grid', value: 'grid'}
     ]
+
     currentHideResults: @poll.hideResults
     hideResultsItems: [
       { text: @$t('common.off'), value: 'off' }
@@ -97,41 +98,41 @@ export default
         @pollOptions = without(@pollOptions, option)
 
     addDateOption: ->
-      @newOption = @newDateOption.toJSON()
-      @addOption()
-
-    addOption: ->
-      if some(@pollOptions, (o) => o.name.toLowerCase() == @newOption.toLowerCase())
+      optionName = @newDateOption.toJSON()
+      if some(@pollOptions, (o) => o.name == optionName)
         Flash.error('poll_poll_form.option_already_added')
       else
-        knownOption = @knownOptions.find (o) =>
-          @$t(o.name_i18n).toLowerCase() == @newOption.toLowerCase()
+        @pollOptions.push({name: optionName})
 
-        if knownOption
-          @pollOptions.push
-            name: @newOption
-            icon:  knownOption.icon
-            meaning: @$t(knownOption.meaning_i18n)
-            prompt: @$t(knownOption.prompt_i18n)
-        else
-          option = 
-            name: @newOption
-            meaning: ''
-            prompt: ''
-            icon: 'agree'
-          @pollOptions.push option
-          if @poll.pollType == 'proposal'
-            Flash.success('poll_common_form.option_added_please_add_details')
-            @editOption(option)
+    addOption: ->
+      option = 
+        name: ''
+        meaning: ''
+        prompt: ''
+        icon: ''
 
-        @newOption = null
-
-    editOption: (option) ->
       EventBus.$emit 'openModal',
         component: 'PollOptionForm'
         props:
           pollOption: option
           poll: @poll
+          submitFn: (option) =>
+            if some(@pollOptions, (o) => o.name.toLowerCase() == option.name.toLowerCase())
+              Flash.error('poll_poll_form.option_already_added')
+            else
+              @pollOptions.push option
+
+    editOption: (option) ->
+      clone = pick(option, 'name', 'icon', 'meaning', 'prompt')
+
+      EventBus.$emit 'openModal',
+        component: 'PollOptionForm'
+        props:
+          edit: true
+          pollOption: clone
+          poll: @poll
+          submitFn: (clone) =>
+            Object.assign(option, clone)
 
     submit: ->
       actionName = if @poll.isNew() then 'created' else 'updated'
@@ -286,32 +287,11 @@ export default
             v-icon.text--secondary(v-handle, :title="$t('common.action.move')" v-if="poll.pollType != 'meeting'") mdi-drag-vertical
 
     template(v-if="optionFormat == 'i18n'")
-      v-select(
-        outlined
-        v-model="newOption"
-        :items="i18nItems" 
-        :label="$t('poll_poll_form.add_option_placeholder')"
-        @change="addOption")
+      p This poll cannot have new options added. (contact support if you see this message)
 
     template(v-if="optionFormat == 'plain'")
-      v-text-field.poll-poll-form__add-option-input.mt-4(
-        v-model="newOption"
-        :label="$t('poll_poll_form.new_option')"
-        :placeholder="$t('poll_poll_form.add_option_hint')"
-        @keydown.enter="addOption"
-        filled
-        rounded
-        color="primary"
-      )
-        template(v-slot:append)
-          v-btn.mt-n2(
-            @click="addOption"
-            icon
-            :disabled="!newOption"
-            color="primary"
-            outlined
-            :title="$t('poll_poll_form.add_option_placeholder')")
-            v-icon mdi-plus
+      .d-flex.justify-center
+        v-btn.my-2(@click="addOption" v-t="'poll_common_add_option.modal.title'")
 
     template(v-if="optionFormat == 'iso8601'")
       .v-label.v-label--active.px-0.text-caption.pt-2(v-t="'poll_poll_form.new_option'")
@@ -323,7 +303,7 @@ export default
           @click='addDateOption()'
           v-t="'poll_poll_form.add_option_placeholder'"
         )
-      poll-meeting-add-option-menu(:poll="poll", :value="newDateOption")
+      poll-meeting-add-option-menu(:poll="poll" :value="newDateOption")
 
   template(v-if="optionFormat == 'iso8601'")
     .d-flex.align-center
@@ -418,9 +398,8 @@ export default
     v-if="poll.specifiedVotersOnly"
     v-t="$t('poll_common_settings.invite_people_next', {poll_type: poll.translatedPollType()})")
 
-
-  .d-flex.align-center
-    v-btn.center.mb-2.mt-4.mx-auto.text-center.poll-common-form__advanced-btn(@click="showAdvanced = !showAdvanced")
+  .d-flex.justify-center
+    v-btn.my-4.poll-common-form__advanced-btn(@click="showAdvanced = !showAdvanced")
       span(v-if='showAdvanced' v-t="'poll_common_form.hide_advanced_settings'")
       span(v-else v-t="'poll_common_form.show_advanced_settings'")
 

--- a/vue/src/components/poll/common/form.vue
+++ b/vue/src/components/poll/common/form.vue
@@ -109,7 +109,7 @@ export default
         name: ''
         meaning: ''
         prompt: ''
-        icon: ''
+        icon: 'agree'
 
       EventBus.$emit 'openModal',
         component: 'PollOptionForm'
@@ -291,7 +291,7 @@ export default
 
     template(v-if="optionFormat == 'plain'")
       .d-flex.justify-center
-        v-btn.my-2(@click="addOption" v-t="'poll_common_add_option.modal.title'")
+        v-btn.poll-common-form__add-option-btn.my-2(@click="addOption" v-t="'poll_common_add_option.modal.title'")
 
     template(v-if="optionFormat == 'iso8601'")
       .v-label.v-label--active.px-0.text-caption.pt-2(v-t="'poll_poll_form.new_option'")

--- a/vue/src/components/poll/common/poll_option_form.vue
+++ b/vue/src/components/poll/common/poll_option_form.vue
@@ -39,7 +39,7 @@ v-card.poll-common-option-form
     v-spacer
     dismiss-modal-button
   v-card-text
-    v-text-field(
+    v-text-field.poll-option-form__name(
       :label="$t('poll_option_form.option_name')"
       v-model="pollOption.name"
       :hint="$t('poll_option_form.option_name_hint')"
@@ -61,5 +61,5 @@ v-card.poll-common-option-form
       v-model="pollOption.prompt")
   v-card-actions
     v-spacer
-    v-btn(@click="submit" v-t="'common.action.done'") 
+    v-btn.poll-option-form__done-btn(@click="submit" v-t="'common.action.done'") 
 </template>

--- a/vue/src/components/poll/common/poll_option_form.vue
+++ b/vue/src/components/poll/common/poll_option_form.vue
@@ -2,14 +2,17 @@
 import Records from '@/shared/services/records'
 import EventBus from '@/shared/services/event_bus'
 import { pick } from 'lodash'
+import I18n from '@/i18n'
 
 export default
   props:
     pollOption: Object
     poll: Object
+    submitFn: Function
+    edit: Boolean
 
   data: ->
-    clone: pick(@pollOption, 'name', 'icon', 'meaning', 'prompt')
+    nameRules: [(v) => v.length <= 60 || I18n.t("poll_option_form.option_name_validation")],
     icons: [
       {text: 'Thumbs up', value: 'agree'},
       {text: 'Thumbs down', value: 'disagree'},
@@ -24,36 +27,38 @@ export default
 
   methods:
     submit: ->
-      Object.assign(@pollOption, @clone)
+      @submitFn(@pollOption)
       EventBus.$emit('closeModal')
 
 </script>
 <template lang="pug">
 v-card.poll-common-option-form
   v-card-title
-    h1.headline(v-t="$t('poll_option_form.edit_option')")
+    h1.headline(v-if="edit" v-t="$t('poll_option_form.edit_option')")
+    h1.headline(v-else v-t="$t('poll_poll_form.add_option_placeholder')")
     v-spacer
     dismiss-modal-button
   v-card-text
     v-text-field(
       :label="$t('poll_option_form.option_name')"
-      v-model="clone.name"
+      v-model="pollOption.name"
       :hint="$t('poll_option_form.option_name_hint')"
-      counter="85"
+      counter
+      :rules="nameRules"
     )
-    v-select(v-if="hasOptionIcon", :label="$t('poll_option_form.icon')" v-model="clone.icon", :items="icons")
+    v-select(v-if="hasOptionIcon", :label="$t('poll_option_form.icon')" v-model="pollOption.icon", :items="icons")
     v-textarea(
       v-if="hasOptionMeaning"
       :label="$t('poll_option_form.meaning')"
       :hint="$t('poll_option_form.meaning_hint')"
-      v-model="clone.meaning"
+      v-model="pollOption.meaning"
       counter="280")
     v-text-field(
       v-if="hasOptionPrompt"
       :label="$t('poll_option_form.prompt')"
       :hint="$t('poll_option_form.prompt_hint')"
       :placeholder="$t('poll_common.reason_placeholder')"
-      v-model="clone.prompt")
+      v-model="pollOption.prompt")
   v-card-actions
     v-spacer
     v-btn(@click="submit" v-t="'common.action.done'") 

--- a/vue/tests/e2e/specs/poll.js
+++ b/vue/tests/e2e/specs/poll.js
@@ -63,9 +63,15 @@ module.exports = {
     page.click('.decision-tools-card__poll-type--poll')
     page.fillIn('.poll-common-form-fields__title input', 'A new proposal')
     page.fillIn('.poll-common-form-fields__details .lmo-textarea div[contenteditable=true]', 'Some details')
-    page.click('.poll-poll-form__add-option-input')
-    page.fillInAndEnter('.poll-poll-form__add-option-input input', 'An option')
-    page.fillInAndEnter('.poll-poll-form__add-option-input input', 'Another option')
+
+    page.click('.poll-common-form__add-option-btn')
+    page.fillIn('.poll-option-form__name input', 'An option')
+    page.click('.poll-option-form__done-btn')
+
+    page.click('.poll-common-form__add-option-btn')
+    page.fillIn('.poll-option-form__name input', 'Another option')
+    page.click('.poll-option-form__done-btn')
+
     page.click('.poll-common-form__submit')
     page.expectElement('.poll-members-form__submit')
     page.pause(500)
@@ -92,8 +98,11 @@ module.exports = {
     page.click('.decision-tools-card__poll-type--dot_vote')
     page.fillIn('.poll-common-form-fields__title input', 'A new proposal')
     page.fillIn('.poll-common-form-fields__details .lmo-textarea div[contenteditable=true]', 'Some details')
-    page.click('.poll-poll-form__add-option-input')
-    page.fillInAndEnter('.poll-poll-form__add-option-input input', 'An option')
+
+    page.click('.poll-common-form__add-option-btn')
+    page.fillIn('.poll-option-form__name input', 'An option')
+    page.click('.poll-option-form__done-btn')
+
     page.click('.poll-common-form__submit')
     page.expectElement('.poll-members-form__submit')
     page.pause(500)
@@ -122,8 +131,10 @@ module.exports = {
     // page.click(".poll-common-tool-tip__collapse")
     page.fillIn('.poll-common-form-fields__title input', 'A new proposal')
     page.fillIn('.poll-common-form-fields__details .lmo-textarea div[contenteditable=true]', 'Some details')
-    page.click('.poll-poll-form__add-option-input')
-    page.fillInAndEnter('.poll-poll-form__add-option-input input', 'An option')
+
+    page.click('.poll-common-form__add-option-btn')
+    page.fillIn('.poll-option-form__name input', 'An option')
+    page.click('.poll-option-form__done-btn')
 
     page.click('.poll-common-form__submit')
     page.expectElement('.poll-members-form__submit')
@@ -184,9 +195,14 @@ module.exports = {
     page.fillIn('.poll-common-form-fields__title input', 'A new proposal')
     page.fillIn('.poll-common-form-fields__details .lmo-textarea div[contenteditable=true]', 'Some details')
 
-    page.click('.poll-poll-form__add-option-input')
-    page.fillInAndEnter('.poll-poll-form__add-option-input input', 'An option')
-    page.fillInAndEnter('.poll-poll-form__add-option-input input', 'Another option')
+    page.click('.poll-common-form__add-option-btn')
+    page.fillIn('.poll-option-form__name input', 'An option')
+    page.click('.poll-option-form__done-btn')
+
+    page.click('.poll-common-form__add-option-btn')
+    page.fillIn('.poll-option-form__name input', 'Another option')
+    page.click('.poll-option-form__done-btn')
+    
     page.click('.poll-common-form__submit')
 
     page.expectElement('.poll-members-form__submit')


### PR DESCRIPTION
This is because many people did not realise there was an option 'meaning' which handles long information much better than option name.

This way, we can reference detailed options by name, and only show detail when user is voting.

Very long names are really hard to work with throughout the UI - so we must encourage use of the meaning field