### PR TITLE
Invite people as admins to invite-only threads

### DIFF
--- a/app/models/ability/discussion.rb
+++ b/app/models/ability/discussion.rb
@@ -50,7 +50,7 @@ module Ability::Discussion
         discussion.group.admins.exists?(user.id) ||
         (discussion.group.members_can_add_guests && discussion.members.exists?(user.id))
       else
-        !discussion.id || discussion.members.exists?(user.id)
+        !discussion.id || discussion.admins.exists?(user.id)
       end
     end
 

--- a/app/services/discussion_service.rb
+++ b/app/services/discussion_service.rb
@@ -245,6 +245,7 @@ class DiscussionService
       DiscussionReader.new(user: user,
                            discussion: discussion,
                            inviter: if volumes[user.id] then nil else actor end,
+                           admin: !discussion.group_id,
                            volume: volumes[user.id] || DiscussionReader.volumes[:normal])
     end
 

--- a/vue/src/components/strand/members_list.vue
+++ b/vue/src/components/strand/members_list.vue
@@ -138,7 +138,13 @@ export default
       @new-query="newQuery"
       @new-recipients="newRecipients")
 
-    v-textarea(v-if="hasRecipients" rows="3" v-model="message" :label="$t('announcement.form.invitation_message_label')" :placeholder="$t('announcement.form.invitation_message_placeholder')")
+    v-textarea(
+      v-if="hasRecipients"
+      rows="3"
+      v-model="message"
+      :label="$t('announcement.form.invitation_message_label')"
+      :placeholder="$t('announcement.form.invitation_message_placeholder')"
+    )
 
     .d-flex
       v-spacer

--- a/vue/src/components/strand/members_list.vue
+++ b/vue/src/components/strand/members_list.vue
@@ -48,7 +48,9 @@ export default
 
   methods:
     isGroupAdmin: (reader) ->
-      @membershipsByUserId[reader.userId] && @membershipsByUserId[reader.userId].admin
+      @discussion.groupId && 
+      @membershipsByUserId[reader.userId] &&
+      @membershipsByUserId[reader.userId].admin
 
     isGuest: (reader) ->
       !@membershipsByUserId[reader.userId]

--- a/vue/src/shared/services/ability_service.coffee
+++ b/vue/src/shared/services/ability_service.coffee
@@ -114,7 +114,7 @@ export default new class AbilityService
       discussion.group().adminsInclude(Session.user()) ||
       (discussion.group().membersCanAddGuests && discussion.group().membersInclude(Session.user()))
     else
-      !discussion.id || discussion.membersInclude(Session.user())
+      !discussion.id || discussion.adminsInclude(Session.user())
 
   canAnnouncePoll: (poll) ->
     user = Session.user()


### PR DESCRIPTION
This reverts the change that gives members more permissions in an invite only thread.

This way, we preserve the ability to control the level of access in an invite only thread, but default to permissive. It also maintains continuity with admin/members throughout the app.