### PR TITLE
Allow admins to manage memberships of any group

### DIFF
--- a/app/controllers/api/b2/memberships_controller.rb
+++ b/app/controllers/api/b2/memberships_controller.rb
@@ -43,8 +43,12 @@ class API::B2::MembershipsController < API::B2::BaseController
   end
 
   def group
-    group = current_user.adminable_groups.find_by(id: params[:group_id])
-    raise CanCan::AccessDenied unless group
+    group = Group.find(params[:group_id])
+    raise ActiveRecord::RecordNotFound, "Group not found" unless group
+
+    unless current_user.is_admin? || current_user.adminable_groups.include?(group)
+      raise CanCan::AccessDenied, "User is not an admin"
+    end
     group
   end
 

--- a/app/models/ability/group.rb
+++ b/app/models/ability/group.rb
@@ -51,10 +51,13 @@ module Ability::Group
          :invite_people,
          :announce,
          :manage_membership_requests], ::Group do |group|
-      Subscription.for(group).is_active? && 
-      !group.has_max_members &&
+      user.is_admin ||
       (
-        ((group.members_can_add_members? && group.members.exists?(user.id)) || group.admins.exists?(user.id))
+        Subscription.for(group).is_active? &&
+        !group.has_max_members &&
+        (
+          ((group.members_can_add_members? && group.members.exists?(user.id)) || group.admins.exists?(user.id))
+        )
       )
     end
 

--- a/spec/controllers/api/b2/memberships_controller_spec.rb
+++ b/spec/controllers/api/b2/memberships_controller_spec.rb
@@ -76,5 +76,30 @@ describe API::B2::MembershipsController do
       }
       expect(response.status).to eq 403
     end
+
+    it 'user is global admin and not in the group' do
+      new_admin = create(:user)
+      new_admin.update(is_admin: true)
+      post :create, params: {
+        group_id: group.id,
+        emails: ['hi@there.com'],
+        api_key: new_admin.api_key
+      }
+      expect(response.status).to eq 200
+      json = JSON.parse response.body
+      expect(json['added_emails']).to eq ['hi@there.com']
+      expect(json['removed_emails']).to eq []
+    end
+
+    it 'user is not global admin and not in the group' do
+      new_user = create(:user)
+      new_user.update(is_admin: false)
+      post :create, params: {
+        group_id: group.id,
+        emails: ['hi@there.com'],
+        api_key: new_user.api_key
+      }
+      expect(response.status).to eq 403
+    end
   end
 end

--- a/spec/controllers/api/b2/memberships_controller_spec.rb
+++ b/spec/controllers/api/b2/memberships_controller_spec.rb
@@ -57,7 +57,7 @@ describe API::B2::MembershipsController do
         emails: ['hey@there.com'],
         api_key: admin.api_key 
       }
-      expect(response.status).to eq 403
+      expect(response.status).to eq 404
     end
 
     it 'missing api_key' do


### PR DESCRIPTION
When using the API to manage memberships is very inconvenient to have to add bots to every group and make them admin of the group in order to be able to manage members programmatically. This generates noise because for every group people will be able to see the bot users as members.

Considering that global admins are already able to manage the application from the admin interface, it would make sense that they can also have more permissions when using the API.

This patch allows users that are global admins of the application to be able to manage users of any group when using the API.

This is a proposal and I understand if you don't want to accept it, but we ended up adding it downstream to our instance so I decided to send it here in case you find it useful too :)