### PR TITLE
simplify the logic about announcing a poll

### DIFF
--- a/app/models/ability/poll.rb
+++ b/app/models/ability/poll.rb
@@ -38,11 +38,10 @@ module Ability::Poll
     can [:announce, :remind], ::Poll do |poll|
       if poll.group_id
         poll.group.admins.exists?(user.id) ||
-        (poll.group.members_can_announce && poll.admins.exists?(user.id)) ||
-        (poll.group.members_can_announce && !poll.specified_voters_only && poll.members.exists?(user.id))
+        (poll.group.members_can_announce && poll.admins.exists?(user.id))
       else
         poll.admins.exists?(user.id) ||
-        (!poll.specified_voters_only && poll.members.exists?(user.id)) 
+        (!poll.specified_voters_only && poll.members.exists?(user.id))
       end
     end
 

--- a/spec/models/ability/poll_spec.rb
+++ b/spec/models/ability/poll_spec.rb
@@ -183,10 +183,8 @@ describe "poll abilities" do
 
         context "anyone in group can vote" do
           before do
-            poll.update(specified_voters_only: false)
-            guest_poll.update(specified_voters_only: false) 
+            guest_poll.update(specified_voters_only: false)
           end
-          it {should be_able_to(:announce, poll) }
           it {should be_able_to(:announce, guest_poll) }
         end
       end

--- a/vue/src/shared/services/ability_service.js
+++ b/vue/src/shared/services/ability_service.js
@@ -167,8 +167,7 @@ export default new class AbilityService {
     if (poll.discardedAt) { return false; }
     if (poll.groupId) {
       return poll.group().adminsInclude(user) ||
-      (poll.group().membersCanAnnounce && poll.adminsInclude(user)) ||
-      (poll.group().membersCanAnnounce && !poll.specifiedVotersOnly && poll.membersInclude(user));
+      (poll.group().membersCanAnnounce && poll.adminsInclude(user))
     } else {
       return poll.adminsInclude(user) ||
       (!poll.specifiedVotersOnly && poll.membersInclude(user));
@@ -182,7 +181,7 @@ export default new class AbilityService {
   canAddGuestsPoll(poll) {
     if (poll.groupId) {
       return poll.group().adminsInclude(Session.user()) ||
-      (poll.group().membersCanAddGuests && poll.group(Session.user()));
+      (poll.group().membersCanAddGuests && poll.adminsInclude(Session.user()));
     } else {
       return poll.adminsInclude(Session.user());
     }

--- a/vue/src/shared/services/poll_service.js
+++ b/vue/src/shared/services/poll_service.js
@@ -106,7 +106,7 @@ export default new class PollService {
         dock: 2,
         canPerform() {
           if (poll.discardedAt || poll.closedAt) { return false; }
-          return AbilityService.canAnnouncePoll(poll);
+          return AbilityService.canAddMembersPoll(poll);
         },
         perform() {
           return openModal({


### PR DESCRIPTION
I cannot explain why we had complicated logic around this, so I'm removing the case where non admins of a poll could announce/remind a poll