### PR TITLE
dont lazyload users, rather fetch all users for a poll when we show it.

### DIFF
--- a/app/controllers/api/v1/polls_controller.rb
+++ b/app/controllers/api/v1/polls_controller.rb
@@ -40,7 +40,7 @@ class API::V1::PollsController < API::V1::RestfulController
 
   def voters
     load_and_authorize(:poll)
-    if !@poll.anonymous && @poll.show_results?(voted: true)
+    if !@poll.anonymous
       self.collection = User.where(id: @poll.voter_ids)
     else
       self.collection = User.none

--- a/app/controllers/api/v1/polls_controller.rb
+++ b/app/controllers/api/v1/polls_controller.rb
@@ -38,6 +38,17 @@ class API::V1::PollsController < API::V1::RestfulController
     respond_with_resource
   end
 
+  def voters
+    load_and_authorize(:poll)
+    if !@poll.anonymous && @poll.show_results?(voted: true)
+      self.collection = User.where(id: @poll.voter_ids)
+    else
+      self.collection = User.none
+    end
+      cache = RecordCache.for_collection(collection, current_user.id, exclude_types)
+      respond_with_collection serializer: AuthorSerializer, root: :users, scope: {cache: cache, exclude_types: exclude_types}
+  end
+
   private
   def create_action
     @event = service.create(**{resource_symbol => resource, actor: current_user, params: resource_params})

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -243,6 +243,7 @@ Rails.application.routes.draw do
           post :close
           post :reopen
           patch :add_to_thread
+          get :voters
         end
         get  :closed, on: :collection
       end

--- a/vue/package-lock.json
+++ b/vue/package-lock.json
@@ -55,7 +55,7 @@
         "deepmerge": "^4.3.1",
         "emoji-unicode": "^2.0.1",
         "jstimezonedetect": "~1.0.7",
-        "lodash-es": "*",
+        "lodash-es": "latest",
         "lokijs": "1.5.12",
         "marked": "^4.3.0",
         "md5": "2.3.0",
@@ -77,15 +77,15 @@
         "vuetify": "2.6.15"
       },
       "devDependencies": {
-        "@modyfi/vite-plugin-yaml": "*",
-        "@originjs/vite-plugin-commonjs": "*",
-        "@vitejs/plugin-vue2": "*",
+        "@modyfi/vite-plugin-yaml": "latest",
+        "@originjs/vite-plugin-commonjs": "latest",
+        "@vitejs/plugin-vue2": "latest",
         "nightwatch": "^3.5.0",
-        "pug": "*",
-        "sass": "*",
-        "unplugin-vue-components": "*",
+        "pug": "latest",
+        "sass": "latest",
+        "unplugin-vue-components": "latest",
         "vite": "^5.2.2",
-        "vite-plugin-env-compatible": "*"
+        "vite-plugin-env-compatible": "latest"
       }
     },
     "node_modules/@antfu/utils": {

--- a/vue/src/components/poll/common/chart/panel.vue
+++ b/vue/src/components/poll/common/chart/panel.vue
@@ -26,14 +26,9 @@ export default {
   },
 
   created() {
-    this.watchRecords({
-      collections: ['polls'],
-      query: () => {
-        if (Session.isSignedIn()) {
-          Records.users.fetchAnyMissingById(this.poll.decidedVoterIds());
-        }
-      }
-    });
+    if (Session.isSignedIn()) {
+      Records.fetch({path: "polls/"+this.poll.id+"/voters"})
+    }
   }
 };
 

--- a/vue/src/components/poll/common/chart/table.vue
+++ b/vue/src/components/poll/common/chart/table.vue
@@ -38,8 +38,6 @@ export default {
             let user;
             if ((user = Records.users.find(id))) {
               Vue.set(this.users, id, user);
-            } else {
-              Records.users.addMissing(id);
             }
           });
         });

--- a/vue/src/shared/models/reaction_model.js
+++ b/vue/src/shared/models/reaction_model.js
@@ -5,7 +5,6 @@ export default class ReactionModel extends BaseModel {
   static singular = 'reaction';
   static plural = 'reactions';
   static indices = ['userId', 'reactableId', 'reactableType'];
-  static lazyLoad = true;
 
   relationships() {
     this.belongsTo('user');

--- a/vue/src/shared/models/user_model.js
+++ b/vue/src/shared/models/user_model.js
@@ -5,7 +5,6 @@ import { find, filter, flatten, uniq, head, compact, map, truncate  } from 'loda
 export default class UserModel extends BaseModel {
   static singular = 'user';
   static plural = 'users';
-  static lazyLoad = true;
   static uniqueIndices = ['id'];
 
   relationships() {

--- a/vue/src/shared/record_store/base_records_interface.js
+++ b/vue/src/shared/record_store/base_records_interface.js
@@ -49,7 +49,7 @@ export default class BaseRecordsInterface {
 
   addMissing(id) {
     this.missingIds.push(id);
-    return this.fetchMissing();
+    this.fetchMissing();
   }
 
   fetchAnyMissingById(allIds) {

--- a/vue/src/shared/services/ability_service.js
+++ b/vue/src/shared/services/ability_service.js
@@ -176,7 +176,7 @@ export default new class AbilityService {
   }
 
   canAddMembersPoll(poll) {
-    return poll.adminsInclude(user());
+    return poll.adminsInclude(Session.user());
   }
 
   canAddGuestsPoll(poll) {


### PR DESCRIPTION
We do this because it's faster, and less work for the client, also we were generating errors for polls with lots of voters when the GET string was too long fetching users by id