### PR TITLE
show email address of recipient when inviting people to join discussi…

### DIFF
--- a/app/controllers/api/v1/announcements_controller.rb
+++ b/app/controllers/api/v1/announcements_controller.rb
@@ -147,8 +147,14 @@ class API::V1::AnnouncementsController < API::V1::RestfulController
   end
 
   def default_scope
+    if target_model && target_model.respond_to?(:group_id)
+      is_admin = target_model.group_id ? target_model.group.admins.exists?(current_user.id) : target_model.admins.exists?(current_user.id)
+    else
+      is_admin = false
+    end
+
     super.merge(
-      include_email: (target_model && target_model.admins.exists?(current_user.id))
+      include_email: (is_admin)
     )
   end
 

--- a/app/controllers/api/v1/discussion_readers_controller.rb
+++ b/app/controllers/api/v1/discussion_readers_controller.rb
@@ -48,7 +48,9 @@ class API::V1::DiscussionReadersController < API::V1::RestfulController
   end
 
   def default_scope
-    super.merge({include_email: (@discussion_reader || @discussion).discussion.admins.exists?(current_user.id)})
+    discussion = (@discussion_reader || @discussion).discussion
+    is_admin = discussion.group_id ? discussion.group.admins.exists?(current_user.id) : discussion.admins.exists?(current_user.id)
+    super.merge({include_email: is_admin})
   end
 
   def accessible_records

--- a/vue/src/components/common/recipients_autocomplete.vue
+++ b/vue/src/components/common/recipients_autocomplete.vue
@@ -387,7 +387,7 @@ div.recipients-autocomplete
         user-avatar(v-if="data.item.type == 'user'", :user="data.item.user", :size="24" no-link)
         common-icon.mr-1(v-else small name="data.item.icon")
       v-list-item-content.announcement-chip__content
-        v-list-item-title.align-center
+        v-list-item-title
           span {{data.item.name}}
           span(v-if="data.item.type == 'user' && currentUserId == data.item.id")
             space

--- a/vue/src/components/common/recipients_autocomplete.vue
+++ b/vue/src/components/common/recipients_autocomplete.vue
@@ -387,11 +387,13 @@ div.recipients-autocomplete
         user-avatar(v-if="data.item.type == 'user'", :user="data.item.user", :size="24" no-link)
         common-icon.mr-1(v-else small name="data.item.icon")
       v-list-item-content.announcement-chip__content
-        v-list-item-title
+        v-list-item-title.align-center
           span {{data.item.name}}
           span(v-if="data.item.type == 'user' && currentUserId == data.item.id")
             space
             span ({{ $t('common.you') }})
+        v-list-item-subtitle(v-if="data.item.user && data.item.user.email")
+          span {{data.item.user.email}}
   notifications-count(
     v-show="!hideCount && recipients.length"
     :model='model'


### PR DESCRIPTION
…on, poll, group, if you're an admin

this is because it's easy for two people to have the same name, and we need a way to tell them apart