### PR TITLE
fix invitations remaining

### DIFF
--- a/app/controllers/api/v1/announcements_controller.rb
+++ b/app/controllers/api/v1/announcements_controller.rb
@@ -18,6 +18,18 @@ class API::V1::AnnouncementsController < API::V1::RestfulController
     respond_with_collection
   end
 
+  def new_member_count
+    current_user.ability.authorize! :show, target_model
+
+    count = UserInviter.new_members_count(
+      parent_group: target_model.parent_or_self,
+      user_ids: String(params[:recipient_user_xids]).split('x').map(&:to_i),
+      emails: String(params[:recipient_emails_cmr]).split(',')
+    )
+    render json: {count: count}
+  end
+
+  # count for number of notifications that will be send
   def count
     count = UserInviter.count(
       actor: current_user,

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -285,11 +285,11 @@ class Group < ApplicationRecord
     reload
   end
 
-  def org_memberships_count
+  def org_members_count
     Membership.active.where(group_id: id_and_subgroup_ids).count('distinct user_id')
   end
 
-  def org_members_count
+  def org_accepted_members_count
     Membership.active.accepted.where(group_id: id_and_subgroup_ids).count('distinct user_id')
   end
 

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -24,7 +24,7 @@ class Subscription < ApplicationRecord
   def can_invite()
     parent_group = parent_or_self
     subscription = Subscription.for(parent_group)
-    subscription.max_members && parent_group.org_memberships_count >= subscription.max_members
+    subscription.max_members && parent_group.org_members_count >= subscription.max_members
   end
 
   def level

--- a/app/serializers/group_serializer.rb
+++ b/app/serializers/group_serializer.rb
@@ -46,7 +46,6 @@ class GroupSerializer < ApplicationSerializer
              :is_visible_to_public,
              :is_visible_to_parent_members,
              :parent_members_can_see_discussions,
-             :org_memberships_count,
              :org_discussions_count,
              :org_members_count,
              :subscription,
@@ -114,10 +113,6 @@ class GroupSerializer < ApplicationSerializer
   end
 
   private
-  def include_org_memberships_count?
-    object.is_parent?
-  end
-
   def include_org_members_count?
     object.is_parent?
   end

--- a/app/views/admin/groups/_stats.haml
+++ b/app/views/admin/groups/_stats.haml
@@ -6,9 +6,9 @@
         -# %td
         -#   %h2{ style: "text-align: center"}= Queries::AdminGroupPage.visits_count(group)
         %td
-          %h2{ style: "text-align: center"}= group.org_memberships_count
-        %td
           %h2{ style: "text-align: center"}= group.org_members_count
+        %td
+          %h2{ style: "text-align: center"}= group.org_accepted_members_count
         %td
           %h2{ style: "text-align: center"}= group.subgroups.count
         %td

--- a/app/views/groups/stats.html.haml
+++ b/app/views/groups/stats.html.haml
@@ -55,9 +55,6 @@
               %tr
                 %td
                   %p{ style: "text-align: center"}
-                    - if @group.parent_or_self.id == ENV['SOLE_GROUP_ID'].to_i
-                      = @group.org_memberships_count
-                    - else
                       = @group.org_members_count
                 %td
                   %p{ style: "text-align: center"}= @group.subgroups.count

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -303,6 +303,7 @@ Rails.application.routes.draw do
         collection do
           get :audience
           get :count
+          get :new_member_count
           get :search
           get :history
           get :users_notified_count

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -142,12 +142,12 @@ describe Group do
     end
   end
 
-  describe "org membership count" do
+  describe "org members count" do
     let!(:group) { create(:group) }
     let!(:subgroup) { create(:group, parent: group) }
     it 'returns total number of memberships in the org' do
       expect(group.memberships.count + subgroup.memberships.count).to eq 3
-      expect(group.org_memberships_count).to eq 2
+      expect(group.org_members_count).to eq 2
     end
   end
 end


### PR DESCRIPTION
previously we were inaccurate when inviting people who already belonged to a subgroup or parent group