### PR TITLE
revoke discussion readers for revoked memberships.

### DIFF
--- a/app/services/membership_service.rb
+++ b/app/services/membership_service.rb
@@ -40,7 +40,7 @@ class MembershipService
 
     # remove any existing guest access in these groups
     DiscussionReader.joins(:discussion)
-    .where(user_id: actor.id, 'discussions.group_id': invited_group_ids, guest: true)
+    .where(user_id: actor.id, 'discussions.group_id': invited_group_ids)
     .update_all(guest: false, revoked_at: nil, revoker_id: nil)
 
     Stance.joins(:poll)
@@ -78,7 +78,7 @@ class MembershipService
     DiscussionReader
     .joins(:discussion).guests
     .where('discussions.group_id': group_ids, user_id: user_id)
-    .update_all(guest: false)
+    .update_all(guest: false, revoked_at: revoked_at, revoker_id: actor_id)
 
     Stance.joins(:poll).guests
     .where('polls.group_id': group_ids, participant_id: user_id)

--- a/app/services/membership_service.rb
+++ b/app/services/membership_service.rb
@@ -76,7 +76,7 @@ class MembershipService
 
   def self.revoke_by_id(group_ids, user_id, actor_id, revoked_at = DateTime.now)
     DiscussionReader
-    .joins(:discussion).guests
+    .joins(:discussion)
     .where('discussions.group_id': group_ids, user_id: user_id)
     .update_all(guest: false, revoked_at: revoked_at, revoker_id: actor_id)
 

--- a/app/workers/migrate_discussion_readers_for_deactivated_members_worker.rb
+++ b/app/workers/migrate_discussion_readers_for_deactivated_members_worker.rb
@@ -1,0 +1,20 @@
+class MigrateDiscussionReadersForDeactivatedMembersWorker
+  include Sidekiq::Worker
+
+  def perform
+    Membership.includes(:user).where("revoked_at is not null").each do |m|
+      rel = DiscussionReader
+            .joins(:discussion)
+            .where(
+              user_id: m.user_id,
+              'discussion.group_id': m.group_id,
+              guest: false,
+              revoked_at: nil,
+            )
+      if m.user.present?
+        updated_count = rel.update_all(revoked_at: m.revoked_at, revoker_id: m.revoker_id)
+        puts "updated #{updated_count} readers in group_id: #{m.group_id} for user_id #{m.user_id}"
+      end
+    end
+  end
+end

--- a/db/migrate/20241116031145_revoke_discussion_readers_for_revoked_memberships.rb
+++ b/db/migrate/20241116031145_revoke_discussion_readers_for_revoked_memberships.rb
@@ -1,0 +1,5 @@
+class RevokeDiscussionReadersForRevokedMemberships < ActiveRecord::Migration[7.0]
+  def change
+    MigrateDiscussionReadersForDeactivatedMembersWorker.perform_async
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_11_04_023432) do
+ActiveRecord::Schema[7.0].define(version: 2024_11_16_031145) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "hstore"

--- a/spec/services/membership_service_spec.rb
+++ b/spec/services/membership_service_spec.rb
@@ -5,11 +5,11 @@ describe MembershipService do
   let(:user)  { create :user }
   let(:admin) { create :user }
   let(:unverified_user) { create :user, email_verified: false }
-  let(:membership) { create :membership, group: group, user: unverified_user, accepted_at: nil }
+  let(:unverified_user_membership) { create :membership, group: group, user: unverified_user, accepted_at: nil }
 
   before { group.add_admin! admin }
 
-  describe 'destroy' do
+  describe 'revoke' do
     let!(:subgroup) { create :group, parent: group }
     let!(:subgroup_discussion) { create :discussion, group: subgroup, private: false }
     let!(:discussion) { create :discussion, group: group, private: false }
@@ -17,7 +17,6 @@ describe MembershipService do
     let!(:membership) { create :membership, user: user, group: group }
 
     it 'cascade deletes memberships' do
-      membership
       subgroup.add_member! user
       subgroup_discussion.add_guest! user, subgroup_discussion.author
       reader = discussion.add_guest! user, discussion.author
@@ -33,6 +32,14 @@ describe MembershipService do
       expect(poll.members).to_not include user
       expect(reader.reload.guest).to eq false
       expect(stance.reload.guest).to eq false
+    end
+
+    it 'marks discussion readers as revoked' do
+      discussion_reader = DiscussionReader.create(discussion: discussion, user: user)
+      expect(discussion_reader.revoked_at).to be nil
+      MembershipService.revoke(membership: membership, actor: user)
+      discussion_reader.reload
+      expect(discussion_reader.revoked_at).to be_present
     end
   end
 
@@ -50,9 +57,10 @@ describe MembershipService do
       group.add_admin! second_inviter
     end
 
+    # verified user claims unverified users invitiation
     it 'sets accepted_at' do
-      MembershipService.redeem(membership: membership, actor: user)
-      membership.reload.accepted_at.should be_present
+      MembershipService.redeem(membership: unverified_user_membership, actor: user)
+      unverified_user_membership.reload.accepted_at.should be_present
     end
 
     it "handles simple case" do
@@ -94,7 +102,7 @@ describe MembershipService do
       expect(reader.revoked_at).to_not eq nil
       expect(stance.guest).to eq true
       expect(reader.guest).to eq true
-      MembershipService.redeem(membership: membership, actor: user)
+      MembershipService.redeem(membership: unverified_user_membership, actor: user)
       expect(stance.reload.guest).to eq false
       expect(reader.reload.guest).to eq false
       expect(stance.reload.revoked_at).to eq nil
@@ -102,7 +110,7 @@ describe MembershipService do
     end
 
     it 'notifies the invitor of acceptance' do
-      MembershipService.redeem(membership: membership, actor: user)
+      MembershipService.redeem(membership: unverified_user_membership, actor: user)
       expect(Event.last.kind).to eq 'invitation_accepted'
     end
   end


### PR DESCRIPTION
 This fixes an issue where you could invite 'everyone in thread' to a poll and it would invite people who had been removed from the group