### PR TITLE
hid sidebar and user dropdown entries that depend on being logged in

### DIFF
--- a/vue/src/components/common/sidebar.vue
+++ b/vue/src/components/common/sidebar.vue
@@ -195,24 +195,25 @@ v-navigation-drawer.sidenav-left.lmo-no-print(app v-model="open")
         v-list-item-subtitle(v-t="'profile_page.set_your_profile_picture'")
   v-divider
 
-  v-list-item.sidebar__list-item-button--recent(dense to="/dashboard")
-    v-list-item-title(v-t="'dashboard_page.aria_label'")
-  v-list-item(dense to="/inbox")
-    v-list-item-title(v-t="{ path: 'sidebar.unread_threads', args: { count: unreadThreadCount() } }")
-  v-list-item.sidebar__list-item-button--private(:disabled="organizations.length == 0" dense to="/threads/direct")
-    v-list-item-title
-      span(v-t="'sidebar.direct_threads'")
-      span(v-if="unreadDirectThreadsCount > 0")
-        space
-        span ({{unreadDirectThreadsCount}})
-  v-list-item.sidebar__list-item-button--start-thread(v-if="showNewThreadButton" dense to="/d/new")
-    v-list-item-title(v-t="'sidebar.start_thread'")
-    v-list-item-icon
-      common-icon(name="mdi-plus")
-  v-list-item(dense to="/tasks" :disabled="organizations.length == 0")
-    v-list-item-title(v-t="'tasks.tasks'")
+  template(v-if="isSignedIn")
+    v-list-item.sidebar__list-item-button--recent(dense to="/dashboard")
+      v-list-item-title(v-t="'dashboard_page.aria_label'")
+    v-list-item(dense to="/inbox")
+      v-list-item-title(v-t="{ path: 'sidebar.unread_threads', args: { count: unreadThreadCount() } }")
+    v-list-item.sidebar__list-item-button--private(:disabled="organizations.length == 0" dense to="/threads/direct")
+      v-list-item-title
+        span(v-t="'sidebar.direct_threads'")
+        span(v-if="unreadDirectThreadsCount > 0")
+          space
+          span ({{unreadDirectThreadsCount}})
+    v-list-item.sidebar__list-item-button--start-thread(v-if="showNewThreadButton" dense to="/d/new")
+      v-list-item-title(v-t="'sidebar.start_thread'")
+      v-list-item-icon
+        common-icon(name="mdi-plus")
+    v-list-item(dense to="/tasks" :disabled="organizations.length == 0")
+      v-list-item-title(v-t="'tasks.tasks'")
 
-  v-divider
+    v-divider
 
   v-list.sidebar__groups(dense)
     template(v-for="parentGroup in organizations")

--- a/vue/src/components/common/user_dropdown.vue
+++ b/vue/src/components/common/user_dropdown.vue
@@ -38,7 +38,8 @@ export default {
     version() { return AppConfig.version; },
     release() { return AppConfig.release; },
     siteName() { return AppConfig.theme.site_name; },
-    user() { return Session.user(); }
+    user() { return Session.user(); },
+    isSignedIn() { return Session.isSignedIn(); }
   }
 };
 
@@ -46,22 +47,25 @@ export default {
 
 <template lang="pug">
 div.user-dropdown
-  v-list-item(v-if="!user.experiences['sidebar']" @click="togglePinned" dense)
-      v-list-item-title(v-t="'user_dropdown.pin_sidebar'")
+
+  template(v-if="isSignedIn")
+    v-list-item(v-if="!user.experiences['sidebar']" @click="togglePinned" dense)
+        v-list-item-title(v-t="'user_dropdown.pin_sidebar'")
+        v-list-item-icon
+          common-icon(name="mdi-pin")
+    v-list-item(v-if="user.experiences['sidebar']" @click="togglePinned" dense)
+        v-list-item-title(v-t="'user_dropdown.unpin_sidebar'")
+        v-list-item-icon
+          common-icon(name="mdi-pin-off")
+    v-list-item.user-dropdown__list-item-button--profile(to="/profile" dense)
+      v-list-item-title(v-t="'user_dropdown.edit_profile'")
       v-list-item-icon
-        common-icon(name="mdi-pin")
-  v-list-item(v-if="user.experiences['sidebar']" @click="togglePinned" dense)
-      v-list-item-title(v-t="'user_dropdown.unpin_sidebar'")
+        common-icon(name="mdi-account")
+    v-list-item.user-dropdown__list-item-button--email-settings(to="/email_preferences" dense)
+      v-list-item-title(v-t="'user_dropdown.email_settings'")
       v-list-item-icon
-        common-icon(name="mdi-pin-off")
-  v-list-item.user-dropdown__list-item-button--profile(to="/profile" dense)
-    v-list-item-title(v-t="'user_dropdown.edit_profile'")
-    v-list-item-icon
-      common-icon(name="mdi-account")
-  v-list-item.user-dropdown__list-item-button--email-settings(to="/email_preferences" dense)
-    v-list-item-title(v-t="'user_dropdown.email_settings'")
-    v-list-item-icon
-      common-icon(name="mdi-cog-outline")
+        common-icon(name="mdi-cog-outline")
+
   v-list-item(v-if="!isDark" @click="toggleDark" dense)
       v-list-item-title(v-t="'user_dropdown.enable_dark_mode'")
       v-list-item-icon
@@ -70,10 +74,13 @@ div.user-dropdown
       v-list-item-title(v-t="'user_dropdown.disable_dark_mode'")
       v-list-item-icon
         common-icon(name="mdi-white-balance-sunny")
-  v-list-item(@click="signOut()" dense)
-    v-list-item-title(v-t="'user_dropdown.sign_out'")
-    v-list-item-icon
-      common-icon(name="mdi-exit-to-app")
+
+  template(v-if="isSignedIn")      
+    v-list-item(@click="signOut()" dense)
+      v-list-item-title(v-t="'user_dropdown.sign_out'")
+      v-list-item-icon
+        common-icon(name="mdi-exit-to-app")
+
   v-list-item(href="https://github.com/loomio/loomio/releases" target="_blank" dense :title="release")
     v-list-item-title.text--secondary
       span(v-t="'common.version'")


### PR DESCRIPTION
**What**
Resolves https://github.com/loomio/loomio/issues/11107 - I hope this is as intended, the desired state wasn't really described in the issue.

I had to insert multiple conditionals in order to preserve the order of the menu items. (I did not remove darkmode from the the sidemenu for guests because it looks kind of buggy otherwise).

Guest menu view:
![image](https://github.com/user-attachments/assets/a4db9865-aaa4-4057-a10e-af23e80117ea)
