### PR TITLE
Env toggle for thread from mail feature

### DIFF
--- a/app/extras/app_config.rb
+++ b/app/extras/app_config.rb
@@ -102,6 +102,7 @@ class AppConfig
       public_groups:              !ENV['FEATURES_DISABLE_PUBLIC_GROUPS'],
       help_link:                  !ENV['FEATURES_DISABLE_HELP_LINK'],
       example_content:            !ENV['FEATURES_DISABLE_EXAMPLE_CONTENT'],
+      thread_from_mail:           !ENV['FEATURES_DISABLE_THREAD_FROM_MAIL'],
       explore_public_groups:      ENV.fetch('FEATURES_EXPLORE_PUBLIC_GROUPS', false),
       template_gallery:           ENV.fetch('FEATURES_TEMPLATE_GALLERY', false),
       show_contact:               ENV.fetch('FEATURES_SHOW_CONTACT', false),

--- a/app/services/received_email_service.rb
+++ b/app/services/received_email_service.rb
@@ -36,8 +36,10 @@ class ReceivedEmailService
 
     when /[^\s]+\+u=.+&k=.+/ 
       # personal email-to-group, eg. enspiral+u=99&k=adsfghjl@mail.loomio.com
-      if discussion = DiscussionService.create(discussion: Discussion.new(discussion_params(email)), actor: actor_from_email(email))
-        email.update_attribute(:released, true) if discussion.persisted?
+      if AppConfig.app_features[:thread_from_mail]
+        if discussion = DiscussionService.create(discussion: Discussion.new(discussion_params(email)), actor: actor_from_email(email))
+          email.update_attribute(:released, true) if discussion.persisted?
+        end
       end
     else
       if forward_email_rule = ForwardEmailRule.find_by(handle: email.route_path)

--- a/vue/src/shared/services/group_service.js
+++ b/vue/src/shared/services/group_service.js
@@ -20,7 +20,7 @@ export default new class GroupService {
         icon: 'mdi-email',
         dock: 2,
         canPerform() {
-          return group.handle && AbilityService.canStartThread(group);
+          return group.handle && AbilityService.canStartThread(group) && AppConfig.features.app.thread_from_mail;
         },
         perform() {
           EventBus.$emit('openModal', {


### PR DESCRIPTION
Resolves #10112 

Adds `FEATURES_DISABLE_THREAD_FROM_MAIL` env which is used to hide/show the group email action. GUI part is tested, but I could not test the changes to `received_email_service.rb` because I don't have mail set up in my development environment. Would appreciate if someone else could try if threads are still created when mail is incoming or not when the flag is disabled or enabled (I don't think me setting up local mail is worth this).
Alternatively, discarding `received_email_service.rb`  changes might also be an option?