### PR TITLE
Mobile friendly group navigation

### DIFF
--- a/vue/src/components/group/page.vue
+++ b/vue/src/components/group/page.vue
@@ -50,11 +50,11 @@ export default
       if (this.$route.query.subgroups) { query = '?subgroups='+this.$route.query.subgroups; }
 
       return [
-        {id: 0, name: 'threads',   route: this.urlFor(this.group, null)+query},
-        {id: 1, name: 'decisions', route: this.urlFor(this.group, 'polls')+query},
-        {id: 2, name: 'members',   route: this.urlFor(this.group, 'members')+query},
-        {id: 4, name: 'files',     route: this.urlFor(this.group, 'files')+query},
-        {id: 5, name: 'subgroups',  route: this.urlFor(this.group, 'subgroups')+query}
+        {id: 0, name: 'threads',   route: this.urlFor(this.group, null)+query, msIcon: "mdi-forum"},
+        {id: 1, name: 'decisions', route: this.urlFor(this.group, 'polls')+query, msIcon: "mdi-poll"},
+        {id: 2, name: 'members',   route: this.urlFor(this.group, 'members')+query, msIcon: "mdi-account-multiple"},
+        {id: 4, name: 'files',     route: this.urlFor(this.group, 'files')+query, msIcon: "mdi-paperclip"},
+        {id: 5, name: 'subgroups',  route: this.urlFor(this.group, 'subgroups')+query, msIcon: "mdi-account-group"}
         // {id: 6, name: 'settings',  route: @urlFor(@group, 'settings')}
       ].filter(obj => !((obj.name === "subgroups") && this.group.parentId));
     }
@@ -132,19 +132,19 @@ v-main
     document-list(:model='group')
     attachment-list(:attachments="group.attachments")
     v-divider.mt-4
-    v-tabs(
+    v-bottom-navigation(
       v-model="activeTab"
       background-color="transparent"
       center-active
-      grow
+      shift
     )
-      v-tab(
+      v-btn(
         v-for="tab of tabs"
         :key="tab.id"
         :to="tab.route"
         :class="'group-page-' + tab.name + '-tab' "
       )
-        //- common-icon(name="mdi-comment-multiple")
+        common-icon(:name="tab.msIcon")
         span(v-t="'group_page.'+tab.name")
     router-view
 </template>


### PR DESCRIPTION
V-tabs are not properly styled on small screens, resulting in overflowing navigation tabs that are hard to traverse (going right by clicking each tab one by one works, but especially for new users, the tabs to the right might as well not exist).

![image](https://github.com/user-attachments/assets/cabd75b0-544b-494c-be62-20fd5e55151e)

From what I read during trying to fix this, this might already be fixed in vue3, so feel free to reject this PR (just couldn't help myself ✨). Basically, this replaces v-tabs with v-bottom-navigation, making use of icons to save enough space to prevent overflow on average devices. 

## Look on mobile:

![image](https://github.com/user-attachments/assets/c1906aff-8563-45c1-94f5-8c501e4b8bd6)

 ## Look on desktop:
Although tabs look fine on wider formats and changing layouts for smaller screens would be an option, I didn't want put more to work into this at this stage. (Doesn't look too bad either imo).

![image](https://github.com/user-attachments/assets/ac010fd3-515b-4578-b024-0b7b15130242)
