### PR TITLE
Fix reaction display

### DIFF
--- a/vue/src/components/common/action_dock.vue
+++ b/vue/src/components/common/action_dock.vue
@@ -37,13 +37,13 @@ section.d-flex.flex-wrap.align-center.action-dock.pb-1(style="margin-left: -6px"
   .action-dock__action(v-for='(action, name) in leftActions' v-if='action.canPerform()', :key="name")
     action-button(v-if="name != 'react'", :action="action", :name="name", :small="small", :nameArgs="action.nameArgs && action.nameArgs()")
   v-spacer(v-if="!left")
-  reaction-display(:model="model" v-if="!left && actions.react && actions.react.canPerform()", :small="small")
+  reaction-display(:model="model" v-if="!left && actions.react" :canEdit="actions.react.canPerform()", :small="small")
   .action-dock__action(v-for='(action, name) in rightActions' v-if='action.canPerform()', :key="name")
     reaction-input.action-dock__button--react(:model="model" v-if="name == 'react'", :small="small")
     action-button(v-if="name != 'react'", :action="action", :name="name", :small="small", :nameArgs="action.nameArgs && action.nameArgs()")
   action-menu(v-if="menuActions", :actions='menuActions', :menuIcon="menuIcon" :small="small" icon, :name="$t('action_dock.more_actions')")
   v-spacer(v-if="left")
-  reaction-display(:model="model" v-if="left && actions.react && actions.react.canPerform()", :small="small")
+  reaction-display(:model="model" v-if="left && actions.react" :canEdit="actions.react.canPerform()", :small="small")
 </template>
 
 <style lang="sass">

--- a/vue/src/components/reaction/display.vue
+++ b/vue/src/components/reaction/display.vue
@@ -8,7 +8,8 @@ import { colonToUnicode, stripColons, imgForEmoji, srcForEmoji, emojiSupported }
 export default {
   props: {
     model: Object,
-    small: Boolean
+    small: Boolean,
+    canEdit: Boolean
   },
 
   data() {
@@ -76,7 +77,8 @@ export default {
     srcForEmoji,
     stripColons,
     colonToUnicode,
-    removeMine(reaction) {
+    removeMine(reaction, canEdit) {
+      if (!canEdit) { return; }
       const mine = Records.reactions.find(merge({}, this.reactionParams, {
         userId:   Session.user().id,
         reaction
@@ -104,7 +106,7 @@ export default {
 <template lang="pug">
 .reactions-display.mr-2(v-if="reactionTypes.length")
   .reactions-display__emojis
-    .reaction.lmo-pointer(@click="removeMine(reaction)" v-for="reaction in reactionTypes" :key="reaction")
+    .reaction.lmo-pointer(@click="removeMine(reaction, canEdit)" v-for="reaction in reactionTypes" :key="reaction")
       v-tooltip(bottom)
         template(v-slot:activator="{ on, attrs }")
           .reactions-display__group(v-on="on" v-bind="attrs")

--- a/vue/src/components/reaction/display.vue
+++ b/vue/src/components/reaction/display.vue
@@ -3,7 +3,7 @@ import Records from '@/shared/services/records';
 import Session from '@/shared/services/session';
 import ReactionService from '@/shared/services/reaction_service';
 import {merge, capitalize, difference, keys, startsWith, each, compact} from 'lodash-es';
-import { colonToUnicode, stripColons, imgForEmoji, srcForEmoji, emojiSupported } from '@/shared/helpers/emojis';
+import { colonToUnicode, stripColons, srcForEmoji, emojiSupported } from '@/shared/helpers/emojis';
 
 export default {
   props: {


### PR DESCRIPTION
If a thread is closed the user shouldn't be able to send reactions but they should be able to see the existing ones.

![image](https://github.com/user-attachments/assets/9482c638-c9ea-4ce2-b26b-e71613ced467)
