### PR TITLE
Fix erroneous Dutch translation

### DIFF
--- a/config/locales/client.nl_NL.yml
+++ b/config/locales/client.nl_NL.yml
@@ -2584,7 +2584,7 @@ nl_NL:
     stance_reason_required_label: Het opgeven van een reden bij het stemmen is ...
     stance_reason_required: Vereist
     stance_reason_optional: Optioneel
-    stance_reason_disabled: Gehandicapt
+    stance_reason_disabled: Uitgeschakeld
     stance_reason_is_required: Geef een reden op voor uw stem
     limit_reason_length: Beperk de reden tot maximaal 500 tekens
     save_poll: Poll opslaan


### PR DESCRIPTION
Hi there! I ran into a translation issue: 'Disabled' was wrongly translated to refer to handicap rather than a feature's state.

The translation guide linked in the [CONTRIBUTION.md](https://github.com/loomio/loomio/blob/master/CONTRIBUTING.md) file returns a [404](https://help.loomio.org/en/dev_manual/translation/), so I hope a pull request is fine for your workflow :)