### PR TITLE
fix: Add missing import for I18n in form

### DIFF
--- a/vue/src/components/poll/common/form.vue
+++ b/vue/src/components/poll/common/form.vue
@@ -2,6 +2,7 @@
 import AppConfig from '@/shared/services/app_config';
 import Session from '@/shared/services/session';
 import { mapKeys, without, some, pick, snakeCase } from 'lodash-es';
+import { I18n } from '@/i18n';
 import Flash from '@/shared/services/flash';
 import Records from '@/shared/services/records';
 import EventBus from '@/shared/services/event_bus';


### PR DESCRIPTION
During some testing in our deployment, we came across this error:
<img width="1410" height="251" alt="Screenshot from 2025-10-09 12-20-00" src="https://github.com/user-attachments/assets/3d3a999d-b886-49cb-9bad-f235cb02043c" />

It seems that the `vue/src/components/poll/common/form.vue`  was missing the import statement for the I18n package. This tiny fix PR adds the missing import.