### PR TITLE
Show how voted after closed

### DIFF
--- a/vue/src/components/poll/common/action_panel.vue
+++ b/vue/src/components/poll/common/action_panel.vue
@@ -130,7 +130,8 @@ export default
           :size="28"
           :poll="poll"
           :stance-choice="stance.stanceChoice()"
-          verbose)
+          verbose
+        )
         poll-common-stance-choices(v-else :stance='stance')
       .d-flex.align-center
         span.text-truncate.text-medium-emphasis {{strippedReason}}


### PR DESCRIPTION
Thanks for the inspiration @anarute. I like your attempt but I needed to have a go myself.

There are a few things happening. 
- We no longer need to build a new stance if myStance() returns null, as the server will always give us a vote if we can vote now. So we can delete that code.
- I wanted to document the purpose of the logic in watchRecords
- We can reduce duplication in the template between single and multiple choice cases.

