### PR TITLE
dashboard: fix check to display no polls message

### DIFF
--- a/vue/src/components/dashboard/polls_panel.vue
+++ b/vue/src/components/dashboard/polls_panel.vue
@@ -76,8 +76,8 @@ export default
           v-for="poll in votePolls",
           :key="poll.id"
         )
+      template(v-if='votePolls.length == 0 && !loader.loading')
         v-card-text(
-          v-if="votePolls.length == 0",
           v-t="'dashboard_page.no_polls_to_vote_on'"
         )
       template(v-if="otherPolls.length")


### PR DESCRIPTION
If there's no poll to vote on it should display a message to the user.

There was a regression that made the message to never be displayed because it was inside a component that would be shown only if there are polls to vote on.