### PR TITLE
Add ARM64 support for Docker images

### DIFF
--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -22,6 +22,14 @@ jobs:
         uses: actions/checkout@v3
         if: env.HAVESECRET != null
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        if: env.HAVESECRET != null
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        if: env.HAVESECRET != null
+
       - name: Log in to Docker Hub
         uses: docker/login-action@v2
         if: env.HAVESECRET != null
@@ -41,6 +49,7 @@ jobs:
         if: env.HAVESECRET != null
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## Summary

This PR adds ARM64 (aarch64) support to Loomio's Docker images, enabling native performance on Apple Silicon Macs, AWS Graviton instances, and other ARM64 platforms.

## Changes

Updated `.github/workflows/docker_image.yml` to build multi-platform Docker images:
- Added QEMU setup for cross-platform emulation
- Added Docker Buildx setup for multi-platform builds
- Configured build to target both `linux/amd64` and `linux/arm64` platforms

## Compatibility

The existing Dockerfile is already compatible with ARM64:
- Ruby base image `ruby:3.4.7-slim` supports both AMD64 and ARM64
- All apt packages (libvips, ffmpeg, poppler-utils, etc.) are available for ARM64
- Node.js from NodeSource repository supports ARM64
- All build tools and dependencies work on both architectures

## Benefits

- **Apple Silicon**: Native performance on M1/M2/M3 Macs without Rosetta emulation
- **AWS Graviton**: Better price-performance ratio on ARM-based AWS instances
- **Energy Efficiency**: ARM64 typically offers better performance per watt
- **Broader Platform Support**: Access to ARM-based instances across various cloud providers

## Testing

The multi-platform build process has been tested and verified. Docker automatically pulls the correct architecture for the target platform.

## Migration Path

This is a backward-compatible change. Existing AMD64 users will continue to receive AMD64 images automatically. ARM64 users will now receive native ARM64 images instead of emulated AMD64 images.

## Note

Users can build multi-platform images locally using standard Docker Buildx commands if needed:
```bash
docker buildx build --platform linux/amd64,linux/arm64 -t loomio/loomio:local .
```