### PR TITLE
Fix CSRF cookie secure flag for local development

### DIFF
--- a/app/helpers/protected_from_forgery.rb
+++ b/app/helpers/protected_from_forgery.rb
@@ -17,7 +17,7 @@ module ProtectedFromForgery
       cookies[:csrftoken] = {
         value: form_authenticity_token,
         expires: 1.day.from_now,
-        secure: true
+        secure: Rails.application.config.force_ssl
       }
     end
   end


### PR DESCRIPTION
## Problem

When `FORCE_SSL` is not set (for local development), the CSRF cookie is still hardcoded with `secure: true`, causing browsers to refuse sending it over HTTP. This results in silent 422 errors during login/signup.

## Solution

Set CSRF cookie `secure` flag based on `Rails.application.config.force_ssl` instead of hardcoding to `true`.

**File changed:** `app/helpers/protected_from_forgery.rb` (line 20)

```ruby
-secure: true
+secure: Rails.application.config.force_ssl
```

## Testing

With this change, when FORCE_SSL is not set:
- CSRF cookie is sent over HTTP
- Login/signup forms work correctly
- No more silent 422 errors

When FORCE_SSL is set (production):
- CSRF cookie remains secure
- No behavior change