### PR TITLE
Fix NoMethodError in avatar_kind for Rails 7.2

### DIFF
--- a/app/models/concerns/has_avatar.rb
+++ b/app/models/concerns/has_avatar.rb
@@ -22,7 +22,7 @@ module HasAvatar
   def avatar_kind
     return 'mdi-duck' if deactivated_at?
     return 'mdi-email-outline' if !name
-    super
+    read_attribute(:avatar_kind)
   end
 
   def thumb_url


### PR DESCRIPTION
## Problem

When running Loomio on Rails 7.2, the `avatar_kind` method in `HasAvatar` concern causes a `NoMethodError`:

```
NoMethodError: super: no superclass method 'avatar_kind' for an instance of User
at /loomio/app/models/concerns/has_avatar.rb:25
```

This error occurs when Sidekiq workers (like `PublishEventWorker`) try to serialize user data for email notifications, causing email delivery to fail.

## Root Cause

In Rails 7.2, when you override an attribute method that corresponds to a database column, calling `super` no longer works correctly. The method tries to call a parent implementation that doesn't exist in the expected way.

## Solution

Replace `super` with `read_attribute(:avatar_kind)` - the correct Rails pattern for accessing database column values in overridden attribute methods.

### Before
```ruby
def avatar_kind
  return 'mdi-duck' if deactivated_at?
  return 'mdi-email-outline' if !name
  super  # ❌ Doesn't work in Rails 7.2
end
```

### After
```ruby
def avatar_kind
  return 'mdi-duck' if deactivated_at?
  return 'mdi-email-outline' if !name
  read_attribute(:avatar_kind)  # ✅ Correct Rails 7.2 pattern
end
```

## Testing

Tested on:
- Rails 7.2.2.1
- Ruby 3.4.7
- Linux ARM64 (Raspberry Pi) and AMD64

After applying this fix:
- Invite emails send successfully
- No more `NoMethodError` in Sidekiq worker logs
- User serialization works correctly

## Impact

- **Scope**: Minimal - single line change
- **Risk**: Low - `read_attribute` is the canonical way to access column values
- **Backward compatible**: Yes - works on earlier Rails versions too

## References

- ActiveRecord attribute methods: https://api.rubyonrails.org/classes/ActiveRecord/AttributeMethods.html
- Related Rails issue pattern: https://github.com/rails/rails/issues/42918