### PR TITLE
Allow "request to join" option for any group type

### DIFF
--- a/vue/src/components/group/form.vue
+++ b/vue/src/components/group/form.vue
@@ -4,6 +4,7 @@ import LmoUrlService from '@/shared/services/lmo_url_service';
 import Records  from '@/shared/services/records';
 import Flash   from '@/shared/services/flash';
 import EventBus   from '@/shared/services/event_bus';
+import Session from '@/shared/services/session';
 import { groupPrivacy, groupPrivacyStatement } from '@/shared/helpers/helptext';
 import { isEmpty, debounce } from 'lodash-es';
 
@@ -121,7 +122,7 @@ export default
 
   watch: {
     'group.groupPrivacy'(val) {
-      if (this.group.groupPrivacy != 'open' && this.group.membershipGrantedUpon == 'request') {
+      if (this.group.groupPrivacy != 'open' && this.group.membershipGrantedUpon == 'request' && !Session.user().isAdmin) {
         this.group.membershipGrantedUpon = 'approval';
       }
     }
@@ -133,7 +134,7 @@ export default
     },
 
     membershipGrantedUponOptions() {
-      if (this.group.groupPrivacy == 'open') {
+      if (Session.user().isAdmin) {
         return ['request', 'approval', 'invitation']
       } else {
         return ['approval', 'invitation']


### PR DESCRIPTION
PR Closed: Sorry, I meant to create this PR on my fork first, not directly here.

### Problem
From the admin panel, I can set a group to allow users to join on "request"
From the regular group settings (outside the admin panel), I cannot do this

<img width="458" height="168" alt="Screenshot 2026-01-25 at 13 43 49" src="https://github.com/user-attachments/assets/183b7dee-ac8f-4462-bfd0-2888da491d1a" />
<img width="728" height="446" alt="Screenshot 2026-01-25 at 13 45 31" src="https://github.com/user-attachments/assets/c3a8efdb-0a3f-4c0f-84ee-52d78d548cf7" />

### Proposal
After checking the code, I see that this option is only available for public groups. I'm not sure I understand why.
In our case, we use Loomio as a closed community — our groups are private, but within our community we want people to be able to join groups without barriers or approval processes.

Currently, this forces me to use my super admin rights to set groups to "request" mode from the admin panel