### PR TITLE
Add polls to vote on page

### DIFF
--- a/config/locales/client.ca.yml
+++ b/config/locales/client.ca.yml
@@ -1625,6 +1625,7 @@ ca:
     view_recent: Voleu veure totes les discussions recents?
     discussion_marked_as_read: Discussió marcada com a llegida
     discussion_marked_as_unread: Discussió marcada com a no llegida
+    polls_to_vote_on_count: Enquestes per votar (%{count})
   threads_page:
     no_direct_threads: No teniu fils directes
     no_invite_only_threads: No tens fils només per invitació

--- a/config/locales/client.da.yml
+++ b/config/locales/client.da.yml
@@ -1607,6 +1607,7 @@ da:
     view_recent: Se alle de seneste diskussioner?
     discussion_marked_as_read: Diskussion markeret som læst
     discussion_marked_as_unread: Diskussion markeret som ulæst
+    polls_to_vote_on_count: Afstemninger at stemme om (%{count})
   threads_page:
     no_direct_threads: Du har ingen direkte tråde
     no_invite_only_threads: Du har ingen tråde kun for inviterede

--- a/config/locales/client.de.yml
+++ b/config/locales/client.de.yml
@@ -1631,6 +1631,7 @@ de:
     view_recent: Alle aktuellen Diskussionen ansehen?
     discussion_marked_as_read: Diskussion als gelesen markiert
     discussion_marked_as_unread: Diskussion als ungelesen markiert
+    polls_to_vote_on_count: Umfragen zur Abstimmung (%{count})
   threads_page:
     no_direct_threads: Du hast keine direkten Diskussionen
     no_invite_only_threads: Es gibt keine Threads, die nur auf Einladung zugänglich sind.

--- a/config/locales/client.el.yml
+++ b/config/locales/client.el.yml
@@ -1607,6 +1607,7 @@ el:
     view_recent: Δείτε όλες τις πρόσφατες συζητήσεις;
     discussion_marked_as_read: Η συζήτηση επισημάνθηκε ως αναγνωσμένη
     discussion_marked_as_unread: Η συζήτηση επισημάνθηκε ως μη αναγνωσμένη
+    polls_to_vote_on_count: Δημοσκοπήσεις για ψήφο (%{count})
   threads_page:
     no_direct_threads: Δεν έχετε απευθείας νήματα
     no_invite_only_threads: Δεν έχετε θέματα μόνο με πρόσκληση

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1630,6 +1630,7 @@ en:
   dashboard_page:
     dashboard: Dashboard
     polls_to_vote_on: Polls to vote on
+    polls_to_vote_on_count: Polls to vote on (%{count})
     no_polls_to_vote_on: There are no polls you need to vote on
     recent_polls: Recent polls
     current_polls: Current polls

--- a/config/locales/client.es.yml
+++ b/config/locales/client.es.yml
@@ -1634,6 +1634,7 @@ es:
     view_recent: "¿Ver todas las discusiones recientes?"
     discussion_marked_as_read: Discusión marcada como leída
     discussion_marked_as_unread: Discusión marcada como no leída
+    polls_to_vote_on_count: Encuestas para votar (%{count})
   threads_page:
     no_direct_threads: No tienes hilos directos
     no_invite_only_threads: No tienes hilos solo para invitados

--- a/config/locales/client.fi.yml
+++ b/config/locales/client.fi.yml
@@ -1607,6 +1607,7 @@ fi:
     view_recent: Näyttääkö kaikki viimeaikaiset keskustelut?
     discussion_marked_as_read: Keskustelu merkitty luetuksi
     discussion_marked_as_unread: Keskustelu merkitty lukemattomaksi
+    polls_to_vote_on_count: Äänestettävät kyselyt (%{count})
   threads_page:
     no_direct_threads: Sinulla ei ole suoria lankoja
     no_invite_only_threads: Sinulla ei ole kutsusta lähetettäviä keskusteluketjuja

--- a/config/locales/client.fr.yml
+++ b/config/locales/client.fr.yml
@@ -1644,6 +1644,7 @@ fr:
     view_recent: Voir toutes les discussions récentes ?
     discussion_marked_as_read: Discussion marquée comme lue
     discussion_marked_as_unread: Discussion marquée comme non lue
+    polls_to_vote_on_count: Sondages sur lesquels voter (%{count})
   threads_page:
     no_direct_threads: Vous n'avez pas de discussion directe
     no_invite_only_threads: Vous n'avez pas de sujets accessibles uniquement sur invitation.

--- a/config/locales/client.he.yml
+++ b/config/locales/client.he.yml
@@ -1619,6 +1619,7 @@ he:
     view_recent: להציג את כל הדיונים האחרונים?
     discussion_marked_as_read: דיון סומן כנקרא
     discussion_marked_as_unread: דיון סומן כלא נקרא
+    polls_to_vote_on_count: סקרים להצבעה עליהם (%{count})
   threads_page:
     no_direct_threads: אין לך שרשורים ישירים
     no_invite_only_threads: אין לך שרשורים למוזמנים בלבד

--- a/config/locales/client.hr.yml
+++ b/config/locales/client.hr.yml
@@ -1607,6 +1607,7 @@ hr:
     view_recent: Želite li vidjeti sve nedavne rasprave?
     discussion_marked_as_read: Rasprava označena kao pročitana
     discussion_marked_as_unread: Rasprava označena kao nepročitana
+    polls_to_vote_on_count: Ankete za glasanje (%{count})
   threads_page:
     no_direct_threads: Nemate izravnih niti
     no_invite_only_threads: Nemate niti samo za pozvane

--- a/config/locales/client.hu.yml
+++ b/config/locales/client.hu.yml
@@ -1611,6 +1611,7 @@ hu:
     view_recent: Megtekinted az összes legutóbbi beszélgetést?
     discussion_marked_as_read: Vita megjelölve olvasottként
     discussion_marked_as_unread: A beszélgetés olvasatlanként van megjelölve
+    polls_to_vote_on_count: Szavazandó szavazások (%{count})
   threads_page:
     no_direct_threads: Nincsenek közvetlen szálaid
     no_invite_only_threads: Nincsenek meghívásos beszélgetéseid

--- a/config/locales/client.it.yml
+++ b/config/locales/client.it.yml
@@ -1635,6 +1635,7 @@ it:
     view_recent: Visualizzare tutte le discussioni recenti?
     discussion_marked_as_read: Discussione contrassegnata come letta
     discussion_marked_as_unread: Discussione contrassegnata come non letta
+    polls_to_vote_on_count: Sondaggi su cui votare (%{count})
   threads_page:
     no_direct_threads: Non hai discussioni dirette
     no_invite_only_threads: Non hai discussioni riservate agli inviti

--- a/config/locales/client.ja.yml
+++ b/config/locales/client.ja.yml
@@ -1606,6 +1606,7 @@ ja:
     view_recent: 最近のディスカッションをすべて表示しますか?
     discussion_marked_as_read: ディスカッションを既読としてマークしました
     discussion_marked_as_unread: ディスカッションを未読としてマークしました
+    polls_to_vote_on_count: 投票するアンケート（%{count}）
   threads_page:
     no_direct_threads: 直接のスレッドはありません
     no_invite_only_threads: 招待限定のスレッドはありません

--- a/config/locales/client.nl_NL.yml
+++ b/config/locales/client.nl_NL.yml
@@ -1623,6 +1623,7 @@ nl_NL:
     view_recent: Alle recente discussies bekijken?
     discussion_marked_as_read: Discussie gemarkeerd als gelezen
     discussion_marked_as_unread: Discussie gemarkeerd als ongelezen
+    polls_to_vote_on_count: Peilingen om op te stemmen (%{count})
   threads_page:
     no_direct_threads: Je hebt geen directe borden
     no_invite_only_threads: Je hebt geen alleen-op-uitnodiging-threads

--- a/config/locales/client.pl.yml
+++ b/config/locales/client.pl.yml
@@ -1623,6 +1623,7 @@ pl:
     view_recent: Zobaczyć wszystkie ostatnie dyskusje?
     discussion_marked_as_read: Dyskusja oznaczona jako przeczytana
     discussion_marked_as_unread: Dyskusja oznaczona jako nieprzeczytana
+    polls_to_vote_on_count: Ankiety, w których można głosować (%{count})
   threads_page:
     no_direct_threads: Nie masz żadnych bezpośrednich wątków
     no_invite_only_threads: Nie masz żadnych wątków dostępnych tylko na zaproszenie

--- a/config/locales/client.pt_BR.yml
+++ b/config/locales/client.pt_BR.yml
@@ -1644,6 +1644,7 @@ pt_BR:
     view_recent: Ver todas as discussões recentes?
     discussion_marked_as_read: Discussão marcada como lida
     discussion_marked_as_unread: Discussão marcada como não lida
+    polls_to_vote_on_count: Enquetes para votar (%{count})
   threads_page:
     no_direct_threads: Você não tem tópicos diretos
     no_invite_only_threads: Você não tem tópicos somente para convidados.

--- a/config/locales/client.ro.yml
+++ b/config/locales/client.ro.yml
@@ -1607,6 +1607,7 @@ ro:
     view_recent: Vizualizați toate discuțiile recente?
     discussion_marked_as_read: Discuție marcată ca citită
     discussion_marked_as_unread: Discuție marcată ca necitită
+    polls_to_vote_on_count: Sondaje pentru care se poate vota (%{count})
   threads_page:
     no_direct_threads: Nu ai fire directe
     no_invite_only_threads: Nu aveți subiecte de discuție doar pe invitație

--- a/config/locales/client.ru.yml
+++ b/config/locales/client.ru.yml
@@ -1607,6 +1607,7 @@ ru:
     view_recent: Просмотреть все недавние обсуждения?
     discussion_marked_as_read: Обсуждение отмечено как прочитанное
     discussion_marked_as_unread: Обсуждение отмечено как непрочитанное
+    polls_to_vote_on_count: Опросы, по которым предстоит голосовать (%{count})
   threads_page:
     no_direct_threads: У вас нет прямых тем
     no_invite_only_threads: У вас нет тем, доступных только по приглашению

--- a/config/locales/client.sl.yml
+++ b/config/locales/client.sl.yml
@@ -1607,6 +1607,7 @@ sl:
     view_recent: Ogled vseh nedavnih razprav?
     discussion_marked_as_read: Razprava je označena kot prebrana
     discussion_marked_as_unread: Razprava je označena kot neprebrana
+    polls_to_vote_on_count: Ankete za glasovanje (%{count})
   threads_page:
     no_direct_threads: Nimate neposrednih niti
     no_invite_only_threads: Nimate niti samo za povabilo

--- a/config/locales/client.sv.yml
+++ b/config/locales/client.sv.yml
@@ -1607,6 +1607,7 @@ sv:
     view_recent: Visa alla senaste diskussioner?
     discussion_marked_as_read: Diskussion markerad som läst
     discussion_marked_as_unread: Diskussion markerad som oläst
+    polls_to_vote_on_count: Opinionsundersökningar att rösta på (%{count})
   threads_page:
     no_direct_threads: Du har inga direkta trådar
     no_invite_only_threads: Du har inga trådar endast för inbjudna

--- a/config/locales/client.tr.yml
+++ b/config/locales/client.tr.yml
@@ -1607,6 +1607,7 @@ tr:
     view_recent: Tüm son tartışmaları görüntüle?
     discussion_marked_as_read: Tartışma okundu olarak işaretlendi
     discussion_marked_as_unread: Tartışma okunmamış olarak işaretlendi
+    polls_to_vote_on_count: Oylanacak anketler (%{count})
   threads_page:
     no_direct_threads: Doğrudan konunuz yok
     no_invite_only_threads: Yalnızca davetlilerin katılabileceği bir konunuz yok

--- a/config/locales/client.uk.yml
+++ b/config/locales/client.uk.yml
@@ -1626,6 +1626,7 @@ uk:
     view_recent: Переглянути всі останні обговорення?
     discussion_marked_as_read: Обговорення позначено як прочитане
     discussion_marked_as_unread: Обговорення позначено як непрочитане
+    polls_to_vote_on_count: Опитування для голосування (%{count})
   threads_page:
     no_direct_threads: У вас нема особистих тем
     no_invite_only_threads: У вас немає тем лише для запрошень

--- a/config/locales/client.zh_CN.yml
+++ b/config/locales/client.zh_CN.yml
@@ -1624,6 +1624,7 @@ zh_CN:
       thisweek: 本星期
       thismonth: 本月
       older: 超过一个月
+    polls_to_vote_on_count: 待投票的民意调查 (%{count})
   threads_page:
     no_direct_threads: 您没有直接帖子
     no_invite_only_threads: 您没有仅限受邀者参与的讨论串。

--- a/config/locales/client.zh_TW.yml
+++ b/config/locales/client.zh_TW.yml
@@ -1626,6 +1626,7 @@ zh_TW:
     view_recent: 查看所有近期討論？
     discussion_marked_as_read: 已讀
     discussion_marked_as_unread: 討論內容標記為未讀
+    polls_to_vote_on_count: 待投票的民調 (%{count})
   threads_page:
     no_direct_threads: 您沒有直接討論串
     no_invite_only_threads: 您沒有僅限受邀者參與的討論串。

--- a/vue/src/components/dashboard/polls_to_vote_on_page.vue
+++ b/vue/src/components/dashboard/polls_to_vote_on_page.vue
@@ -1,0 +1,102 @@
+<script setup lang="js">
+import { ref, onMounted, onUnmounted } from 'vue';
+import { useRoute } from 'vue-router';
+import { escapeRegExp, filter } from 'lodash-es';
+import { subDays } from 'date-fns';
+
+import Records from '@/shared/services/records';
+import RecordLoader from '@/shared/services/record_loader';
+import EventBus from '@/shared/services/event_bus';
+import Session from '@/shared/services/session';
+
+const route = useRoute();
+
+const votePolls = ref([]);
+const loader = ref(null);
+const watchedRecords = ref([]);
+
+const watchRecordsFunc = (options) => {
+  const { collections, query, key } = options;
+  const name = collections.concat(key || parseInt(Math.random() * 10000)).join('_');
+  watchedRecords.value.push(name);
+  Records.view({
+    name,
+    collections,
+    query
+  });
+};
+
+const findRecords = () => {
+  const groupIds = Session.user().groupIds();
+  const pollIds = Records.stances.find({myStance: true}).map(stance => stance.pollId);
+
+  let chain = Records.polls.collection.chain();
+  chain = chain.find({discardedAt: null, closingAt: {$ne: null}});
+  chain = chain.find({$or: [{groupId: {$in: groupIds}}, {id: {$in: pollIds}}, {authorId: Session.user().id}]});
+  chain = chain.find({$or: [{closedAt: null}, {closedAt: {$gt: subDays(new Date, 3)}}]});
+
+  if (route.query.q) {
+    const rx = new RegExp(escapeRegExp(route.query.q), 'i');
+    chain = chain.find({$or: [{'title': {'$regex': rx}},
+                             {'description': {'$regex': rx}}]});
+  }
+
+  const votable = p => p.iCanVote() && !p.iHaveVoted();
+  votePolls.value = filter(chain.simplesort('closingAt', true).data(), votable);
+};
+
+loader.value = new RecordLoader({
+  collection: 'polls',
+  params: {
+    exclude_types: 'group',
+    status: 'recent'
+  }
+});
+
+loader.value.fetchRecords();
+
+watchRecordsFunc({
+  collections: ['polls', 'groups', 'memberships', 'stances'],
+  query: () => findRecords()
+});
+
+onMounted(() => {
+  EventBus.$emit('currentComponent', {
+    titleKey: 'dashboard_page.polls_to_vote_on',
+    page: 'pollsToVoteOnPage'
+  });
+});
+
+onUnmounted(() => {
+  watchedRecords.value.forEach(name => delete Records.views[name]);
+});
+
+const titleVisible = (visible) => {
+  EventBus.$emit('content-title-visible', visible);
+};
+</script>
+
+<template lang="pug">
+v-main
+  v-container.polls-to-vote-on-page.max-width-1024.px-0.px-sm-3
+    h1.text-h4.my-4(tabindex="-1" v-intersect="{handler: titleVisible}" v-t="'dashboard_page.polls_to_vote_on'")
+    
+    section.polls-to-vote-on-page__loading(v-if='loader.loading && votePolls.length == 0')
+      v-card.mb-2
+        v-list(lines="two")
+          loading-content(:lineCount='2' v-for='(item, index) in [1,2,3]' :key='index')
+    
+    section.polls-to-vote-on-page__content(v-if='!loader.loading || votePolls.length > 0')
+      v-card.mb-2(v-if='votePolls.length > 0')
+        v-list(lines="two")
+          poll-common-preview(
+            display-group-name
+            full-name
+            :poll="poll"
+            v-for="poll in votePolls"
+            :key="poll.id"
+          )
+      
+      v-card.mb-2(v-if='votePolls.length == 0 && !loader.loading')
+        v-card-text(v-t="'dashboard_page.no_polls_to_vote_on'")
+</template>

--- a/vue/src/components/inbox/page.vue
+++ b/vue/src/components/inbox/page.vue
@@ -84,10 +84,12 @@ v-main
       .thread-previews-container
         loading-content.thread-preview(:lineCount='2' v-for='(item, index) in [1,2,3,4,5,6,7,8,9,10]' :key='index')
     section.inbox-page__threads(v-if='unreadCount > 0 || !loading')
-      .inbox-page__no-threads(v-show='unreadCount == 0')
-        span(v-t="'inbox_page.no_discussions'")
-        span 🙌
-      .inbox-page__no-groups(v-show='groups.length == 0')
+      v-card.mb-3(v-show='unreadCount == 0')
+        v-card-text
+          span(v-t="'inbox_page.no_discussions'")
+          span 🙌
+      v-card.mb-3(v-show='groups.length == 0')
+        v-card-text
         p(v-t="'inbox_page.no_groups.explanation'")
         button.lmo-btn-link--blue(v-t="'inbox_page.no_groups.start'", @click='startGroup()')
         | &nbsp;
@@ -96,10 +98,15 @@ v-main
         span(v-html="$t('inbox_page.no_groups.join_group')")
       .inbox-page__group(v-for='group in groups', :key='group.id')
         v-card.mb-3(v-if='views[group.key].length > 0')
-          v-card-title
-            group-avatar.mr-2(:group="group" :size="40")
-            router-link.inbox-page__group-name(:to="'/g/' + group.key")
-              span.subheading {{group.name}}
-          thread-preview-collection(:threads="views[group.key]", :limit="threadLimit")
+          v-list
+            v-list-subheader
+              router-link.inbox-page__group-link(:to="'/g/' + group.key") {{group.name}}
+            thread-preview-collection(:threads="views[group.key]", :limit="threadLimit")
         //- strand-wall(:threads="views[group.key]")
 </template>
+
+<style lang="sass">
+.inbox-page__group-link
+  color: inherit
+  text-decoration: none
+</style>

--- a/vue/src/components/sidebar/panel.vue
+++ b/vue/src/components/sidebar/panel.vue
@@ -1,154 +1,183 @@
-<script lang="js">
-import AppConfig      from '@/shared/services/app_config';
-import Session        from '@/shared/services/session';
-import Records        from '@/shared/services/records';
-import EventBus       from '@/shared/services/event_bus';
-import AbilityService from '@/shared/services/ability_service';
-import InboxService   from '@/shared/services/inbox_service';
-import WatchRecords from '@/mixins/watch_records';
-import UrlFor from '@/mixins/url_for';
-import FormatDate from '@/mixins/format_date';
+<script setup lang="js">
+import { ref, computed, watch, onMounted, onUnmounted } from 'vue';
+import { useRouter, useRoute } from 'vue-router';
+import { useDisplay } from 'vuetify';
+import { useTheme } from 'vuetify';
+import { compact, filter } from 'lodash-es';
+import { subDays } from 'date-fns';
 
-import { compact } from 'lodash-es';
+import AppConfig from '@/shared/services/app_config';
+import Session from '@/shared/services/session';
+import Records from '@/shared/services/records';
+import EventBus from '@/shared/services/event_bus';
+import AbilityService from '@/shared/services/ability_service';
+import InboxService from '@/shared/services/inbox_service';
+import LmoUrlService from '@/shared/services/lmo_url_service';
+
 import SidebarSubgroups from '@/components/sidebar/subgroups';
 import SidebarSettings from '@/components/sidebar/settings';
 import SidebarHelp from '@/components/sidebar/help';
 
 import { mdiPlus, mdiCog } from '@mdi/js';
 
-import { useTheme } from 'vuetify';
+const router = useRouter();
+const route = useRoute();
+const display = useDisplay();
+const theme = useTheme();
 
-var theme = {}
+const user = ref(Session.user());
+const page = ref('dashboardPage');
+const organization = ref(null);
+const discussions = ref([]);
+const discussionsGroup = ref(null);
+const open = ref(false);
+const group = ref(null);
+const version = ref(AppConfig.version);
+const tree = ref([]);
+const myGroups = ref([]);
+const otherGroups = ref([]);
+const organizations = ref([]);
+const unreadCounts = ref({});
+const openGroups = ref([]);
+const openCounts = ref({});
+const unreadDirectThreadsCount = ref(0);
+const showSettings = ref(false);
+const watchedRecords = ref([]);
 
-export default {
-  components: { SidebarSettings, SidebarSubgroups, SidebarHelp },
-  mixins: [WatchRecords, UrlFor, FormatDate],
-  data() {
-    return {
-      mdiPlus, mdiCog,
-      page: 'dashboardPage',
-      organization: null,
-      discussions: [],
-      discussionsGroup: null,
-      open: false,
-      group: null,
-      version: AppConfig.version,
-      tree: [],
-      myGroups: [],
-      otherGroups: [],
-      organizations: [],
-      unreadCounts: {},
-      openGroups: [],
-      openCounts: {},
-      unreadDirectThreadsCount: 0,
-      showSettings: false
-    };
-  },
+// Computed properties
+const canStartGroups = computed(() => AbilityService.canStartGroups());
+const greySidebarLogo = computed(() => 
+  AppConfig.features.app.gray_sidebar_logo_in_dark_mode && theme.global.name.value.startsWith("dark")
+);
+const isSignedIn = computed(() => Session.isSignedIn());
+const activeGroup = computed(() => group.value ? [group.value.id] : []);
+const logoUrl = computed(() => AppConfig.theme.app_logo_src);
+const showTemplateGallery = computed(() => AppConfig.features.app.template_gallery);
+const showNewThreadButton = computed(() => AppConfig.features.app.new_thread_button);
 
-  created() {
-    theme = useTheme();
-    this.user = Session.user();
-
-    EventBus.$on('toggleSidebar', () => {
-      this.open = !this.open;
-      Records.users.saveExperience('sidebar', this.open)
-    });
-
-    EventBus.$on('currentComponent', data => {
-      // this.page = data.page;
-
-      if (data.group) {
-        this.page = 'groupPage'
-        this.group = data.group;
-        this.organization = data.group.parentOrSelf();
-      } else {
-        this.group = null;
-        this.organization = null;
-      }
-    });
-
-    this.watchRecords({
-      collections: ['groups', 'memberships', 'discussions'],
-      query: () => {
-        this.unreadDirectThreadsCount =
-          Records.discussions.collection.chain().
-          find({groupId: null}).
-          where(thread => thread.isUnread()).data().length;
-        this.updateGroups();
-      }
-    });
-
-    EventBus.$on('signedIn', user => {
-      this.user = Session.user();
-      this.fetchData();
-      this.openIfPinned();
-    });
-
-    if (Session.isSignedIn()) { return this.fetchData(); }
-  },
-
-  mounted() {
-    this.openIfPinned();
-  },
-
-  watch: {
-    organization: 'updateGroups',
-
-    open(val) {
-      EventBus.$emit("sidebarOpen", val);
-    }
-  },
-
-  methods: {
-    unreadThreadCount() {
-      return InboxService.unreadCount();
-    },
-
-    openIfPinned() {
-      this.open = !!Session.isSignedIn() && this.$vuetify.display.lgAndUp && (Session.user().experiences['sidebar'] === undefined) || (Session.user().experiences['sidebar'] == true);
-    },
-
-    fetchData() {
-      Records.users.findOrFetchGroups().then(() => {
-        if (this.$route.path == "/dashboard") {
-          if (Session.user().groups().length == 0) {
-            this.$router.replace("/g/new");
-          }
-          if (Session.user().groups().length == 1) {
-              this.$router.replace(`/g/${Session.user().groups()[0].key}`);
-          }
-        }
-      });
-      InboxService.load();
-    },
-
-    updateGroups() {
-      this.organizations = compact(Session.user().parentGroups().concat(Session.user().orphanParents())) || [];
-      this.openCounts = {};
-      this.openGroups = [];
-      Session.user().groups().forEach(group => {
-        this.openCounts[group.id] = group.discussions().filter(discussion => discussion.isUnread()).length;
-      });
-      Session.user().parentGroups().forEach(group => {
-        if (this.organization && (this.organization.id === group.parentOrSelf().id)) {
-          this.openGroups[group.id] = true;
-        }
-      });
-    },
-  },
-
-  computed: {
-    canStartGroups() { return AbilityService.canStartGroups(); },
-    greySidebarLogo() {
-      return AppConfig.features.app.gray_sidebar_logo_in_dark_mode && theme.global.name.value.startsWith("dark")
-    },
-    isSignedIn() { return Session.isSignedIn(); },
-    activeGroup() { if (this.group) { return [this.group.id]; } else { return []; } },
-    logoUrl() { return AppConfig.theme.app_logo_src; },
-    showTemplateGallery() { return AppConfig.features.app.template_gallery; },
-    showNewThreadButton() { return AppConfig.features.app.new_thread_button; },
-  }
+// Methods
+const unreadThreadCount = () => {
+  return InboxService.unreadCount();
 };
+
+const pollsToVoteOnCount = () => {
+  const groupIds = Session.user().groupIds();
+  const pollIds = Records.stances.find({myStance: true}).map(stance => stance.pollId);
+
+  let chain = Records.polls.collection.chain();
+  chain = chain.find({discardedAt: null, closingAt: {$ne: null}});
+  chain = chain.find({$or: [{groupId: {$in: groupIds}}, {id: {$in: pollIds}}, {authorId: Session.user().id}]});
+  chain = chain.find({$or: [{closedAt: null}, {closedAt: {$gt: subDays(new Date, 3)}}]});
+
+  const votable = p => p.iCanVote() && !p.iHaveVoted();
+  const votePolls = filter(chain.data(), votable);
+  
+  return votePolls.length;
+};
+
+const urlFor = (model, action, params) => {
+  return LmoUrlService.route({model, action, params});
+};
+
+const watchRecordsFunc = (options) => {
+  const { collections, query, key } = options;
+  const name = collections.concat(key || parseInt(Math.random() * 10000)).join('_');
+  watchedRecords.value.push(name);
+  Records.view({
+    name,
+    collections,
+    query
+  });
+};
+
+const openIfPinned = () => {
+  open.value = !!Session.isSignedIn() && 
+    display.lgAndUp.value && 
+    (Session.user().experiences['sidebar'] === undefined || Session.user().experiences['sidebar'] === true);
+};
+
+const fetchData = () => {
+  Records.users.findOrFetchGroups().then(() => {
+    if (route.path === "/dashboard") {
+      if (Session.user().groups().length === 0) {
+        router.replace("/g/new");
+      }
+      if (Session.user().groups().length === 1) {
+        router.replace(`/g/${Session.user().groups()[0].key}`);
+      }
+    }
+  });
+  InboxService.load();
+};
+
+const updateGroups = () => {
+  organizations.value = compact(Session.user().parentGroups().concat(Session.user().orphanParents())) || [];
+  openCounts.value = {};
+  openGroups.value = [];
+  Session.user().groups().forEach(g => {
+    openCounts.value[g.id] = g.discussions().filter(discussion => discussion.isUnread()).length;
+  });
+  Session.user().parentGroups().forEach(g => {
+    if (organization.value && (organization.value.id === g.parentOrSelf().id)) {
+      openGroups.value[g.id] = true;
+    }
+  });
+};
+
+// Event listeners setup
+EventBus.$on('toggleSidebar', () => {
+  open.value = !open.value;
+  Records.users.saveExperience('sidebar', open.value);
+});
+
+EventBus.$on('currentComponent', data => {
+  if (data.group) {
+    page.value = 'groupPage';
+    group.value = data.group;
+    organization.value = data.group.parentOrSelf();
+  } else {
+    group.value = null;
+    organization.value = null;
+  }
+});
+
+watchRecordsFunc({
+  collections: ['groups', 'memberships', 'discussions', 'polls', 'stances'],
+  query: () => {
+    unreadDirectThreadsCount.value = Records.discussions.collection.chain()
+      .find({groupId: null})
+      .where(thread => thread.isUnread())
+      .data().length;
+    updateGroups();
+  }
+});
+
+EventBus.$on('signedIn', u => {
+  user.value = Session.user();
+  fetchData();
+  openIfPinned();
+});
+
+if (Session.isSignedIn()) {
+  fetchData();
+}
+
+onMounted(() => {
+  openIfPinned();
+});
+
+onUnmounted(() => {
+  watchedRecords.value.forEach(name => delete Records.views[name]);
+});
+
+// Watchers
+watch(organization, () => {
+  updateGroups();
+});
+
+watch(open, (val) => {
+  EventBus.$emit("sidebarOpen", val);
+});
 </script>
 
 <template lang="pug">
@@ -169,7 +198,10 @@ v-navigation-drawer.sidenav-left.lmo-no-print(app v-model="open")
     v-divider
     v-list(nav density="compact" :lines="false")
       v-list-item.sidebar__list-item-button--recent(to="/dashboard" :title="$t('dashboard_page.dashboard')")
-      v-list-item(to="/inbox" :title="$t('sidebar.unread_discussions_count', { count: unreadThreadCount() })")
+      v-list-item(to="/dashboard/polls_to_vote_on")
+        v-list-item-title(:class="{'text-medium-emphasis': pollsToVoteOnCount() === 0}") {{ $t('dashboard_page.polls_to_vote_on_count', {count: pollsToVoteOnCount()}) }}
+      v-list-item(to="/inbox")
+        v-list-item-title(:class="{'text-medium-emphasis': unreadThreadCount() === 0}") {{ $t('sidebar.unread_discussions_count', {count: unreadThreadCount()}) }}
       v-list-item.sidebar__list-item-button--private(to="/threads/direct")
         v-list-item-title
           span(v-t="'sidebar.invite_only_discussions'")

--- a/vue/src/components/threads/page.vue
+++ b/vue/src/components/threads/page.vue
@@ -78,14 +78,14 @@ v-main
         loading-content(:lineCount='2' v-for='(item, index) in [1,2,3]' :key='index' )
     div(v-else)
       section.threads-page__loaded
-        .threads-page__empty(v-if='threads.length == 0')
-          p(v-t="'threads_page.no_invite_only_threads'")
+        v-card.mb-3(v-if='threads.length == 0')
+          v-card-text(v-t="'threads_page.no_invite_only_threads'")
         .threads-page__collections(v-else)
           v-card.mb-3.thread-preview-collection__container
             v-list.thread-previews(lines="two")
               thread-preview(v-for="thread in threads", :key="thread.id", :thread="thread")
 
-      .d-flex.align-center.justify-center
+      .d-flex.align-center.justify-center(v-if='threads.length > 0')
         div
           p.text-center.text-medium-emphasis(v-t="{path: 'members_panel.loaded_of_total', args: {loaded: threads.length, total: loader.total}}")
           v-btn(v-if="!loader.exhausted" @click="loader.fetchRecords()", :loading="loader.loading", v-t="'common.action.load_more'")

--- a/vue/src/routes.js
+++ b/vue/src/routes.js
@@ -3,6 +3,7 @@ import GroupPage from './components/group/page.vue';
 import StrandPage from './components/strand/page';
 
 const InboxPage = wrapAsyncLoader(() => import('./components/inbox/page'));
+const PollsToVoteOnPage = wrapAsyncLoader(() => import('./components/dashboard/polls_to_vote_on_page'));
 const ExplorePage = wrapAsyncLoader(() => import('./components/explore/page'));
 const ProfilePage = wrapAsyncLoader(() => import('./components/profile/page'));
 const PollShowPage = wrapAsyncLoader(() => import('./components/poll/show_page'));
@@ -65,6 +66,7 @@ const router = createRouter({
     {path: '/tasks', component: TasksPage},
     {path: '/report', component: ReportPage},
     {path: '/dashboard', component: DashboardPage},
+    {path: '/dashboard/polls_to_vote_on', component: PollsToVoteOnPage},
     {path: '/dashboard/:filter', component: DashboardPage},
     {path: '/threads/direct', component: ThreadsPage},
     {path: '/inbox', component: InboxPage },


### PR DESCRIPTION
Hi @anarute - I would like feedback on this effort to make Polls to vote on more accessible. Happy to try another approach, but this might help? And it works when you're looking at other pages like discussions etc.

I've added "Polls to vote on" to the sidebar. It has a count like unread discussion, and will be bright when count > 0 and dim when not.

The dashboard continues to have a "Polls to vote on" section, but if you click the sidebar link, it takes you to a page with only polls to vote on.

Screenshot showing 1 poll to vote on
<img width="1307" height="739" alt="image" src="https://github.com/user-attachments/assets/fd99b9ea-7c59-4700-82f1-759c3720fa53" />

Screenshot showing polls to vote on page
<img width="1334" height="310" alt="image" src="https://github.com/user-attachments/assets/214e95a0-21e1-4a6c-992f-936a55296579" />

Screenshot showing no polls to vote on
<img width="717" height="400" alt="image" src="https://github.com/user-attachments/assets/9e12bc7b-3c54-4112-a96f-342adf540450" />

Changes in detail
- Convert sidebar/panel.vue to Vue 3 Composition API with <script setup>
- Implement pollsToVoteOnCount() method to count polls user can vote on
- Add new /dashboard/polls_to_vote_on page showing only votable polls
- Add polls_to_vote_on_count translation key with count parameter
- Update sidebar links to show counts with medium emphasis when zero
- Wrap empty states in v-cards for consistent styling across inbox, threads, and polls pages
- Fix inbox page group links to inherit text color
- Hide pagination when no items to display on threads page