### PR TITLE
Add LOOMIO_RESTRICT_EXPLORE_TO_SIGNED_IN_USERS

### DIFF
--- a/app/controllers/api/v1/groups_controller.rb
+++ b/app/controllers/api/v1/groups_controller.rb
@@ -1,4 +1,6 @@
 class Api::V1::GroupsController < Api::V1::RestfulController
+  before_action :require_signed_in_user_for_explore, only: [:index, :count_explore_results]
+
   def token
     self.resource = load_and_authorize(:group, :invite_people)
     respond_with_resource scope: {include_token: true, exclude_types: ['membership', 'user']}
@@ -71,6 +73,10 @@ class Api::V1::GroupsController < Api::V1::RestfulController
   end
 
   private
+
+  def require_signed_in_user_for_explore
+    require_current_user if AppConfig.app_features[:restrict_explore_to_signed_in_users]
+  end
 
   def ensure_photo_params
     params.require(:file)

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,4 +1,6 @@
 class GroupsController < ApplicationController
+  before_action :require_signed_in_user_for_explore, only: [:index]
+
   def index
     @groups = Queries::ExploreGroups.new.search_for(params[:q]).order('groups.memberships_count DESC')
     @total = @groups.count
@@ -22,5 +24,11 @@ class GroupsController < ApplicationController
     respond_to do |format|
       format.html
     end
+  end
+
+  private
+
+  def require_signed_in_user_for_explore
+    require_current_user if AppConfig.app_features[:restrict_explore_to_signed_in_users]
   end
 end

--- a/app/extras/app_config.rb
+++ b/app/extras/app_config.rb
@@ -135,6 +135,7 @@ class AppConfig
       example_content: !ENV['FEATURES_DISABLE_EXAMPLE_CONTENT'],
       thread_from_mail: !ENV['FEATURES_DISABLE_THREAD_FROM_MAIL'],
       explore_public_groups: ENV.fetch('FEATURES_EXPLORE_PUBLIC_GROUPS', false),
+      restrict_explore_to_signed_in_users: ENV.fetch('LOOMIO_RESTRICT_EXPLORE_TO_SIGNED_IN_USERS', false),
       template_gallery: ENV.fetch('FEATURES_TEMPLATE_GALLERY', false),
       show_contact: ENV.fetch('FEATURES_SHOW_CONTACT', false),
       show_contact_consent: ENV.fetch('FEATURES_SHOW_CONTACT_CONSENT', false),

--- a/spec/controllers/api/v1/groups_controller_spec.rb
+++ b/spec/controllers/api/v1/groups_controller_spec.rb
@@ -252,4 +252,63 @@ describe Api::V1::GroupsController do
     end
   end
 
+  describe 'LOOMIO_RESTRICT_EXPLORE_TO_SIGNED_IN_USERS' do
+    let(:explore_group) { create(:group, group_privacy: 'open', listed_in_explore: true) }
+
+    before do
+      explore_group.update_attribute(:memberships_count, 5)
+      explore_group.update_attribute(:discussions_count, 3)
+      explore_group.subscription = Subscription.create(plan: 'trial', state: 'active')
+      explore_group.save
+    end
+
+    context 'when restriction is disabled' do
+      before do
+        allow(AppConfig).to receive(:app_features).and_return({ restrict_explore_to_signed_in_users: false })
+      end
+
+      it 'allows logged out users to access index' do
+        get :index, params: { q: 'test' }
+        expect(response.status).to eq 200
+      end
+
+      it 'allows logged out users to access count_explore_results' do
+        get :count_explore_results, params: { q: 'test' }
+        expect(response.status).to eq 200
+      end
+    end
+
+    context 'when restriction is enabled' do
+      before do
+        allow(AppConfig).to receive(:app_features).and_return({ restrict_explore_to_signed_in_users: true })
+      end
+
+      it 'prevents logged out users from accessing index' do
+        get :index, params: { q: 'test' }
+        expect(response.status).to eq 401
+        json = JSON.parse(response.body)
+        expect(json['error']).to eq 'you gotta be signed in'
+      end
+
+      it 'prevents logged out users from accessing count_explore_results' do
+        get :count_explore_results, params: { q: 'test' }
+        expect(response.status).to eq 401
+        json = JSON.parse(response.body)
+        expect(json['error']).to eq 'you gotta be signed in'
+      end
+
+      it 'allows signed in users to access index' do
+        sign_in user
+        get :index, params: { q: 'test' }
+        expect(response.status).to eq 200
+      end
+
+      it 'allows signed in users to access count_explore_results' do
+        sign_in user
+        get :count_explore_results, params: { q: 'test' }
+        expect(response.status).to eq 200
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
When LOOMIO_RESTRICT_EXPLORE_TO_SIGNED_IN_USERS is set, the explore page and related API endpoints will require users to be signed in. Unauthenticated users will receive a 401 error.