### PR TITLE
Add app feature to mask participants in anon poll receipts

### DIFF
--- a/app/extras/app_config.rb
+++ b/app/extras/app_config.rb
@@ -131,6 +131,7 @@ class AppConfig
       create_user: !ENV['FEATURES_DISABLE_CREATE_USER'],
       create_group: !ENV['FEATURES_DISABLE_CREATE_GROUP'],
       public_groups: !ENV['FEATURES_DISABLE_PUBLIC_GROUPS'],
+      mask_anonymous_participants: !!ENV['FEATURES_MASK_ANONYMOUS_PARTICIPANTS'],
       help_link: !ENV['FEATURES_DISABLE_HELP_LINK'],
       example_content: !ENV['FEATURES_DISABLE_EXAMPLE_CONTENT'],
       thread_from_mail: !ENV['FEATURES_DISABLE_THREAD_FROM_MAIL'],


### PR DESCRIPTION
This PR adds an app feature, configured by a `FEATURES_MASK_ANONYMOUS_PARTICIPANTS` environment variable, to remove information on individuals from anonymous poll receipts, when the receipt is generated by a non-admin.

With the addition of verified participants this option is important for us as a mass political organization. We routinely use loomio polls to make decisions and need a way to do so that does not leak identifying information of members to any participant.

This PR also adds a few tests for the new functionality, which pass, but we have not tested it end to end just yet with the frontend.

Feedback is also (of course) welcome on approach. I was learning ruby on rails and the stack on the fly here.