### PR TITLE
Fix duplicate events keys in JSON responses causing lost data

### DIFF
--- a/app/serializers/discussion_serializer.rb
+++ b/app/serializers/discussion_serializer.rb
@@ -54,8 +54,8 @@ class DiscussionSerializer < ApplicationSerializer
   has_one :author, serializer: AuthorSerializer, root: :users
   has_one :group, serializer: GroupSerializer, root: :groups
   has_many :active_polls, serializer: PollSerializer, root: :polls
-  has_one :created_event, serializer: EventSerializer, root: :events
-  has_one :forked_event, serializer: EventSerializer, root: :events
+  has_one :created_event, serializer: EventSerializer, root: :parent_events
+  has_one :forked_event, serializer: EventSerializer, root: :parent_events
   has_one :closer, serializer: AuthorSerializer, root: :users
   has_one :translation, serializer: TranslationSerializer, root: :translations
   hide_when_discarded [:description, :title]

--- a/app/serializers/poll_serializer.rb
+++ b/app/serializers/poll_serializer.rb
@@ -59,7 +59,7 @@ class PollSerializer < ApplicationSerializer
              :quorum_votes_required
 
   has_one :discussion, serializer: DiscussionSerializer, root: :discussions
-  has_one :created_event, serializer: EventSerializer, root: :events
+  has_one :created_event, serializer: EventSerializer, root: :parent_events
   has_one :group, serializer: GroupSerializer, root: :groups
   has_one :author, serializer: AuthorSerializer, root: :users
   has_one :current_outcome, serializer: OutcomeSerializer, root: :outcomes

--- a/test/controllers/api/v1/discussions_controller_test.rb
+++ b/test/controllers/api/v1/discussions_controller_test.rb
@@ -417,7 +417,7 @@ class Api::V1::DiscussionsControllerTest < ActionController::TestCase
     assert_not_nil discussion.reload.closed_at
     
     json = JSON.parse(response.body)
-    assert_includes json.keys, 'events'
+    assert_includes json.keys, 'parent_events'
   end
 
   test "does not allow non-admins to close a thread" do
@@ -458,7 +458,7 @@ class Api::V1::DiscussionsControllerTest < ActionController::TestCase
     assert_nil discussion.reload.closed_at
     
     json = JSON.parse(response.body)
-    assert_includes json.keys, 'events'
+    assert_includes json.keys, 'parent_events'
   end
 
   test "does not allow non-admins to reopen a thread" do

--- a/vue/src/shared/loaders/thread_loader.js
+++ b/vue/src/shared/loaders/thread_loader.js
@@ -132,7 +132,7 @@ export default class ThreadLoader {
         find: {
           actorId: AppConfig.currentUserId,
           discussionId: this.discussion.id,
-          createdAt: { $gte: new Date() }
+          createdAt: { $gte: this.discussion.createdAt }
         }
       }
     })


### PR DESCRIPTION
Sideloaded created_event from DiscussionSerializer and PollSerializer used root: :events, conflicting with the primary events root key. JSON.parse behavior for duplicate keys is implementation-defined, so the new_comment event could be silently dropped, causing comments to not appear and a "load more 0" button to show instead.

Changed to root: :parent_events which the client already handles.