### PR TITLE
Add Notion integration and rename Chatbots to Integrations in UI

### DIFF
--- a/app/controllers/api/v1/chatbots_controller.rb
+++ b/app/controllers/api/v1/chatbots_controller.rb
@@ -10,6 +10,21 @@ class Api::V1::ChatbotsController < Api::V1::RestfulController
     head :ok
   end
 
+  def create_notion_database
+    client = Clients::Notion.new(access_token: params[:access_token])
+    response = client.create_database(
+      page_id: params[:page_id],
+      title: params[:title] || "Loomio Decisions"
+    )
+
+    if response.success?
+      render json: { database_id: response.parsed_response["id"] }
+    else
+      render json: { error: response.parsed_response&.dig("message") || "Failed to create database" },
+             status: :unprocessable_entity
+    end
+  end
+
   def index_scope
     default_scope.merge({ current_user_is_admin: @group.admins.exists?(current_user.id)})
   end

--- a/app/extras/clients/notion.rb
+++ b/app/extras/clients/notion.rb
@@ -1,0 +1,96 @@
+class Clients::Notion
+  NOTION_API_VERSION = "2022-06-28"
+  NOTION_BASE_URL = "https://api.notion.com/v1"
+
+  DATABASE_PROPERTIES = {
+    "Title"  => { title: {} },
+    "Event"  => { rich_text: {} },
+    "Author" => { rich_text: {} },
+    "URL"    => { url: {} },
+    "Group"  => { rich_text: {} },
+    "Type"   => { select: {} },
+    "Status" => { select: {} },
+    "Closing" => { date: {} }
+  }.freeze
+
+  def initialize(access_token:)
+    @access_token = access_token
+  end
+
+  def create_database(page_id:, title:)
+    response = HTTParty.post(
+      "#{NOTION_BASE_URL}/databases",
+      headers: headers,
+      body: {
+        parent: { type: "page_id", page_id: page_id },
+        title: [{ type: "text", text: { content: title } }],
+        properties: DATABASE_PROPERTIES
+      }.to_json
+    )
+
+    unless response.success?
+      Rails.logger.error "Notion API error: #{response.code} #{response.body}"
+    end
+
+    response
+  end
+
+  def create_page(database_id:, properties:)
+    response = HTTParty.post(
+      "#{NOTION_BASE_URL}/pages",
+      headers: headers,
+      body: {
+        parent: { database_id: database_id },
+        properties: properties
+      }.to_json
+    )
+
+    unless response.success?
+      Rails.logger.error "Notion API error: #{response.code} #{response.body}"
+    end
+
+    response
+  end
+
+  def update_page(page_id:, properties:)
+    response = HTTParty.patch(
+      "#{NOTION_BASE_URL}/pages/#{page_id}",
+      headers: headers,
+      body: { properties: properties }.to_json
+    )
+
+    unless response.success?
+      Rails.logger.error "Notion API error: #{response.code} #{response.body}"
+    end
+
+    response
+  end
+
+  def find_page_by_loomio_id(database_id:, loomio_url:)
+    response = HTTParty.post(
+      "#{NOTION_BASE_URL}/databases/#{database_id}/query",
+      headers: headers,
+      body: {
+        filter: {
+          property: "URL",
+          url: { equals: loomio_url }
+        }
+      }.to_json
+    )
+
+    return nil unless response.success?
+
+    results = response.parsed_response["results"]
+    results&.first
+  end
+
+  private
+
+  def headers
+    {
+      "Authorization" => "Bearer #{@access_token}",
+      "Content-Type" => "application/json",
+      "Notion-Version" => NOTION_API_VERSION
+    }
+  end
+end

--- a/app/models/chatbot.rb
+++ b/app/models/chatbot.rb
@@ -5,7 +5,7 @@ class Chatbot < ApplicationRecord
   validates_presence_of :server
   validates_presence_of :name
   validates_inclusion_of :kind, in: ['matrix', 'webhook']
-  validates_inclusion_of :webhook_kind, in: ['slack', 'microsoft', 'discord', 'markdown', 'webex', nil]
+  validates_inclusion_of :webhook_kind, in: ['slack', 'microsoft', 'discord', 'markdown', 'webex', 'notion', nil]
 
   def config
     {

--- a/app/serializers/webhook/notion/event_serializer.rb
+++ b/app/serializers/webhook/notion/event_serializer.rb
@@ -1,0 +1,89 @@
+class Webhook::Notion::EventSerializer < ActiveModel::Serializer
+  include PrettyUrlHelper
+
+  # Returns Notion page properties hash for creating/updating a database row
+  attributes :properties, :description
+
+  def properties
+    props = {
+      "Title" => title_property,
+      "Event" => select_property(event_label),
+      "Author" => rich_text_property(user.name),
+      "URL" => url_property(event_url),
+      "Group" => rich_text_property(object.eventable.group.full_name)
+    }
+
+    if poll
+      props["Type"] = select_property(poll.poll_type.titleize)
+      props["Status"] = select_property(poll_status)
+      props["Closing"] = date_property(poll.closing_at) if poll.closing_at
+    end
+
+    props
+  end
+
+  def description
+    body = object.eventable.respond_to?(:body) ? object.eventable.body : nil
+    body.present? ? body.truncate(2000) : nil
+  end
+
+  private
+
+  def poll
+    @poll ||= if %w[Poll Stance Outcome].include?(object.eventable_type)
+      object.eventable.poll
+    end
+  end
+
+  def user
+    object.user || object.eventable.author
+  end
+
+  def event_url
+    polymorphic_url(object.eventable)
+  end
+
+  def event_label
+    I18n.t("notifications.without_title.#{object.kind}",
+           actor: user.name,
+           title: object.eventable.title_model.title,
+           poll_type: poll ? I18n.t("poll_types.#{poll.poll_type}") : nil,
+           site_name: AppConfig.theme[:site_name])
+        .gsub(/\[|\]/, '')
+        .gsub(/\(http[^\)]*\)/, '')
+        .strip
+        .truncate(100)
+  end
+
+  def poll_status
+    if poll.closed?
+      "Closed"
+    elsif poll.active?
+      "Open"
+    elsif poll.scheduled?
+      "Scheduled"
+    else
+      "Draft"
+    end
+  end
+
+  def title_property
+    { title: [{ text: { content: object.eventable.title_model.title.truncate(100) } }] }
+  end
+
+  def select_property(value)
+    { select: { name: value.truncate(100) } }
+  end
+
+  def rich_text_property(value)
+    { rich_text: [{ text: { content: value.to_s.truncate(2000) } }] }
+  end
+
+  def url_property(value)
+    { url: value }
+  end
+
+  def date_property(value)
+    { date: { start: value.iso8601 } }
+  end
+end

--- a/app/services/chatbot_service.rb
+++ b/app/services/chatbot_service.rb
@@ -44,7 +44,9 @@ class ChatbotService
                                     date_time_pref: example_user.date_time_pref)
 
       I18n.with_locale(recipient.locale) do
-        if chatbot.kind == "webhook"
+        if chatbot.webhook_kind == "notion"
+          publish_to_notion!(chatbot, event, template_name, recipient)
+        elsif chatbot.kind == "webhook"
           serializer = "Webhook::#{chatbot.webhook_kind.classify}::EventSerializer".constantize
           payload = serializer.new(event, root: false, scope: {template_name: template_name, recipient: recipient}).as_json
           req = Clients::Webhook.new.post(chatbot.server, params: payload)
@@ -58,6 +60,28 @@ class ChatbotService
           matrix_client.send_html(chatbot.channel, html)
         end
       end
+    end
+  end
+
+  def self.publish_to_notion!(chatbot, event, template_name, recipient)
+    serializer = Webhook::Notion::EventSerializer.new(event, root: false, scope: {template_name: template_name, recipient: recipient})
+    payload = serializer.as_json
+    properties = payload["properties"]
+    event_url = properties.dig("URL", "url")
+
+    client = Clients::Notion.new(access_token: chatbot.access_token)
+
+    # Update existing page if one exists for this URL, otherwise create
+    existing = event_url && client.find_page_by_loomio_id(database_id: chatbot.channel, loomio_url: event_url)
+
+    if existing
+      response = client.update_page(page_id: existing["id"], properties: properties)
+    else
+      response = client.create_page(database_id: chatbot.channel, properties: properties)
+    end
+
+    unless response.success?
+      Sentry.capture_message("chatbot id #{chatbot.id} notion post event id #{event.id} failed: code: #{response.code} body: #{response.body}")
     end
   end
 
@@ -103,6 +127,14 @@ class ChatbotService
     case params[:kind]
     when 'slack_webhook'
       Clients::Webhook.new.post(params[:server], params: {text: I18n.t('chatbot.connection_test_successful')})
+    when 'notion'
+      client = Clients::Notion.new(access_token: params[:access_token])
+      client.create_page(
+        database_id: params[:channel],
+        properties: {
+          "Title" => { title: [{ text: { content: I18n.t('chatbot.connection_test_successful') } }] }
+        }
+      )
     else
       matrix_client = Clients::Matrix.new(server: params[:server], access_token: params[:access_token])
       message = I18n.t('chatbot.connection_test_successful', group: params[:group_name])

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2660,9 +2660,33 @@ en:
     discord: Discord
     mattermost: Mattermost
     microsoft_teams: Microsoft Teams
+    notion: Notion
+    notion_helptext: Connect Loomio to a Notion database to automatically log decisions and discussions. Create a Notion integration at notion.so/profile/integrations, then share your target page with it.
+    notion_api_token: Notion API token
+    notion_api_token_hint: "Create at notion.so/profile/integrations — starts with ntn_"
+    notion_database_id: Notion database ID
+    notion_database_id_hint: Found in the database URL between the workspace name and the question mark
+    notion_page_id: Notion page ID
+    notion_page_id_hint: The ID of the page where the database will be created. Find it in the page URL.
+    notion_create_new_database: Create new database
+    notion_use_existing_database: Use existing database
+    notion_create_database_btn: Create Loomio database in Notion
+    notion_database_created: Notion database created successfully!
+    notion_database_create_failed: "Failed to create Notion database. Check your API token and that the page is shared with your integration."
+    notion_test_success: Check your Notion database for a test entry!
     event_kind_helptext: Select events the bot will always be notified about. If you're not sure, just leave them all off.
     notification_only_label: Send notification headline only
     check_for_test_message: Check your chatroom for a message from the bot!
+    integration: Integration
+    integrations: Integrations
+    add_integration: Add integration
+    integration_name: Integration name
+    integration_saved: Integration saved!
+    configure_integration: Configure integration
+    integration_event_kind_helptext: Select events this integration will be notified about. If you're not sure, just leave them all off.
+    integration_notification_only_label: Send notification headline only
+    check_for_test_notification: Check your service for a test notification!
+    integration_connection_test_successful: Loomio connection test successful!
   webhook:
     integrations: Integrations
     api_keys: API keys

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -68,6 +68,7 @@ Rails.application.routes.draw do
       resources :webhooks, only: [:create, :destroy, :index, :update]
       resources :chatbots, only: [:create, :destroy, :index, :update] do
         post :check, on: :collection
+        post :create_notion_database, on: :collection
       end
 
       resources :boot, only: [] do

--- a/vue/src/components/chatbot/list.vue
+++ b/vue/src/components/chatbot/list.vue
@@ -15,7 +15,7 @@ export default {
   data() {
     return {
       chatbots: [],
-      kinds: ['matrix', 'slack', 'discord', 'mattermost', 'teams', 'webex'],
+      kinds: ['matrix', 'slack', 'discord', 'mattermost', 'teams', 'webex', 'notion'],
       loading: true,
       addActions: {},
       icons: {
@@ -24,7 +24,8 @@ export default {
         discord: 'mdi-discord',
         mattermost: 'mdi-chat-processing',
         teams: 'mdi-microsoft-teams',
-        webex: 'webex'
+        webex: 'webex',
+        notion: 'mdi-note-text-outline'
       }
     };
   },
@@ -50,28 +51,25 @@ export default {
     },
 
     editChatbot(bot) {
-      if (bot.kind === "webhook") {
-        EventBus.$emit('openModal', {
-          component: 'ChatbotWebhookForm',
-          props: {
-            chatbot: bot
-          }
-        });
+      let component;
+      if (bot.webhookKind === "notion") {
+        component = 'ChatbotNotionForm';
+      } else if (bot.kind === "webhook") {
+        component = 'ChatbotWebhookForm';
       } else {
-        EventBus.$emit('openModal', {
-          component: 'ChatbotMatrixForm',
-          props: {
-            chatbot: bot
-          }
-        });
+        component = 'ChatbotMatrixForm';
       }
+      EventBus.$emit('openModal', {
+        component: component,
+        props: { chatbot: bot }
+      });
     }
   }
 };
 
 </script>
 <template lang="pug">
-v-card.chatbot-list(:title="$t('chatbot.chatbots')")
+v-card.chatbot-list(:title="$t('chatbot.integrations')")
   template(v-slot:append)
     dismiss-modal-button
   v-card-text
@@ -81,7 +79,7 @@ v-card.chatbot-list(:title="$t('chatbot.chatbots')")
         v-list-item-title {{bot.name}}
         v-list-item-subtitle {{bot.kind}} {{bot.server}} {{bot.channel}}
   v-card-actions
-    help-btn(path='en/user_manual/groups/integrations/chatbots')
+    help-btn(path='en/user_manual/groups/integrations')
     v-spacer
-    action-menu(:actions='addActions' :name="$t('chatbot.add_chatbot')")
+    action-menu(:actions='addActions' :name="$t('chatbot.add_integration')")
 </template>

--- a/vue/src/components/chatbot/matrix_form.vue
+++ b/vue/src/components/chatbot/matrix_form.vue
@@ -20,7 +20,7 @@ export default {
     submit() {
       this.chatbot.save()
       .then(() => {
-        Flash.success('chatbot.saved');
+        Flash.success('chatbot.integration_saved');
         EventBus.$emit('closeModal');
       }).catch(b => {
         Flash.error('common.something_went_wrong');
@@ -46,7 +46,7 @@ export default {
         channel: this.chatbot.channel,
         group_name: "group name was here"
       }).finally(() => {
-        Flash.success('chatbot.check_for_test_message');
+        Flash.success('chatbot.check_for_test_notification');
         this.testing = false;
       });
     }
@@ -55,11 +55,11 @@ export default {
 
 </script>
 <template lang="pug">
-v-card.chatbot-matrix-form(:title="$t('chatbot.chatbot')")
+v-card.chatbot-matrix-form(:title="$t('chatbot.integration')")
   template(v-slot:append)
     dismiss-modal-button
   v-card-text
-    v-text-field(:label="$t('chatbot.name')" v-model="chatbot.name" hint="The name of your chatroom")
+    v-text-field(:label="$t('chatbot.integration_name')" v-model="chatbot.name" hint="The name of your chatroom")
     v-text-field(:label="$t('chatbot.homeserver_url')"  v-model="chatbot.server" hint="https://example.com")
     v-text-field(
       :label="$t('chatbot.access_token')"
@@ -74,10 +74,10 @@ v-card.chatbot-matrix-form(:title="$t('chatbot.chatbot')")
       
     v-checkbox.webhook-form__include-body(
       v-model="chatbot.notificationOnly", 
-      :label="$t('chatbot.notification_only_label')" 
+      :label="$t('chatbot.integration_notification_only_label')"
       hide-details)
 
-    p.mt-4.text-medium-emphasis(v-t="'chatbot.event_kind_helptext'")
+    p.mt-4.text-medium-emphasis(v-t="'chatbot.integration_event_kind_helptext'")
 
     v-checkbox.webhook-form__event-kind(
       hide-details 

--- a/vue/src/components/chatbot/notion_form.vue
+++ b/vue/src/components/chatbot/notion_form.vue
@@ -1,0 +1,145 @@
+<script lang="js">
+import EventBus from '@/shared/services/event_bus';
+import AppConfig from '@/shared/services/app_config';
+import Records from '@/shared/services/records';
+import Flash  from '@/shared/services/flash';
+
+export default {
+  props: {
+    chatbot: Object
+  },
+
+  data() {
+    return {
+      kinds: AppConfig.webhookEventKinds,
+      testing: false,
+      creatingDatabase: false,
+      useExistingDatabase: !!this.chatbot.channel,
+      pageId: ''
+    };
+  },
+
+  methods: {
+    submit() {
+      this.chatbot.save()
+      .then(() => {
+        Flash.success('chatbot.integration_saved');
+        EventBus.$emit('closeModal');
+      }).catch(b => {
+        Flash.warning('common.check_for_errors_and_try_again');
+      });
+    },
+
+    destroy() {
+      this.chatbot.destroy().then(() => {
+        Flash.success('poll_common_delete_modal.success');
+        EventBus.$emit('closeModal');
+      }).catch(b => {
+        Flash.error('common.something_went_wrong');
+        console.log(this.chatbot.errors);
+      });
+    },
+
+    createDatabase() {
+      this.creatingDatabase = true;
+      Records.remote.post('chatbots/create_notion_database', {
+        access_token: this.chatbot.accessToken,
+        page_id: this.pageId,
+        title: this.chatbot.name || 'Loomio Decisions'
+      }).then((response) => {
+        this.chatbot.channel = response.database_id;
+        Flash.success('chatbot.notion_database_created');
+      }).catch(() => {
+        Flash.error('chatbot.notion_database_create_failed');
+      }).finally(() => {
+        this.creatingDatabase = false;
+      });
+    },
+
+    testConnection() {
+      this.testing = true;
+      Records.remote.post('chatbots/check', {
+        kind: 'notion',
+        access_token: this.chatbot.accessToken,
+        channel: this.chatbot.channel
+      }).then(() => {
+        Flash.success('chatbot.notion_test_success');
+      }).catch(() => {
+        Flash.error('common.something_went_wrong');
+      }).finally(() => {
+        this.testing = false;
+      });
+    }
+  }
+};
+
+</script>
+<template lang="pug">
+v-card.chatbot-notion-form(:title="$t('chatbot.notion')")
+  template(v-slot:append)
+    dismiss-modal-button
+  v-card-text
+    p.text-body-2.text-medium-emphasis {{ $t('chatbot.notion_helptext') }}
+
+    v-text-field(
+      :label="$t('chatbot.integration_name')"
+      v-model="chatbot.name"
+      autocomplete="off")
+    validation-errors(:subject="chatbot" field="name")
+
+    v-text-field(
+      :label="$t('chatbot.notion_api_token')"
+      v-model="chatbot.accessToken"
+      autocomplete="off"
+      placeholder="ntn_..."
+      :hint="$t('chatbot.notion_api_token_hint')")
+    validation-errors(:subject="chatbot" field="access_token")
+
+    v-radio-group.mt-2(v-if="!chatbot.id" v-model="useExistingDatabase" inline hide-details)
+      v-radio(:label="$t('chatbot.notion_create_new_database')" :value="false")
+      v-radio(:label="$t('chatbot.notion_use_existing_database')" :value="true")
+
+    template(v-if="useExistingDatabase || chatbot.id")
+      v-text-field(
+        :label="$t('chatbot.notion_database_id')"
+        v-model="chatbot.channel"
+        autocomplete="off"
+        placeholder="e.g. 8a3b5c7d-1234-5678-9abc-def012345678"
+        :hint="$t('chatbot.notion_database_id_hint')")
+      validation-errors(:subject="chatbot" field="channel")
+
+    template(v-if="!useExistingDatabase && !chatbot.id")
+      v-text-field(
+        :label="$t('chatbot.notion_page_id')"
+        v-model="pageId"
+        autocomplete="off"
+        placeholder="e.g. 8a3b5c7d-1234-5678-9abc-def012345678"
+        :hint="$t('chatbot.notion_page_id_hint')")
+      v-btn.mt-2(
+        @click="createDatabase"
+        :loading="creatingDatabase"
+        :disabled="!chatbot.accessToken || !pageId"
+        variant="tonal")
+        span(v-t="'chatbot.notion_create_database_btn'")
+
+    v-checkbox.webhook-form__include-body(
+      v-model="chatbot.notificationOnly",
+      :label="$t('chatbot.integration_notification_only_label')"
+      hide-details)
+
+    p.mt-4.text-medium-emphasis(v-t="'chatbot.integration_event_kind_helptext'")
+
+    v-checkbox.webhook-form__event-kind(
+      hide-details
+      v-for='kind in kinds'
+      v-model='chatbot.eventKinds'
+      :key="kind"
+      :label="$t('webhook.event_kinds.' + kind)"
+      :value="kind")
+
+  v-card-actions
+    v-btn(v-if="chatbot.id" @click='destroy' v-t="'common.action.delete'")
+    v-spacer
+    v-btn(v-if="chatbot.channel" @click='testConnection' v-t="'chatbot.test_connection'" :loading="testing")
+    v-btn(color='primary' @click='submit' :disabled="!chatbot.channel" v-t="'common.action.save'")
+</template>

--- a/vue/src/components/chatbot/webhook_form.vue
+++ b/vue/src/components/chatbot/webhook_form.vue
@@ -36,7 +36,7 @@ export default {
 
     submit() {
       this.chatbot.save().then(() => {
-        Flash.success('chatbot.saved');
+        Flash.success('chatbot.integration_saved');
         EventBus.$emit('closeModal');
       }).catch(b => {
         Flash.warning('common.check_for_errors_and_try_again');
@@ -49,7 +49,7 @@ export default {
         server: this.chatbot.server,
         kind: 'slack_webhook'
       }).finally(() => {
-        Flash.success('chatbot.check_for_test_message');
+        Flash.success('chatbot.check_for_test_notification');
         this.testing = false;
       });
     }
@@ -70,12 +70,12 @@ export default {
 
 </script>
 <template lang="pug">
-v-card.chatbot-matrix-form(:title="'Webhook ' + $t('chatbot.chatbot')")
+v-card.chatbot-matrix-form(:title="$t('chatbot.integration')")
   template(v-slot:append)
     dismiss-modal-button
   v-card-text
     v-text-field(
-      :label="$t('chatbot.name')"
+      :label="$t('chatbot.integration_name')"
       autocomplete="off"
       v-model="chatbot.name"
       hint="The name of your chatroom")
@@ -92,9 +92,9 @@ v-card.chatbot-matrix-form(:title="'Webhook ' + $t('chatbot.chatbot')")
 
     v-checkbox.webhook-form__include-body(
       v-model="chatbot.notificationOnly",
-      :label="$t('chatbot.notification_only_label')"
+      :label="$t('chatbot.integration_notification_only_label')"
       hide-details)
-    p.mt-4.text-medium-emphasis(v-t="'chatbot.event_kind_helptext'")
+    p.mt-4.text-medium-emphasis(v-t="'chatbot.integration_event_kind_helptext'")
 
     v-checkbox.webhook-form__event-kind(
       hide-details

--- a/vue/src/shared/services/chatbot_service.js
+++ b/vue/src/shared/services/chatbot_service.js
@@ -119,6 +119,26 @@ export default new class ChatbotService {
           });
         }
       },
+
+      notion: {
+        name: 'chatbot.notion',
+        icon: 'mdi-note-text-outline',
+        menu: true,
+        canPerform() { return true; },
+        perform() {
+          return openModal({
+            component: 'ChatbotNotionForm',
+            props: {
+              chatbot: Records.chatbots.build({
+                groupId: group.id,
+                kind: "webhook",
+                webhookKind: "notion",
+                server: "https://api.notion.com"
+              })
+            }
+          });
+        }
+      },
     };
   }
 };

--- a/vue/src/shared/services/group_service.js
+++ b/vue/src/shared/services/group_service.js
@@ -133,8 +133,8 @@ export default new class GroupService {
       },
 
       chatbots: {
-        name: 'chatbot.chatbots',
-        icon: 'mdi-robot',
+        name: 'chatbot.integrations',
+        icon: 'mdi-connection',
         menu: true,
         canPerform() {
           return group.adminsInclude(Session.user());


### PR DESCRIPTION
- Add Clients::Notion for Notion API (create/update pages, create databases, query by URL)
- Add Webhook::Notion::EventSerializer to map Loomio events to Notion database properties
- Add Notion form Vue component with option to auto-create database or use existing
- Add create_notion_database API endpoint for one-click database setup
- Rename user-facing "Chatbots" to "Integrations" using new i18n keys (preserves existing translated keys)
- Update all chat integration forms to use new integration terminology