### PR TITLE
Add calendar RSVP voting for proposal polls

### DIFF
--- a/app/mailboxes/received_email_mailbox.rb
+++ b/app/mailboxes/received_email_mailbox.rb
@@ -1,5 +1,9 @@
 class ReceivedEmailMailbox < ApplicationMailbox
   def process
+    # Handle calendar RSVP replies (Accept/Decline/Maybe on proposal invites)
+    # before building a ReceivedEmail, since these are often auto-generated
+    return if CalendarRsvpService.process(mail)
+
     email = build_received_email
 
     if !email.is_addressed_to_loomio? || email.is_auto_response?

--- a/app/mailers/event_mailer.rb
+++ b/app/mailers/event_mailer.rb
@@ -54,6 +54,15 @@ class EventMailer < ApplicationMailer
       }
     end
 
+    if poll&.poll_type == 'proposal' && poll.active? && poll.closing_at && recipient.is_logged_in?
+      reply_to = reply_to_address(model: event.eventable, user: recipient)
+      ics = CalendarRsvpService.build_ics(poll: poll, recipient: recipient, reply_to: reply_to)
+      attachments['proposal.ics'] = {
+        content_type: 'text/calendar; method=REQUEST',
+        content: ics
+      }
+    end
+
     # this should be notification.i18n_key
     event_key = self.class.event_key_for(event, recipient)
 

--- a/app/services/calendar_rsvp_service.rb
+++ b/app/services/calendar_rsvp_service.rb
@@ -1,0 +1,102 @@
+class CalendarRsvpService
+  include PrettyUrlHelper
+
+  PARTSTAT_TO_ICON = {
+    'ACCEPTED' => 'agree',
+    'DECLINED' => 'disagree',
+    'TENTATIVE' => 'abstain'
+  }.freeze
+
+  # Generate an ICS calendar invite for a proposal poll notification
+  def self.build_ics(poll:, recipient:, reply_to:)
+    new.build_ics(poll: poll, recipient: recipient, reply_to: reply_to)
+  end
+
+  def build_ics(poll:, recipient:, reply_to:)
+    calendar = Icalendar::Calendar.new
+    calendar.append_custom_property("METHOD", "REQUEST")
+
+    calendar.event do |event|
+      event.uid = "loomio-poll-#{poll.id}@#{ENV['CANONICAL_HOST']}"
+      event.dtstart = Icalendar::Values::DateTime.new(poll.created_at.utc, tzid: 'UTC')
+      event.dtend = Icalendar::Values::DateTime.new(poll.closing_at.utc, tzid: 'UTC')
+      event.summary = poll.title
+      event.description = poll_url(poll)
+      event.organizer = Icalendar::Values::CalAddress.new(
+        "mailto:#{reply_to}",
+        cn: poll.author.name
+      )
+      event.attendee = Icalendar::Values::CalAddress.new(
+        "mailto:#{recipient.email}",
+        cn: recipient.name,
+        "PARTSTAT" => "NEEDS-ACTION",
+        "RSVP" => "TRUE"
+      )
+      event.ip_class = "PRIVATE"
+      event.url = poll_url(poll)
+    end
+
+    calendar.to_ical
+  end
+
+  # Process an inbound calendar RSVP reply email
+  # Returns true if handled, false if not a calendar RSVP
+  def self.process(mail)
+    calendar_part = mail.parts.find { |part| part.content_type&.include?('text/calendar') }
+    return false unless calendar_part
+
+    calendars = Icalendar::Calendar.parse(calendar_part.decoded)
+    calendar = calendars.first
+    return false unless calendar
+
+    return false unless calendar.ip_method.to_s.upcase == "REPLY"
+
+    event = calendar.events.first
+    return false unless event
+
+    uid = event.uid.to_s
+    return false unless uid.match?(/\Aloomio-poll-\d+@/)
+
+    poll_id = uid.match(/\Aloomio-poll-(\d+)@/)[1].to_i
+    poll = Poll.find_by(id: poll_id)
+    return false unless poll&.active? && poll.poll_type == 'proposal'
+
+    partstat = extract_partstat(event)
+    return false unless partstat && PARTSTAT_TO_ICON.key?(partstat)
+
+    sender_email = mail.from&.first&.downcase
+    actor = User.find_by(email: sender_email)
+    return false unless actor
+
+    icon = PARTSTAT_TO_ICON[partstat]
+    poll_option = poll.poll_options.find { |o| o.icon == icon }
+    return false unless poll_option
+
+    cast_vote(poll: poll, poll_option: poll_option, actor: actor)
+    true
+  rescue => e
+    Rails.logger.error("CalendarRsvpService error: #{e.class} #{e.message}")
+    false
+  end
+
+  private
+
+  def self.extract_partstat(event)
+    attendee = Array(event.attendee).first
+    return nil unless attendee
+    Array(attendee.ical_params["partstat"]).first&.upcase
+  end
+
+  def self.cast_vote(poll:, poll_option:, actor:)
+    stance = poll.stances.latest.find_by(participant: actor)
+    return unless stance
+
+    StanceService.update(
+      stance: stance,
+      actor: actor,
+      params: {
+        stance_choices_attributes: [{ poll_option_id: poll_option.id, score: 1 }]
+      }
+    )
+  end
+end

--- a/app/services/calendar_rsvp_service.rb
+++ b/app/services/calendar_rsvp_service.rb
@@ -64,8 +64,7 @@ class CalendarRsvpService
     partstat = extract_partstat(event)
     return false unless partstat && PARTSTAT_TO_ICON.key?(partstat)
 
-    sender_email = mail.from&.first&.downcase
-    actor = User.find_by(email: sender_email)
+    actor = actor_from_mail(mail)
     return false unless actor
 
     icon = PARTSTAT_TO_ICON[partstat]
@@ -80,6 +79,17 @@ class CalendarRsvpService
   end
 
   private
+
+  def self.actor_from_mail(mail)
+    reply_hostnames = [ENV['REPLY_HOSTNAME'], ENV['OLD_REPLY_HOSTNAME']].compact
+    to_addresses = Array(mail.to)
+    route_address = to_addresses.find { |addr| reply_hostnames.include?(addr.split('@')[1]&.downcase) }
+    return nil unless route_address
+
+    route_path = route_address.split('@')[0]
+    params = ReceivedEmailService.send(:parse_route_params, route_path)
+    User.find_by(id: params['u'], email_api_key: params['k'])
+  end
 
   def self.extract_partstat(event)
     attendee = Array(event.attendee).first

--- a/app/views/dev/main/last_email.html.haml
+++ b/app/views/dev/main/last_email.html.haml
@@ -31,4 +31,4 @@
             %td Reply to
             %td= Array(@email.reply_to).join(', ')
         %hr
-        %main{style:"margin: 8px"}=  raw @email.body.parts.last.decoded
+        %main{style:"margin: 8px"}=  raw (@email.html_part || @email.body.parts.last).decoded

--- a/test/services/calendar_rsvp_service_test.rb
+++ b/test/services/calendar_rsvp_service_test.rb
@@ -60,9 +60,9 @@ class CalendarRsvpServiceTest < ActionMailbox::TestCase
     assert_not CalendarRsvpService.process(mail)
   end
 
-  test "ignores rsvp from unknown sender" do
+  test "ignores rsvp with invalid credentials" do
     ics = build_ics(partstat: "ACCEPTED")
-    mail = build_rsvp_mail(ics: ics, from: "unknown@example.com")
+    mail = build_rsvp_mail(ics: ics, to: "pt=p&pi=#{@poll.id}&d=#{@discussion.id}&u=#{@voter.id}&k=badkey@#{ENV['REPLY_HOSTNAME']}")
     assert_not CalendarRsvpService.process(mail)
   end
 
@@ -103,9 +103,9 @@ class CalendarRsvpServiceTest < ActionMailbox::TestCase
     ICS
   end
 
-  def build_rsvp_mail(ics:, from: nil)
+  def build_rsvp_mail(ics:, from: nil, to: nil)
     from ||= @voter.email
-    to = "pt=p&pi=#{@poll.id}&d=#{@discussion.id}&u=#{@voter.id}&k=#{@voter.email_api_key}@#{ENV['REPLY_HOSTNAME']}"
+    to ||= "pt=p&pi=#{@poll.id}&d=#{@discussion.id}&u=#{@voter.id}&k=#{@voter.email_api_key}@#{ENV['REPLY_HOSTNAME']}"
 
     Mail.new do |m|
       m.from = from

--- a/test/services/calendar_rsvp_service_test.rb
+++ b/test/services/calendar_rsvp_service_test.rb
@@ -1,0 +1,140 @@
+require 'test_helper'
+
+class CalendarRsvpServiceTest < ActionMailbox::TestCase
+  setup do
+    hex = SecureRandom.hex(4)
+    @user = User.create!(name: "rsvp#{hex}", email: "rsvp#{hex}@example.com", username: "rsvp#{hex}", email_verified: true)
+    @group = Group.new(name: "rsvpgrp#{hex}", group_privacy: 'secret')
+    @group.creator = @user
+    @group.save!
+    @group.add_admin!(@user)
+
+    @voter = User.create!(name: "voter#{hex}", email: "voter#{hex}@example.com", username: "voter#{hex}", email_verified: true)
+    @group.add_member!(@voter)
+
+    @discussion = Discussion.new(title: "RSVP Discussion #{hex}", group: @group, author: @user)
+    DiscussionService.create(discussion: @discussion, actor: @user)
+
+    @poll = Poll.new(
+      title: "RSVP Proposal #{hex}",
+      poll_type: 'proposal',
+      group: @group,
+      discussion: @discussion,
+      author: @user,
+      closing_at: 3.days.from_now,
+      poll_option_names: %w[agree disagree abstain]
+    )
+    PollService.create(poll: @poll, actor: @user)
+    ActionMailer::Base.deliveries.clear
+  end
+
+  test "accept rsvp casts agree vote" do
+    assert_rsvp_casts_vote("ACCEPTED", "agree")
+  end
+
+  test "decline rsvp casts disagree vote" do
+    assert_rsvp_casts_vote("DECLINED", "disagree")
+  end
+
+  test "tentative rsvp casts abstain vote" do
+    assert_rsvp_casts_vote("TENTATIVE", "abstain")
+  end
+
+  test "ignores non-reply calendar emails" do
+    ics = build_ics(method: "REQUEST", partstat: "NEEDS-ACTION")
+    mail = build_rsvp_mail(ics: ics)
+    assert_not CalendarRsvpService.process(mail)
+  end
+
+  test "ignores rsvp for non-proposal polls" do
+    @poll.update_columns(poll_type: 'poll')
+    ics = build_ics(partstat: "ACCEPTED")
+    mail = build_rsvp_mail(ics: ics)
+    assert_not CalendarRsvpService.process(mail)
+  end
+
+  test "ignores rsvp for closed polls" do
+    @poll.update_columns(closed_at: 1.hour.ago)
+    ics = build_ics(partstat: "ACCEPTED")
+    mail = build_rsvp_mail(ics: ics)
+    assert_not CalendarRsvpService.process(mail)
+  end
+
+  test "ignores rsvp from unknown sender" do
+    ics = build_ics(partstat: "ACCEPTED")
+    mail = build_rsvp_mail(ics: ics, from: "unknown@example.com")
+    assert_not CalendarRsvpService.process(mail)
+  end
+
+  test "ignores rsvp with unrecognised uid" do
+    ics = build_ics(partstat: "ACCEPTED", uid: "other-thing-123@example.com")
+    mail = build_rsvp_mail(ics: ics)
+    assert_not CalendarRsvpService.process(mail)
+  end
+
+  test "build_ics generates valid calendar invite" do
+    reply_to = "pt=p&pi=#{@poll.id}&d=#{@discussion.id}&u=#{@voter.id}&k=#{@voter.email_api_key}@#{ENV['REPLY_HOSTNAME']}"
+    ics = CalendarRsvpService.build_ics(poll: @poll, recipient: @voter, reply_to: reply_to)
+
+    calendars = Icalendar::Calendar.parse(ics)
+    cal = calendars.first
+    assert_equal "REQUEST", cal.ip_method.to_s
+    event = cal.events.first
+    assert_equal "loomio-poll-#{@poll.id}@#{ENV['CANONICAL_HOST']}", event.uid.to_s
+    assert_includes event.summary.to_s, @poll.title
+    attendee = Array(event.attendee).first
+    assert_includes attendee.to_s, @voter.email
+  end
+
+  private
+
+  def build_ics(partstat:, method: "REPLY", uid: nil)
+    uid ||= "loomio-poll-#{@poll.id}@#{ENV['CANONICAL_HOST']}"
+    <<~ICS
+      BEGIN:VCALENDAR
+      VERSION:2.0
+      PRODID:-//Test//Test//EN
+      METHOD:#{method}
+      BEGIN:VEVENT
+      UID:#{uid}
+      ATTENDEE;CN=#{@voter.name};PARTSTAT=#{partstat}:mailto:#{@voter.email}
+      END:VEVENT
+      END:VCALENDAR
+    ICS
+  end
+
+  def build_rsvp_mail(ics:, from: nil)
+    from ||= @voter.email
+    to = "pt=p&pi=#{@poll.id}&d=#{@discussion.id}&u=#{@voter.id}&k=#{@voter.email_api_key}@#{ENV['REPLY_HOSTNAME']}"
+
+    Mail.new do |m|
+      m.from = from
+      m.to = to
+      m.subject = "Accepted: #{@poll.title}"
+
+      m.text_part = Mail::Part.new do
+        body ""
+      end
+
+      calendar_part = Mail::Part.new
+      calendar_part.content_type = "text/calendar; method=REPLY; charset=UTF-8"
+      calendar_part.body = ics
+      m.add_part(calendar_part)
+    end
+  end
+
+  def assert_rsvp_casts_vote(partstat, expected_option_name)
+    stance = @poll.stances.latest.find_by(participant: @voter)
+    assert stance, "voter should have a stance"
+    assert_nil stance.cast_at, "stance should not be cast yet"
+
+    ics = build_ics(partstat: partstat)
+    mail = build_rsvp_mail(ics: ics)
+    assert CalendarRsvpService.process(mail)
+
+    stance.reload
+    assert stance.cast_at, "stance should now be cast"
+    chosen_option = stance.poll_options.first
+    assert_equal expected_option_name, chosen_option.icon
+  end
+end


### PR DESCRIPTION
Attach an ICS calendar invite to proposal email notifications so recipients can vote by responding Accept/Decline/Maybe in their calendar client. Accept maps to agree, Decline to disagree, and Maybe/Tentative to abstain.