### PR TITLE
Fix operator precedence in Group create ability

### DIFF
--- a/app/models/ability/group.rb
+++ b/app/models/ability/group.rb
@@ -77,14 +77,11 @@ module Ability::Group
 
     # create group checks against the group to be created
     can :create, ::Group do |group|
-      # anyone can create a top level group of their own
-      # otherwise, the group must be a subgroup
-      # inwhich case we need to confirm membership and permission
-      (user.is_admin or AppConfig.app_features[:create_group]) &&
-      user.email_verified? &&
-      group.is_parent? ||
-      ( user_is_admin_of?(group.parent_id) ||
-        (user_is_member_of?(group.parent_id) && group.parent.members_can_create_subgroups?) )
+      user.email_verified? && (
+        (group.is_parent? && (user.is_admin || AppConfig.app_features[:create_group])) ||
+        user_is_admin_of?(group.parent_id) ||
+        (user_is_member_of?(group.parent_id) && group.parent.members_can_create_subgroups?)
+      )
     end
 
     can :join, ::Group do |group|


### PR DESCRIPTION
## Summary
- Subgroup creation was skipping `email_verified?` check due to `&&` binding tighter than `||`
- Unverified parent group admins could create subgroups
- Added proper parentheses to enforce email verification on all create paths

## Test plan
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)