### PR TITLE
Restrict sensitive fields in API serializers

### DIFF
--- a/app/serializers/restricted/user_serializer.rb
+++ b/app/serializers/restricted/user_serializer.rb
@@ -1,7 +1,7 @@
 class Restricted::UserSerializer < ActiveModel::Serializer
   embed :ids, include: true
   attributes :id, :restricted, :username, :email, :email_when_proposal_closing_soon, :email_catch_up_day, :email_newsletter,
-             :email_when_mentioned, :email_on_participation, :default_membership_volume, :unsubscribe_token, :locale, :deactivated_at
+             :email_when_mentioned, :email_on_participation, :default_membership_volume, :locale, :deactivated_at
   has_many :memberships, serializer: Restricted::MembershipSerializer, root: :memberships
 
   def restricted

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -17,11 +17,19 @@ class UserSerializer < AuthorSerializer
     scope[:include_password_status]
   end
 
+  def include_location?
+    scope[:current_user_id] == object.id
+  end
+
+  def include_sign_in_count?
+    scope[:current_user_id] == object.id
+  end
+
   def include_complaints_count?
-    object.complaints_count > 0
+    object.complaints_count > 0 && scope[:current_user_is_admin]
   end
 
   def include_bounces_count?
-    object.bounces_count > 0
+    object.bounces_count > 0 && scope[:current_user_is_admin]
   end
 end


### PR DESCRIPTION
## Summary
- Remove `unsubscribe_token` from Restricted::UserSerializer (unnecessary echo)
- `complaints_count`, `bounces_count`: admin-only (moderation data)
- `sign_in_count`, `location`: self-only (privacy)

## Test plan
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)