### PR TITLE
Fix SQL injection in HasTimeframe via timeframe_for param

### DIFF
--- a/app/models/concerns/has_timeframe.rb
+++ b/app/models/concerns/has_timeframe.rb
@@ -2,14 +2,15 @@ module HasTimeframe
   extend ActiveSupport::Concern
 
   included do
-    scope :within, ->(since, till, field = nil) { where("#{self.table_name}.#{field || :created_at} BETWEEN ? AND ?", since || 100.years.ago, till || 100.years.from_now) }
+    scope :within, ->(since, till, field = nil) {
+      col = (field && column_names.include?(field.to_s)) ? field : :created_at
+      where("#{table_name}.#{col} BETWEEN ? AND ?", since || 100.years.ago, till || 100.years.from_now)
+    }
     scope :until, ->(till) { within(nil, till) }
     scope :since, ->(since) { within(since, nil) }
 
     def self.has_timeframe?
       true
     end
-
   end
-
 end


### PR DESCRIPTION
## Summary
- User-controlled `params[:timeframe_for]` was interpolated directly into SQL column name
- Now validates against actual `column_names`, falling back to `created_at`
- Only real SQL injection found in brakeman scan of 44 warnings (rest are admin-only or false positives)

## Test plan
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)