### PR TITLE
Bump vue-i18n to fix XSS and prototype pollution

### DIFF
--- a/vue/package-lock.json
+++ b/vue/package-lock.json
@@ -70,7 +70,7 @@
         "turndown-plugin-gfm": "^1.0.2",
         "vue": "^3.5.32",
         "vue-chartjs": "^4.1.2",
-        "vue-i18n": "9.11.0",
+        "vue-i18n": "^9.14.5",
         "vue-router": "^4.2.5",
         "vue-slicksort": "^2.0.5",
         "vuetify": "^3",
@@ -380,11 +380,13 @@
       "license": "ISC"
     },
     "node_modules/@intlify/core-base": {
-      "version": "9.11.0",
+      "version": "9.14.5",
+      "resolved": "https://registry.npmjs.org/@intlify/core-base/-/core-base-9.14.5.tgz",
+      "integrity": "sha512-5ah5FqZG4pOoHjkvs8mjtv+gPKYU0zCISaYNjBNNqYiaITxW8ZtVih3GS/oTOqN8d9/mDLyrjD46GBApNxmlsA==",
       "license": "MIT",
       "dependencies": {
-        "@intlify/message-compiler": "9.11.0",
-        "@intlify/shared": "9.11.0"
+        "@intlify/message-compiler": "9.14.5",
+        "@intlify/shared": "9.14.5"
       },
       "engines": {
         "node": ">= 16"
@@ -394,10 +396,12 @@
       }
     },
     "node_modules/@intlify/message-compiler": {
-      "version": "9.11.0",
+      "version": "9.14.5",
+      "resolved": "https://registry.npmjs.org/@intlify/message-compiler/-/message-compiler-9.14.5.tgz",
+      "integrity": "sha512-IHzgEu61/YIpQV5Pc3aRWScDcnFKWvQA9kigcINcCBXN8mbW+vk9SK+lDxA6STzKQsVJxUPg9ACC52pKKo3SVQ==",
       "license": "MIT",
       "dependencies": {
-        "@intlify/shared": "9.11.0",
+        "@intlify/shared": "9.14.5",
         "source-map-js": "^1.0.2"
       },
       "engines": {
@@ -408,7 +412,9 @@
       }
     },
     "node_modules/@intlify/shared": {
-      "version": "9.11.0",
+      "version": "9.14.5",
+      "resolved": "https://registry.npmjs.org/@intlify/shared/-/shared-9.14.5.tgz",
+      "integrity": "sha512-9gB+E53BYuAEMhbCAxVgG38EZrk59sxBtv3jSizNL2hEWlgjBjAw1AwpLHtNaeda12pe6W20OGEa0TwuMSRbyQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 16"
@@ -7105,11 +7111,14 @@
       }
     },
     "node_modules/vue-i18n": {
-      "version": "9.11.0",
+      "version": "9.14.5",
+      "resolved": "https://registry.npmjs.org/vue-i18n/-/vue-i18n-9.14.5.tgz",
+      "integrity": "sha512-0jQ9Em3ymWngyiIkj0+c/k7WgaPO+TNzjKSNq9BvBQaKJECqn9cd9fL4tkDhB5G1QBskGl9YxxbDAhgbFtpe2g==",
+      "deprecated": "v9 and v10 no longer supported. please migrate to v11. about maintenance status, see https://vue-i18n.intlify.dev/guide/maintenance.html",
       "license": "MIT",
       "dependencies": {
-        "@intlify/core-base": "9.11.0",
-        "@intlify/shared": "9.11.0",
+        "@intlify/core-base": "9.14.5",
+        "@intlify/shared": "9.14.5",
         "@vue/devtools-api": "^6.5.0"
       },
       "engines": {

--- a/vue/package.json
+++ b/vue/package.json
@@ -70,7 +70,7 @@
     "turndown-plugin-gfm": "^1.0.2",
     "vue": "^3.5.32",
     "vue-chartjs": "^4.1.2",
-    "vue-i18n": "9.11.0",
+    "vue-i18n": "^9.14.5",
     "vue-router": "^4.2.5",
     "vue-slicksort": "^2.0.5",
     "vuetify": "^3",


### PR DESCRIPTION
## Summary
- Bump vue-i18n from 9.11.0 to ^9.14.5
- Fixes GHSA-9r9m-ffp6-9x4v (XSS via prototype pollution)
- Fixes GHSA-x8qp-wqqm-57ph (DOM-based XSS via tag attributes)
- Fixes GHSA-hjwq-mjwj-4x6c (@intlify/shared prototype pollution)
- Remaining 8 npm audit findings are all dev/test/build dependencies

## Test plan
- [x] Lock file regenerated with node:24-slim
- [ ] Verify i18n works correctly in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)