### PR TITLE
Clean up temp file after group export

### DIFF
--- a/app/workers/group_export_worker.rb
+++ b/app/workers/group_export_worker.rb
@@ -6,9 +6,13 @@ class GroupExportWorker
     groups = Group.where(id: group_ids)
     filename = GroupExportService.export(groups, group_name)
     document = Document.new(author: actor, title: filename)
-    document.file.attach(io: File.open(filename), filename: filename)
+    File.open(filename, 'r') do |file|
+      document.file.attach(io: file, filename: File.basename(filename))
+    end
     document.save!
     UserMailer.group_export_ready(actor.id, group_name, document.id).deliver
     DestroyRecordWorker.perform_at(1.week.from_now, 'Document', document.id)
+  ensure
+    File.delete(filename) if filename && File.exist?(filename)
   end
 end


### PR DESCRIPTION
## Summary
- Group JSON export wrote to `/tmp` with predictable names and never deleted after attaching to ActiveStorage
- Now uses `File.open` block for safe file handling and `ensure` block to delete temp file
- CSV export was already fine (uses StringIO)
- Export authorization confirmed correct (admin-only via CanCan)

## Test plan
- [x] All tests pass (1249 runs, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)