### PR TITLE
Remove secret_token debug logging from hocuspocus controller

### DIFF
--- a/app/controllers/api/hocuspocus_controller.rb
+++ b/app/controllers/api/hocuspocus_controller.rb
@@ -17,19 +17,6 @@ class Api::HocuspocusController < ActionController::Base
       return
     end
 
-    u = User.active.find_by!(id: user_id)
-
-    logger.debug({
-      hocuspocus: 'debugme',
-      params_user_secret: params[:user_secret],
-      params_user_id: user_id,
-      params_secret_token: secret_token,
-      user_id: u.id,
-      user_name: u.name,
-      user_email: u.email,
-      user_secret_token: u.secret_token
-    })
-
     user = User.active.find_by!(id: user_id, secret_token: secret_token)
 
     if record_id == 'new'
@@ -39,12 +26,6 @@ class Api::HocuspocusController < ActionController::Base
         head :unauthorized
       end
     else
-      logger.debug({
-        hocuspocus: 'debugme',
-        record_type: record_type,
-        record_id: record_id,
-        user_can_update: user.can?(:update, record_type.camelize.constantize.find(record_id.to_i))
-      })
       if user.can? :update, record_type.camelize.constantize.find(record_id.to_i)
         head :ok
       else


### PR DESCRIPTION
## Summary
- Hocuspocus controller was logging `secret_token`, `email`, and `user_secret` params to Rails log via `logger.debug` calls tagged `debugme`
- Auth model is sound (secret_token + CanCan ability check) — just needed the debug output removed

## Test plan
- [x] Code review only — removed debug logging, no logic changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)