### PR TITLE
Add list endpoints to api/b2 for discussions and polls

### DIFF
--- a/app/controllers/api/b2/discussions_controller.rb
+++ b/app/controllers/api/b2/discussions_controller.rb
@@ -9,4 +9,28 @@ class Api::B2::DiscussionsController < Api::B2::BaseController
     DiscussionService.create(actor: current_user, discussion: @discussion, params: params)
     respond_with_resource
   end
+
+  def index
+    instantiate_collection { |collection| collection.order_by_latest_activity }
+    respond_with_collection
+  end
+
+  def accessible_records
+    scope = Discussion.where(group_id: group.id)
+    case params[:status]
+    when 'closed' then scope.is_closed
+    when 'all'    then scope.kept
+    else               scope.is_open
+    end
+  end
+
+  private
+
+  def group
+    @group ||= Group.find(params[:group_id]).tap do |g|
+      unless current_user.is_admin? || current_user.is_member_of?(g)
+        raise CanCan::AccessDenied, "User is not a group member"
+      end
+    end
+  end
 end

--- a/app/controllers/api/b2/polls_controller.rb
+++ b/app/controllers/api/b2/polls_controller.rb
@@ -13,4 +13,28 @@ class Api::B2::PollsController < Api::B2::BaseController
       respond_with_errors
     end
   end
+
+  def index
+    instantiate_collection { |collection| collection.order(created_at: :desc) }
+    respond_with_collection
+  end
+
+  def accessible_records
+    scope = Poll.where(group_id: group.id)
+    case params[:status]
+    when 'closed' then scope.closed
+    when 'all'    then scope.kept
+    else               scope.active
+    end
+  end
+
+  private
+
+  def group
+    @group ||= Group.find(params[:group_id]).tap do |g|
+      unless current_user.is_admin? || current_user.is_member_of?(g)
+        raise CanCan::AccessDenied, "User is not a group member"
+      end
+    end
+  end
 end

--- a/app/controllers/api/v1/snorlax_base.rb
+++ b/app/controllers/api/v1/snorlax_base.rb
@@ -199,7 +199,9 @@ class Api::V1::SnorlaxBase < ActionController::Base
   end
 
   def page_collection(collection)
-    collection.offset(params[:from].to_i).limit((params[:per] || default_page_size).to_i)
+    offset = (params[:offset] || params[:from]).to_i
+    limit  = (params[:limit] || params[:per] || default_page_size).to_i
+    collection.offset(offset).limit(limit)
   end
 
   def order_collection(collection)

--- a/app/views/help/api2.rb
+++ b/app/views/help/api2.rb
@@ -50,6 +50,21 @@ class Views::Help::Api2 < Views::BasicLayout
       h3 { plain "example" }
       pre { plain "curl #{@root_url}api/b2/discussions/abc123?api_key=#{@api_key}" }
 
+      h2 { plain "list discussions" }
+      p { plain "List discussions in a group. The caller must be a member of the group (or a global admin)." }
+      h3 { plain "example" }
+      list_discussions_url = "#{@root_url}api/b2/discussions?api_key=#{@api_key}&group_id=#{@group_id}"
+      a(href: list_discussions_url) { plain list_discussions_url }
+      pre { plain "curl '#{list_discussions_url}'" }
+
+      h3 { plain "params" }
+      table do
+        tr { td { plain "group_id" }; td { plain "integer. required. id of the group to list discussions from." } }
+        tr { td { plain "status" }; td { plain "string. optional. default: 'open'. values: 'open', 'closed', 'all'." } }
+        tr { td { plain "per" }; td { plain "integer. optional. default: 50. page size." } }
+        tr { td { plain "from" }; td { plain "integer. optional. default: 0. offset for pagination." } }
+      end
+
       h2 { plain "create poll" }
       h3 { plain "example" }
       closing_at = 7.days.from_now.at_beginning_of_hour.utc.iso8601
@@ -62,6 +77,21 @@ class Views::Help::Api2 < Views::BasicLayout
       p { plain "Fetch a poll using the poll id (an integer) or key (a string)" }
       h3 { plain "example" }
       pre { plain "curl #{@root_url}api/b2/polls/abc123?api_key=#{@api_key}" }
+
+      h2 { plain "list polls" }
+      p { plain "List polls in a group. The caller must be a member of the group (or a global admin). The response includes each poll's current outcome, so you can use status=closed to list decided proposals." }
+      h3 { plain "example" }
+      list_polls_url = "#{@root_url}api/b2/polls?api_key=#{@api_key}&group_id=#{@group_id}"
+      a(href: list_polls_url) { plain list_polls_url }
+      pre { plain "curl '#{list_polls_url}'" }
+
+      h3 { plain "params" }
+      table do
+        tr { td { plain "group_id" }; td { plain "integer. required. id of the group to list polls from." } }
+        tr { td { plain "status" }; td { plain "string. optional. default: 'active'. values: 'active', 'closed', 'all'." } }
+        tr { td { plain "per" }; td { plain "integer. optional. default: 50. page size." } }
+        tr { td { plain "from" }; td { plain "integer. optional. default: 0. offset for pagination." } }
+      end
 
       h2 { plain "list memberships" }
       url = "#{@root_url}api/b2/memberships?api_key=#{@api_key}&group_id=#{@group_id}"

--- a/app/views/help/api2.rb
+++ b/app/views/help/api2.rb
@@ -61,9 +61,10 @@ class Views::Help::Api2 < Views::BasicLayout
       table do
         tr { td { plain "group_id" }; td { plain "integer. required. id of the group to list discussions from." } }
         tr { td { plain "status" }; td { plain "string. optional. default: 'open'. values: 'open', 'closed', 'all'." } }
-        tr { td { plain "per" }; td { plain "integer. optional. default: 50. page size." } }
-        tr { td { plain "from" }; td { plain "integer. optional. default: 0. offset for pagination." } }
+        tr { td { plain "limit" }; td { plain "integer. optional. default: 50. page size." } }
+        tr { td { plain "offset" }; td { plain "integer. optional. default: 0. offset for pagination." } }
       end
+      p { plain "Legacy: 'per' and 'from' are accepted as aliases for 'limit' and 'offset' and will continue to work." }
 
       h2 { plain "create poll" }
       h3 { plain "example" }
@@ -89,9 +90,10 @@ class Views::Help::Api2 < Views::BasicLayout
       table do
         tr { td { plain "group_id" }; td { plain "integer. required. id of the group to list polls from." } }
         tr { td { plain "status" }; td { plain "string. optional. default: 'active'. values: 'active', 'closed', 'all'." } }
-        tr { td { plain "per" }; td { plain "integer. optional. default: 50. page size." } }
-        tr { td { plain "from" }; td { plain "integer. optional. default: 0. offset for pagination." } }
+        tr { td { plain "limit" }; td { plain "integer. optional. default: 50. page size." } }
+        tr { td { plain "offset" }; td { plain "integer. optional. default: 0. offset for pagination." } }
       end
+      p { plain "Legacy: 'per' and 'from' are accepted as aliases for 'limit' and 'offset' and will continue to work." }
 
       h2 { plain "list memberships" }
       url = "#{@root_url}api/b2/memberships?api_key=#{@api_key}&group_id=#{@group_id}"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -46,8 +46,8 @@ Rails.application.routes.draw do
     end
 
     namespace :b2 do
-      resources :discussions, only: [:create, :show]
-      resources :polls, only: [:create, :show]
+      resources :discussions, only: [:create, :show, :index]
+      resources :polls, only: [:create, :show, :index]
       resources :memberships, only: [:index, :create]
       resources :comments, only: [:create]
     end

--- a/test/controllers/api/b2/discussions_controller_test.rb
+++ b/test/controllers/api/b2/discussions_controller_test.rb
@@ -80,7 +80,13 @@ class Api::B2::DiscussionsControllerTest < ActionController::TestCase
     refute_includes titles, 'Discarded Discussion'
   end
 
-  test "index respects per and from pagination" do
+  test "index respects limit pagination" do
+    get :index, params: { group_id: @group.id, api_key: @user.api_key, limit: 1 }
+    assert_response 200
+    assert_equal 1, JSON.parse(response.body)['discussions'].size
+  end
+
+  test "index still accepts legacy per param" do
     get :index, params: { group_id: @group.id, api_key: @user.api_key, per: 1 }
     assert_response 200
     assert_equal 1, JSON.parse(response.body)['discussions'].size

--- a/test/controllers/api/b2/discussions_controller_test.rb
+++ b/test/controllers/api/b2/discussions_controller_test.rb
@@ -51,4 +51,63 @@ class Api::B2::DiscussionsControllerTest < ActionController::TestCase
     post :create, params: { title: 'test', group_id: @group.id }
     assert_includes [400, 403], response.status, "Expected 400 or 403 but got #{response.status}"
   end
+
+  test "index returns open discussions in the group" do
+    get :index, params: { group_id: @group.id, api_key: @user.api_key }
+    assert_response 200
+    json = JSON.parse(response.body)
+    titles = json['discussions'].map { |d| d['title'] }
+    assert_includes titles, 'Test Discussion'
+    assert_includes titles, 'Private Discussion'
+    refute_includes titles, 'Discarded Discussion'
+  end
+
+  test "index status=closed returns closed discussions only" do
+    discussions(:test_discussion).update!(closed_at: Time.now)
+    get :index, params: { group_id: @group.id, api_key: @user.api_key, status: 'closed' }
+    assert_response 200
+    titles = JSON.parse(response.body)['discussions'].map { |d| d['title'] }
+    assert_equal ['Test Discussion'], titles
+  end
+
+  test "index status=all includes closed and open but not discarded" do
+    discussions(:test_discussion).update!(closed_at: Time.now)
+    get :index, params: { group_id: @group.id, api_key: @user.api_key, status: 'all' }
+    assert_response 200
+    titles = JSON.parse(response.body)['discussions'].map { |d| d['title'] }
+    assert_includes titles, 'Test Discussion'
+    assert_includes titles, 'Private Discussion'
+    refute_includes titles, 'Discarded Discussion'
+  end
+
+  test "index respects per and from pagination" do
+    get :index, params: { group_id: @group.id, api_key: @user.api_key, per: 1 }
+    assert_response 200
+    assert_equal 1, JSON.parse(response.body)['discussions'].size
+  end
+
+  test "index rejects non-member" do
+    hex = SecureRandom.hex(4)
+    stranger = User.create!(name: "stranger#{hex}", email: "stranger#{hex}@example.com", username: "stranger#{hex}", email_verified: true)
+    stranger.update_columns(api_key: "strkey#{SecureRandom.hex(8)}")
+    get :index, params: { group_id: @group.id, api_key: stranger.api_key }
+    assert_response 403
+  end
+
+  test "index allows global admin not in group" do
+    admin = users(:admin_user)
+    admin.update_columns(api_key: "gadmkey#{SecureRandom.hex(8)}")
+    get :index, params: { group_id: @group.id, api_key: admin.api_key }
+    assert_response 200
+  end
+
+  test "index rejects bad api_key" do
+    get :index, params: { group_id: @group.id, api_key: 'nope' }
+    assert_response 403
+  end
+
+  test "index missing group_id returns 404" do
+    get :index, params: { api_key: @user.api_key }
+    assert_response 404
+  end
 end

--- a/test/controllers/api/b2/polls_controller_test.rb
+++ b/test/controllers/api/b2/polls_controller_test.rb
@@ -181,10 +181,26 @@ class Api::B2::PollsControllerTest < ActionController::TestCase
     assert_includes titles, 'closed one'
   end
 
-  test "index respects per pagination" do
+  test "index respects limit pagination" do
+    3.times { |i| make_poll(title: "poll #{i}", group: @group) }
+    @member.update_columns(api_key: "mkey#{SecureRandom.hex(8)}")
+    get :index, params: { group_id: @group.id, api_key: @member.api_key, limit: 2 }
+    assert_response 200
+    assert_equal 2, JSON.parse(response.body)['polls'].size
+  end
+
+  test "index still accepts legacy per param" do
     3.times { |i| make_poll(title: "poll #{i}", group: @group) }
     @member.update_columns(api_key: "mkey#{SecureRandom.hex(8)}")
     get :index, params: { group_id: @group.id, api_key: @member.api_key, per: 2 }
+    assert_response 200
+    assert_equal 2, JSON.parse(response.body)['polls'].size
+  end
+
+  test "index respects offset pagination" do
+    3.times { |i| make_poll(title: "poll #{i}", group: @group) }
+    @member.update_columns(api_key: "mkey#{SecureRandom.hex(8)}")
+    get :index, params: { group_id: @group.id, api_key: @member.api_key, limit: 2, offset: 1 }
     assert_response 200
     assert_equal 2, JSON.parse(response.body)['polls'].size
   end

--- a/test/controllers/api/b2/polls_controller_test.rb
+++ b/test/controllers/api/b2/polls_controller_test.rb
@@ -141,11 +141,94 @@ class Api::B2::PollsControllerTest < ActionController::TestCase
       group_id: @group.id,
       title: 'test',
       poll_type: 'proposal',
+      recipient_audience: 'group',
       closing_at: 3.days.from_now.iso8601,
       options: ['agree', 'disagree'],
-      recipient_audience: 'group',
       api_key: ''
     }
     assert_response 403
+  end
+
+  test "index returns active polls in the group" do
+    make_poll(title: 'open one', group: @group)
+    make_poll(title: 'closed one', group: @group, closed_at: 1.day.ago)
+    @member.update_columns(api_key: "mkey#{SecureRandom.hex(8)}")
+    get :index, params: { group_id: @group.id, api_key: @member.api_key }
+    assert_response 200
+    titles = JSON.parse(response.body)['polls'].map { |p| p['title'] }
+    assert_includes titles, 'open one'
+    refute_includes titles, 'closed one'
+  end
+
+  test "index status=closed returns closed polls" do
+    make_poll(title: 'open one', group: @group)
+    make_poll(title: 'closed one', group: @group, closed_at: 1.day.ago)
+    @member.update_columns(api_key: "mkey#{SecureRandom.hex(8)}")
+    get :index, params: { group_id: @group.id, api_key: @member.api_key, status: 'closed' }
+    assert_response 200
+    titles = JSON.parse(response.body)['polls'].map { |p| p['title'] }
+    assert_equal ['closed one'], titles
+  end
+
+  test "index status=all returns kept polls regardless of closed_at" do
+    make_poll(title: 'open one', group: @group)
+    make_poll(title: 'closed one', group: @group, closed_at: 1.day.ago)
+    @member.update_columns(api_key: "mkey#{SecureRandom.hex(8)}")
+    get :index, params: { group_id: @group.id, api_key: @member.api_key, status: 'all' }
+    assert_response 200
+    titles = JSON.parse(response.body)['polls'].map { |p| p['title'] }
+    assert_includes titles, 'open one'
+    assert_includes titles, 'closed one'
+  end
+
+  test "index respects per pagination" do
+    3.times { |i| make_poll(title: "poll #{i}", group: @group) }
+    @member.update_columns(api_key: "mkey#{SecureRandom.hex(8)}")
+    get :index, params: { group_id: @group.id, api_key: @member.api_key, per: 2 }
+    assert_response 200
+    assert_equal 2, JSON.parse(response.body)['polls'].size
+  end
+
+  test "index rejects non-member" do
+    hex = SecureRandom.hex(4)
+    stranger = User.create!(name: "stranger#{hex}", email: "stranger#{hex}@example.com", username: "stranger#{hex}", email_verified: true)
+    stranger.update_columns(api_key: "strkey#{SecureRandom.hex(8)}")
+    get :index, params: { group_id: @group.id, api_key: stranger.api_key }
+    assert_response 403
+  end
+
+  test "index allows global admin not in group" do
+    admin = users(:admin_user)
+    admin.update_columns(api_key: "gadmkey#{SecureRandom.hex(8)}")
+    get :index, params: { group_id: @group.id, api_key: admin.api_key }
+    assert_response 200
+  end
+
+  test "index rejects bad api_key" do
+    get :index, params: { group_id: @group.id, api_key: 'nope' }
+    assert_response 403
+  end
+
+  test "index missing group_id returns 404" do
+    @member.update_columns(api_key: "mkey#{SecureRandom.hex(8)}")
+    get :index, params: { api_key: @member.api_key }
+    assert_response 404
+  end
+
+  private
+
+  def make_poll(**attrs)
+    defaults = {
+      poll_type: "poll",
+      title: "test poll #{SecureRandom.hex(4)}",
+      author: @admin,
+      poll_option_names: ["engage"],
+      opened_at: Time.now,
+      notify_on_closing_soon: "nobody"
+    }
+    p = Poll.new(defaults.merge(attrs))
+    p.save!
+    p.create_missing_created_event!
+    p
   end
 end


### PR DESCRIPTION
## Summary

External customer (via support) couldn't list discussions or polls via the public API — only `create` and `show` were exposed on `api/b2`. This adds `GET /api/b2/discussions` and `GET /api/b2/polls`, scoped to a `group_id` the caller is a member of (or a global admin).

Also standardises pagination params across Snorlax: `limit` / `offset` are now the primary names; legacy `per` / `from` still work as aliases.

- `status=open|closed|all` for discussions (default `open`)
- `status=active|closed|all` for polls (default `active`)
- `limit` / `offset` for pagination (or legacy `per` / `from`)
- Poll responses include `current_outcome` via `PollSerializer`, so callers can list "consented decisions" with `status=closed` and inspect outcomes client-side.

Docs at `/help/api2` updated with both endpoints and the new param names.

## Test plan

- [x] `bin/rails test test/controllers/api/b2/` — 50 runs, 119 assertions, 0 failures
- [x] `bin/rails test test/controllers/api/` — 409 runs, 1010 assertions, 0 failures (no v1 regressions from the shared `page_collection` change)
- [ ] Spot-check `/help/api2` rendering in the browser
- [ ] `curl '$ROOT_URL/api/b2/discussions?api_key=$KEY&group_id=$ID'` against a dev instance
- [ ] `curl '$ROOT_URL/api/b2/polls?api_key=$KEY&group_id=$ID&status=closed'` to verify outcome inclusion