### PR TITLE
Translate legacy ImageMagick-style ActiveStorage variations

### DIFF
--- a/config/initializers/active_storage_legacy_variations.rb
+++ b/config/initializers/active_storage_legacy_variations.rb
@@ -1,0 +1,43 @@
+module LegacyVariationTranslator
+  GEOMETRY = /\A(\d+)x(\d+)([>^!])?\z/
+
+  def self.call(transformations)
+    return transformations unless transformations.is_a?(Hash)
+
+    transformations.each_with_object({}) do |(key, value), out|
+      if key.to_sym == :resize && value.is_a?(String) && (match = value.match(GEOMETRY))
+        width = match[1].to_i
+        height = match[2].to_i
+        macro = case match[3]
+                when "^" then :resize_to_fill
+                when "!" then :resize_to_fit
+                else          :resize_to_limit
+                end
+        out[macro] = [width, height]
+      else
+        out[key] = value
+      end
+    end
+  end
+end
+
+module ActiveStorageRepresentationLegacyRescue
+  private
+
+  def set_representation
+    super
+  rescue TypeError => error
+    raise error if params[:variation_key].blank?
+
+    original = ActiveStorage::Variation.decode(params[:variation_key]).transformations
+    translated = LegacyVariationTranslator.call(original)
+    raise error if translated == original
+
+    Rails.logger.warn("Translating legacy ActiveStorage variation #{original.inspect} -> #{translated.inspect}")
+    @representation = @blob.representation(translated).processed
+  end
+end
+
+Rails.application.config.to_prepare do
+  ActiveStorage::Representations::BaseController.prepend(ActiveStorageRepresentationLegacyRescue)
+end

--- a/test/extras/legacy_variation_translator_test.rb
+++ b/test/extras/legacy_variation_translator_test.rb
@@ -1,0 +1,48 @@
+require 'test_helper'
+
+class LegacyVariationTranslatorTest < ActiveSupport::TestCase
+  test "translates ImageMagick shrink-only geometry to resize_to_limit" do
+    result = LegacyVariationTranslator.call(resize: "1200x1200>")
+    assert_equal({resize_to_limit: [1200, 1200]}, result)
+  end
+
+  test "translates geometry with no modifier to resize_to_limit" do
+    result = LegacyVariationTranslator.call(resize: "800x600")
+    assert_equal({resize_to_limit: [800, 600]}, result)
+  end
+
+  test "translates fill geometry (^) to resize_to_fill" do
+    result = LegacyVariationTranslator.call(resize: "400x400^")
+    assert_equal({resize_to_fill: [400, 400]}, result)
+  end
+
+  test "translates force-exact geometry (!) to resize_to_fit" do
+    result = LegacyVariationTranslator.call(resize: "512x512!")
+    assert_equal({resize_to_fit: [512, 512]}, result)
+  end
+
+  test "preserves sibling transformations" do
+    result = LegacyVariationTranslator.call(resize: "1280x1280>", saver: {quality: 85, strip: true})
+    assert_equal({resize_to_limit: [1280, 1280], saver: {quality: 85, strip: true}}, result)
+  end
+
+  test "passes modern transformations through unchanged" do
+    input = {resize_to_limit: [512, 512], saver: {quality: 80}}
+    assert_equal input, LegacyVariationTranslator.call(input)
+  end
+
+  test "leaves non-geometry resize values alone" do
+    input = {resize: 0.5}
+    assert_equal input, LegacyVariationTranslator.call(input)
+  end
+
+  test "handles string keys" do
+    result = LegacyVariationTranslator.call("resize" => "100x100>")
+    assert_equal({resize_to_limit: [100, 100]}, result)
+  end
+
+  test "returns non-hash input unchanged" do
+    assert_equal "not a hash", LegacyVariationTranslator.call("not a hash")
+    assert_nil LegacyVariationTranslator.call(nil)
+  end
+end


### PR DESCRIPTION
## Summary
- Old signed `/rails/active_storage/representations` URLs contain ImageMagick-style geometry (e.g. `resize: "1200x1200>"`). libvips' `resize` op wants a numeric scale, so it raises `TypeError` at `GObject.g_value_set_double`. The URLs keep verifying because `secret_key_base` hasn't rotated, so crawlers replaying them flood Sentry with 500s (LOOMIO-COM-270: 27 users, 48 events in 2 days).
- Rescue `TypeError` in `ActiveStorage::Representations::BaseController#set_representation`, translate `resize: "WxH[>^!]"` to the equivalent `image_processing` macro (`resize_to_limit` / `resize_to_fill` / `resize_to_fit`), and retry `@blob.representation(translated).processed`.
- Pure-function translator (`LegacyVariationTranslator`) so it's easy to unit-test; 9 assertions cover each geometry modifier, mixed sibling transformations, string keys, and pass-through of modern/non-hash input.

## Test plan
- [x] `bin/rails test test/extras/legacy_variation_translator_test.rb` — 9 runs, 0 failures
- [ ] CI green
- [ ] After deploy: watch Sentry LOOMIO-COM-270 — should stop firing; new warn log `Translating legacy ActiveStorage variation …` lets us see which shapes are in the wild