### PR TITLE
Handle legacy saver keys + Vips::Error in variation translator

### DIFF
--- a/config/initializers/active_storage_legacy_variations.rb
+++ b/config/initializers/active_storage_legacy_variations.rb
@@ -1,22 +1,46 @@
 module LegacyVariationTranslator
   GEOMETRY = /\A(\d+)x(\d+)([>^!])?\z/
+  SAVER_KEYS = %i[quality strip format colorspace interlace].freeze
 
   def self.call(transformations)
     return transformations unless transformations.is_a?(Hash)
 
-    transformations.each_with_object({}) do |(key, value), out|
-      if key.to_sym == :resize && value.is_a?(String) && (match = value.match(GEOMETRY))
-        width = match[1].to_i
-        height = match[2].to_i
+    out = {}
+    saver = {}
+
+    transformations.each do |key, value|
+      sym_key = key.to_sym
+
+      if sym_key == :resize && value.is_a?(String) && (match = value.match(GEOMETRY))
         macro = case match[3]
                 when "^" then :resize_to_fill
                 when "!" then :resize_to_fit
                 else          :resize_to_limit
                 end
-        out[macro] = [width, height]
+        out[macro] = [match[1].to_i, match[2].to_i]
+      elsif sym_key == :saver && value.is_a?(Hash)
+        saver.merge!(value.transform_keys(&:to_sym))
+      elsif SAVER_KEYS.include?(sym_key)
+        saver[sym_key] = coerce_saver_value(sym_key, value)
       else
         out[key] = value
       end
+    end
+
+    out[:saver] = saver unless saver.empty?
+    out
+  end
+
+  def self.coerce_saver_value(key, value)
+    case key
+    when :quality then Integer(value) rescue value
+    when :strip, :interlace
+      case value
+      when "true", "1", 1 then true
+      when "false", "0", 0 then false
+      else value
+      end
+    else value
     end
   end
 end
@@ -24,9 +48,11 @@ end
 module ActiveStorageRepresentationLegacyRescue
   private
 
+  LEGACY_ERRORS = [TypeError, defined?(Vips::Error) ? Vips::Error : nil].compact.freeze
+
   def set_representation
     super
-  rescue TypeError => error
+  rescue *LEGACY_ERRORS => error
     raise error if params[:variation_key].blank?
 
     original = ActiveStorage::Variation.decode(params[:variation_key]).transformations
@@ -34,7 +60,13 @@ module ActiveStorageRepresentationLegacyRescue
     raise error if translated == original
 
     Rails.logger.warn("Translating legacy ActiveStorage variation #{original.inspect} -> #{translated.inspect}")
-    @representation = @blob.representation(translated).processed
+
+    begin
+      @representation = @blob.representation(translated).processed
+    rescue *LEGACY_ERRORS => retry_error
+      Rails.logger.warn("Legacy variation retry failed: #{retry_error.class}: #{retry_error.message}")
+      head :not_acceptable
+    end
   end
 end
 

--- a/test/extras/legacy_variation_translator_test.rb
+++ b/test/extras/legacy_variation_translator_test.rb
@@ -26,6 +26,21 @@ class LegacyVariationTranslatorTest < ActiveSupport::TestCase
     assert_equal({resize_to_limit: [1280, 1280], saver: {quality: 85, strip: true}}, result)
   end
 
+  test "lifts top-level quality into saver and casts to integer" do
+    result = LegacyVariationTranslator.call(resize: "1200x1200>", quality: "85")
+    assert_equal({resize_to_limit: [1200, 1200], saver: {quality: 85}}, result)
+  end
+
+  test "lifts top-level strip into saver and casts to boolean" do
+    result = LegacyVariationTranslator.call(resize: "800x800>", strip: "true")
+    assert_equal({resize_to_limit: [800, 800], saver: {strip: true}}, result)
+  end
+
+  test "merges lifted saver keys with existing saver hash" do
+    result = LegacyVariationTranslator.call(resize_to_limit: [600, 600], saver: {strip: true}, quality: "90")
+    assert_equal({resize_to_limit: [600, 600], saver: {strip: true, quality: 90}}, result)
+  end
+
   test "passes modern transformations through unchanged" do
     input = {resize_to_limit: [512, 512], saver: {quality: 80}}
     assert_equal input, LegacyVariationTranslator.call(input)


### PR DESCRIPTION
## Summary
- Follow-up to #12349. After it shipped, a different legacy variation shape surfaced: `{resize: "1200x1200>", quality: "85"}` — saver-style keys at the top level. My translator only rewrote `resize`, so vips then tried to call an op named `quality` and raised `Vips::Error` (LOOMIO-COM-27F). The rescue only caught `TypeError`, so it surfaced as a 500.
- Extend `LegacyVariationTranslator` to lift known saver keys (`quality`, `strip`, `format`, `colorspace`, `interlace`) into a nested `saver:` hash, casting string values (`"85"` → `85`, `"true"` → `true`) along the way.
- Extend the controller rescue to cover `Vips::Error` as well, and wrap the retry so any second failure returns `406 :not_acceptable` instead of leaking as a 500. A warn log fires on retry failure so we can see any further new shapes.

## Test plan
- [x] `bin/rails test test/extras/legacy_variation_translator_test.rb` — 12 runs, 0 failures (added 3 cases: top-level quality, strip, mixed with existing saver)
- [ ] CI green
- [ ] After deploy: LOOMIO-COM-27F should stop firing; watch for the retry-failure warn log to surface any further shapes