### PR TITLE
Throttle /bug_tunnel separately and skip its Sentry alerts

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -30,7 +30,14 @@ class Rack::Attack
   end
 
   throttle('req/ip', limit: 300 * RATE_MULTIPLIER, period: (5 * TIME_MULTIPLIER).minutes) do |req|
-    req.remote_ip
+    req.remote_ip unless req.path == '/bug_tunnel'
+  end
+
+  # Dedicated higher-ceiling throttle for the Sentry tunnel. A single client
+  # in a JS error loop can spike bug_tunnel traffic without meaning to DoS
+  # the site — give it room, but still stop runaway clients.
+  throttle('bug_tunnel/ip', limit: 500 * RATE_MULTIPLIER, period: (5 * TIME_MULTIPLIER).minutes) do |req|
+    req.remote_ip if req.path == '/bug_tunnel'
   end
   IP_POST_LIMITS = {
     '/api/v1/trials' => 10,
@@ -91,6 +98,10 @@ class Rack::Attack
     req = req_h[:request]
     matched = req.env['rack.attack.matched']
     discriminator = req.env['rack.attack.match_discriminator']
+    # bug_tunnel receives forwarded browser-side Sentry envelopes, so one
+    # client in an error loop can spam it. Skip alerting on that throttle —
+    # each blocked request would otherwise emit its own Sentry event.
+    next if matched == 'bug_tunnel/ip'
     email = (req.params['email'] || req.params.dig('user', 'email')).to_s.downcase.presence rescue nil
     turnstile_provided = !!(req.params['turnstile_token'] || req.params.dig('user', 'turnstile_token')) rescue false
     Rails.logger.warn "rack_attack:throttle #{matched} #{discriminator} #{req.request_method} #{req.fullpath}"


### PR DESCRIPTION
## Summary
- `/bug_tunnel` is our own forwarder for the browser-side Sentry SDK — every JS error envelope from the client posts here and we forward it to Sentry. A client in a tight error loop can exceed the global `req/ip` throttle (300/5min), which in turn calls `Sentry.capture_message` from the rack_attack subscriber. That creates a feedback loop (LOOMIO-COM-27B: 18 users, 43 events in 3h).
- Exempt `/bug_tunnel` from `req/ip` and give it a dedicated `bug_tunnel/ip` throttle at 500/5min so runaway clients are still capped but ordinary noisy clients pass.
- Skip the `Sentry.capture_message` call for `bug_tunnel/ip` throttle hits so rate-limiting a broken client doesn't itself amplify Sentry traffic.

## Test plan
- [ ] CI green
- [ ] After deploy: LOOMIO-COM-27B should stop accumulating; any client still hitting `bug_tunnel/ip` will be logged via `Rails.logger.warn` but won't reach Sentry