### PR TITLE
Raise profile_get/ip throttle from 20 to 60/hour

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -83,8 +83,21 @@ class Rack::Attack
     end
   end
 
-  throttle("profile_get/ip", limit: 20 * RATE_MULTIPLIER, period: (1 * TIME_MULTIPLIER).hour) do |req|
-    req.remote_ip if req.get? && req.path.starts_with?('/api/v1/profile/')
+  # /api/v1/profile/email_status is unauthenticated and falls through to
+  # User.find_by(email:), so it's the enumeration surface. Throttle it
+  # tightly and separately from the rest of /api/v1/profile/*.
+  throttle("email_status/ip", limit: 20 * RATE_MULTIPLIER, period: (1 * TIME_MULTIPLIER).hour) do |req|
+    req.remote_ip if req.get? && req.path == '/api/v1/profile/email_status'
+  end
+
+  throttle("email_status/email", limit: 5 * RATE_MULTIPLIER, period: (1 * TIME_MULTIPLIER).hour) do |req|
+    if req.get? && req.path == '/api/v1/profile/email_status'
+      req.params['email'].to_s.downcase.presence
+    end
+  end
+
+  throttle("profile_get/ip", limit: 60 * RATE_MULTIPLIER, period: (1 * TIME_MULTIPLIER).hour) do |req|
+    req.remote_ip if req.get? && req.path.starts_with?('/api/v1/profile/') && req.path != '/api/v1/profile/email_status'
   end
 
   ActiveSupport::Notifications.subscribe('throttle.rack_attack') do |name, start, finish, request_id, req_h|


### PR DESCRIPTION
## Summary
- `profile_get/ip` was added in #12311 (Apr 9) as part of a batched auth-security pass, set at 20/hour without being tuned against real usage. `/api/v1/profile/groups` is called by routine app flows (group switcher, auth refresh), so a user with multiple tabs or background refreshes can trip the limit legitimately. LOOMIO-COM-27E shows 12 users / 25 events in 2h — all real users, not attackers.
- Raise to 60/hour. Still caps abuse (nothing else hits this endpoint hard) but absorbs normal polling.

## Test plan
- [ ] CI green
- [ ] After deploy: LOOMIO-COM-27E should drop sharply; revisit if it keeps firing