### PR TITLE
Guard real_participant fallback in event_bus against Poll eventables

### DIFF
--- a/config/initializers/event_bus.rb
+++ b/config/initializers/event_bus.rb
@@ -9,11 +9,16 @@ EventBus.configure do |config|
                 'stance_created_event',
                 'outcome_created_event',
                 'poll_closed_by_user_event') do |event|
-    if event.discussion
-      reader = DiscussionReader.for_model(event.discussion, event.user.presence || event.eventable.real_participant)
-                               .update_reader(ranges: event.sequence_id,
-                                              volume: :loud)
-      # MessageChannelService.publish_models([reader], root: :discussions, user_id: event.real_user.id)
+    # real_participant only exists on Comment and Stance (for anonymous-voting
+    # flows where event.user is the placeholder and the eventable holds the
+    # real actor). Other eventables (Poll, Discussion, Outcome) don't have it,
+    # so skip the fallback there.
+    reader_user = event.user.presence
+    reader_user ||= event.eventable.real_participant if event.eventable.respond_to?(:real_participant)
+
+    if event.discussion && reader_user
+      DiscussionReader.for_model(event.discussion, reader_user)
+                      .update_reader(ranges: event.sequence_id, volume: :loud)
     end
   end
 


### PR DESCRIPTION
## Summary
- `config/initializers/event_bus.rb:13` does `event.user.presence || event.eventable.real_participant`. `Event#user` falls back to `AnonymousUser` when `user_id` is nil, and `Null::Object#presence` returns nil — so the `||` fires. `real_participant` only exists on `Comment` and `Stance` (the anonymous-voting case where `event.user` is a placeholder and the eventable holds the real actor).
- The listener binds to 8 event kinds, several of which have `Poll` / `Discussion` / `Outcome` as eventable. When `event.user` is the Null user and eventable is a `Poll`, the fallback raises `NoMethodError: undefined method 'real_participant' for an instance of Poll` inside `PublishEventWorker` (LOOMIO-COM-271: 16+ events, still firing).
- Only apply the fallback when the eventable responds to `real_participant`; skip the DiscussionReader update if we couldn't resolve a real user (writing with nil isn't meaningful).

## Test plan
- [ ] CI green
- [ ] After deploy: LOOMIO-COM-271 should stop firing