### PR TITLE
Fix German discussion context-menu translations + log Google's traps

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,8 @@
 
 - **Never change the value of an existing i18n key.** Existing keys may be translated into other languages; changing the English value breaks those translations.
 - Instead, create a new key with the new value and update the code to reference the new key.
+- **Review retranslation PRs against `config/locales/translation_corrections.md`** — that file logs sense-errors Google Translate has made before (polysemous short labels, paired actions drifting, misleading German words, glossary overrides like outcome→conclusion across many locales). If a new translation pass reintroduces one of those patterns, catch it at review.
+- **When you hand-correct a translation, append it to `translation_corrections.md`** with the file, key, before/after, and a one-line "why it was wrong". The point is to accumulate the context Google doesn't have, so reviewers of the next retranslation can watch for the same traps.
 
 
 ## Running E2E Tests

--- a/config/locales/client.de.yml
+++ b/config/locales/client.de.yml
@@ -301,7 +301,7 @@ de:
       discard: Verwerfen
       restore: Wiederherstellen
       unsubscribe: Benachrichtigungen deaktivieren
-      subscribe: Benachrichtigung aktivieren
+      subscribe: Benachrichtigungen aktivieren
       unignore: Wieder bemerken
       remind: Erinnern
       resend: Neu senden
@@ -1040,9 +1040,9 @@ de:
     add_poll_to_thread: Zur Diskussion hinzufügen
     count_members: "%{count} Mitglieder "
     count_voters: "%{count} Wähler"
-    pin_discussion: Diskussion über die Pinnwand
-    unpin_discussion: Diskussion aufheben
-    close_discussion: Schließende Diskussion
+    pin_discussion: Diskussion anpinnen
+    unpin_discussion: Diskussion abpinnen
+    close_discussion: Diskussion schließen
     reopen_discussion: Diskussion wieder aufnehmen
     delete_discussion: Diskussion löschen
   formatting:

--- a/config/locales/translation_corrections.md
+++ b/config/locales/translation_corrections.md
@@ -1,0 +1,75 @@
+# Corrected translations
+
+A log of hand-corrections to non-English locale files where
+`bin/rake loomio:translate_strings` (Google Translate) produced a wrong
+sense, not just a typo — Google has very little UI context, so short
+ambiguous labels often come back wrong. Scan this before merging a
+retranslation PR: if the same English key reappears with a suspicious
+change, check it against the patterns below.
+
+## Patterns
+
+- **Polysemous short labels.** A one- or two-word English string gets
+  translated in the wrong sense because the translator can't see that
+  it's a UI verb/imperative. "Pin" → pinboard-noun instead of verb;
+  "Close" → "closing" adjective instead of imperative; "Block" → city
+  block instead of obstruct; "Post" → mail instead of publish.
+- **Siblings drift apart.** Paired actions (subscribe/unsubscribe,
+  pin/unpin, open/close) get translated in isolation, one passes, then
+  the other gets a different structure (plural vs singular, verb vs
+  noun) — they read inconsistently in the UI. Check symmetry when one
+  half of a pair changes.
+- **"aufheben", "auflösen", etc.** German words that can mean
+  "cancel/annul" *or* "lift/remove". Translator picks the wrong sense
+  for UI remove-actions.
+
+## Loomio glossary overrides
+
+Terms with a Loomio-specific meaning Google can't infer from the string alone.
+Force these mappings when retranslating (established in commits 38a9808ce1
+and 7cc8e45029).
+
+### `outcome` ≠ the local word for "result"
+
+In Loomio, **outcome** is the author's closing statement on a poll.
+**Result** is the vote tally. Many languages use the same word for both, so
+Google collapses them and the distinction disappears in the UI. Use the
+locale's word for *conclusion* / *decision* for `outcome`, and keep the
+locale's word for *result* only for vote tallies.
+
+| Locale | Use for `outcome` | Google's default (wrong) |
+|--------|-------------------|---------------------------|
+| fr     | `conclusion`      | `résultat`                |
+| pt-BR  | `conclusão`       | `resultado`               |
+| da     | `konklusion`      | `resultat`                |
+| sv     | `slutsats`        | `resultat`                |
+| nl-NL  | `conclusie`       | `resultaat`               |
+| it     | `conclusione`     | `risultato`               |
+| ro     | `concluzie`       | `rezultat`                |
+| uk     | `висновок`        | `результат`               |
+| he     | `מסקנה`           | `תוצאה`                   |
+| ja     | `結論`            | `結果`                    |
+| zh-TW  | `結論`            | `結果`                    |
+| hu     | `következtetés`   | `eredmény`                |
+| tr     | `karar`           | `sonuç`                   |
+
+Applies to every noun use — `outcomes`, `outcome_announced`, `outcome_created`,
+`outcome_updated`, `outcome_review_due`, `post_outcome`, etc. Similar locales
+not yet reviewed should probably get the same treatment.
+
+### `post` (verb) ≠ postal/temporal "post"
+
+As a verb in strings like "Post outcome" / "posted", Google often picks the
+postal or temporal sense (`poster`/`posté` in fr, `Pós-` prefix in pt-BR,
+literal `après` / "after" in fr). Use the locale's verb for **publish** /
+**share** (`publier`/`publié`, `publicar`, `publiceren`, …). Affected ~17
+languages in the Nov 2025 pass.
+
+## Corrections
+
+| File           | Key                                | Was                                             | Now                               | Why it was wrong                                       |
+|----------------|------------------------------------|-------------------------------------------------|-----------------------------------|--------------------------------------------------------|
+| client.de.yml  | `group_page_actions.subscribe`     | `Benachrichtigung aktivieren` (singular)        | `Benachrichtigungen aktivieren`   | Sibling `unsubscribe` already plural — pair inconsistent |
+| client.de.yml  | `context_panel.pin_discussion`     | `Diskussion über die Pinnwand` ("about the pinboard") | `Diskussion anpinnen`       | Took "pin" as pinboard noun instead of verb            |
+| client.de.yml  | `context_panel.unpin_discussion`   | `Diskussion aufheben` ("cancel the discussion") | `Diskussion abpinnen`             | "aufheben" = cancel, wrong sense of "un-pin"           |
+| client.de.yml  | `context_panel.close_discussion`   | `Schließende Diskussion` ("closing discussion", adjective) | `Diskussion schließen` | Adjectival present participle instead of imperative verb |


### PR DESCRIPTION
## Summary
Reported by die-linke (Kai, email 2026-04-24, kanbn card `zziaz6h458qc`):
three German strings in the discussion context menu were nonsensical.
Hand-corrected `config/locales/client.de.yml`:

- `context_panel.pin_discussion` — "Diskussion über die Pinnwand" (pinboard noun) → **"Diskussion anpinnen"**
- `context_panel.close_discussion` — "Schließende Diskussion" (adjective) → **"Diskussion schließen"**
- `group_page_actions.subscribe` — "Benachrichtigung aktivieren" (singular) → **"Benachrichtigungen aktivieren"** (matches the plural `unsubscribe` sibling)

Also fixed `context_panel.unpin_discussion` in the same block — Google had "Diskussion aufheben" (means "cancel the discussion"). Now **"Diskussion abpinnen"**.

## New: `config/locales/translation_corrections.md`
Google Translate keeps hitting the same traps because it can't see the UI context. Started a running log so reviewers of future retranslation PRs can spot recurring patterns:

- Today's German corrections (pin/close/subscribe — polysemy, paired-sibling drift, "aufheben"-class false friends).
- Glossary override for `outcome` (→ `conclusion` / `konklusion` / `slutsats` / …) across 13 locales, distilled from commits 38a9808ce1 and 7cc8e45029. "Outcome" ≠ the local word for "result"; we reserve that for the vote tally table.
- Glossary override for `post` as a verb (publish, not mail/after).

`AGENTS.md` now points reviewers and agents at this file, with an instruction to **append** future corrections so the glossary grows.

## Test plan
- [x] `ruby script/check_i18n_interpolations.rb` passes on the branch
- [ ] `translations` workflow passes on the PR
- [ ] After merge + deploy: Kai verifies the context menu reads correctly in German