### PR TITLE
Refresh user's groups after joining or being added to a group

### DIFF
--- a/vue/src/shared/interfaces/membership_records_interface.js
+++ b/vue/src/shared/interfaces/membership_records_interface.js
@@ -21,7 +21,8 @@ export default class MemberhipRecordsInterface extends BaseRecordsInterface {
   }
 
   joinGroup(group) {
-    return this.remote.post('join_group', {group_id: group.id});
+    return this.remote.post('join_group', {group_id: group.id})
+      .then(result => this.recordStore.users.fetchGroups().then(() => result));
   }
 
   fetchMyMemberships() {

--- a/vue/src/shared/interfaces/notification_records_interface.js
+++ b/vue/src/shared/interfaces/notification_records_interface.js
@@ -1,11 +1,22 @@
 import BaseRecordsInterface from '@/shared/record_store/base_records_interface';
 import NotificationModel    from '@/shared/models/notification_model';
 
+const KINDS_THAT_GRANT_GROUP_ACCESS = ['user_added_to_group'];
+
 export default class NotificationRecordsInterface extends BaseRecordsInterface {
   constructor(recordStore) {
     super(recordStore);
     this.model = NotificationModel;
     this.baseConstructor(recordStore);
+  }
+
+  importRecord(attributes) {
+    const isNew = attributes.id != null && this.find(attributes.id) == null;
+    const record = super.importRecord(attributes);
+    if (isNew && KINDS_THAT_GRANT_GROUP_ACCESS.includes(attributes.kind)) {
+      this.recordStore.users.fetchGroups();
+    }
+    return record;
   }
 
   fetchNotifications(query, options) {


### PR DESCRIPTION
## Summary
- The sidebar derives its subgroup list from the local `Records.groups` store. When a user gained access to a group mid-session — joining themselves or being added by an admin — the existing membership/notification round-trips never carried subgroups visible via parent membership, so the sidebar appeared empty until a full reload.
- After a successful self-join (`Records.memberships.joinGroup`), refetch all visible groups via `/profile/groups`.
- On first import of a `user_added_to_group` notification (sent over websocket when an admin adds the current user), do the same.
- Both reuse `GroupQuery.visible_to`, which already includes subgroups visible via parent membership. No backend changes — every other group/membership serialization stays cheap.

Reported by die-linke (kanbn [u051khatroe5](https://kanbn.loomio.io)).

## Test plan
- [ ] As an admin, add an existing logged-in user to a parent group that has a subgroup with **\"visible to parent members\"** enabled. The new member's sidebar should show the subgroup without a reload.
- [ ] Sign in as a non-member and click \"Join group\" on an open group with visible subgroups. Subgroups should appear in the sidebar immediately.
- [ ] Existing flows (invitation email link, manual reload) should continue to work — both already trigger `findOrFetchGroups` via panel mount.