### PR TITLE
Don't notify the actor when they @mention their own group

### DIFF
--- a/app/models/events/group_mentioned.rb
+++ b/app/models/events/group_mentioned.rb
@@ -23,6 +23,7 @@ class Events::GroupMentioned < Event
       .active
       .accepted
       .where(group_id: group_ids)
+      .where.not(user_id: user_id)
       .where.not(user_id: already_mentioned_user_ids)
       .where.not(user_id: already_notified_user_ids)
   end

--- a/test/models/events/group_mentioned_test.rb
+++ b/test/models/events/group_mentioned_test.rb
@@ -36,6 +36,15 @@ class Events::GroupMentionedTest < ActiveSupport::TestCase
     assert_equal 1, emails_sent_to(@mentioned_member.email).size
   end
 
+  test "does not notify the actor when they mention the group" do
+    @group.membership_for(@actor).update!(volume: :loud)
+    comment = Comment.new(discussion: @discussion, author: @actor,
+                          body: "hello @#{@group.handle}", body_format: 'md')
+    Events::NewComment.publish!(comment)
+    assert_equal 0, emails_sent_to(@actor.email).size
+    assert_equal 0, Notification.where(event: Event.where(kind: 'group_mentioned'), user: @actor).count
+  end
+
   test "notifies normally" do
     comment = Comment.new(discussion: @discussion, author: @actor,
                           body: "hello @#{@group.handle}", body_format: 'md')


### PR DESCRIPTION
## Summary
- `Events::GroupMentioned`'s recipient scope excluded previously-mentioned and previously-notified users but not the actor themselves, so an author who was a member of the group they mentioned got a self-notification.
- Individual `@user` mentions already avoid this because `HasMentions#mentioned_usernames` strips the author's own username at parse time — this fix applies the equivalent filter on the group-mention scope.

## Test plan
- [x] New regression test in `test/models/events/group_mentioned_test.rb` ("does not notify the actor when they mention the group") asserts zero emails and zero notifications for the actor.
- [x] `bin/rails test test/models/events/group_mentioned_test.rb` — 7 runs, 16 assertions, 0 failures.
- [ ] Manually @mention a group you belong to in a comment and confirm you don't receive a notification.