### PR TITLE
Add pg_trgm GIN indexes for ILIKE search columns

### DIFF
--- a/db/migrate/20260430104335_add_pg_trgm_indexes.rb
+++ b/db/migrate/20260430104335_add_pg_trgm_indexes.rb
@@ -1,0 +1,21 @@
+class AddPgTrgmIndexes < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def change
+    enable_extension :pg_trgm
+
+    add_index :users,    :name,     using: :gin, opclass: :gin_trgm_ops, algorithm: :concurrently, name: :index_users_on_name_trgm
+    add_index :users,    :username, using: :gin, opclass: :gin_trgm_ops, algorithm: :concurrently, name: :index_users_on_username_trgm
+    add_index :users,    :email,    using: :gin, opclass: :gin_trgm_ops, algorithm: :concurrently, name: :index_users_on_email_trgm
+
+    add_index :groups,   :name,        using: :gin, opclass: :gin_trgm_ops, algorithm: :concurrently, name: :index_groups_on_name_trgm
+    add_index :groups,   :handle,      using: :gin, opclass: :gin_trgm_ops, algorithm: :concurrently, name: :index_groups_on_handle_trgm
+    add_index :groups,   :description, using: :gin, opclass: :gin_trgm_ops, algorithm: :concurrently, name: :index_groups_on_description_trgm
+
+    add_index :discussions, :title, using: :gin, opclass: :gin_trgm_ops, algorithm: :concurrently, name: :index_discussions_on_title_trgm
+    add_index :polls,       :title, using: :gin, opclass: :gin_trgm_ops, algorithm: :concurrently, name: :index_polls_on_title_trgm
+    add_index :documents,   :title, using: :gin, opclass: :gin_trgm_ops, algorithm: :concurrently, name: :index_documents_on_title_trgm
+
+    add_index :active_storage_blobs, :filename, using: :gin, opclass: :gin_trgm_ops, algorithm: :concurrently, name: :index_active_storage_blobs_on_filename_trgm
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,12 +10,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_04_20_231026) do
+ActiveRecord::Schema[8.0].define(version: 2026_04_30_104335) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_stat_statements"
+  enable_extension "pg_trgm"
   enable_extension "pgcrypto"
 
   create_table "action_mailbox_inbound_emails", force: :cascade do |t|
@@ -61,6 +62,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_04_20_231026) do
     t.string "checksum"
     t.datetime "created_at", precision: nil, null: false
     t.string "service_name", null: false
+    t.index ["filename"], name: "index_active_storage_blobs_on_filename_trgm", opclass: :gin_trgm_ops, using: :gin
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
   end
 
@@ -317,6 +319,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_04_20_231026) do
     t.index ["private"], name: "index_discussions_on_private"
     t.index ["tags"], name: "index_discussions_on_tags", using: :gin
     t.index ["template"], name: "index_discussions_on_template", where: "(template IS TRUE)"
+    t.index ["title"], name: "index_discussions_on_title_trgm", opclass: :gin_trgm_ops, using: :gin
   end
 
   create_table "documents", id: :serial, force: :cascade do |t|
@@ -338,6 +341,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_04_20_231026) do
     t.index ["group_id"], name: "index_documents_on_group_id"
     t.index ["model_id"], name: "index_documents_on_model_id"
     t.index ["model_type"], name: "index_documents_on_model_type"
+    t.index ["title"], name: "index_documents_on_title_trgm", opclass: :gin_trgm_ops, using: :gin
   end
 
   create_table "events", id: :serial, force: :cascade do |t|
@@ -480,10 +484,13 @@ ActiveRecord::Schema[8.0].define(version: 2026_04_20_231026) do
     t.boolean "members_can_create_templates", default: false, null: false
     t.index ["archived_at"], name: "index_groups_on_archived_at", where: "(archived_at IS NULL)"
     t.index ["created_at"], name: "index_groups_on_created_at"
+    t.index ["description"], name: "index_groups_on_description_trgm", opclass: :gin_trgm_ops, using: :gin
     t.index ["full_name"], name: "index_groups_on_full_name"
     t.index ["handle"], name: "index_groups_on_handle", unique: true
+    t.index ["handle"], name: "index_groups_on_handle_trgm", opclass: :gin_trgm_ops, using: :gin
     t.index ["key"], name: "index_groups_on_key", unique: true
     t.index ["name"], name: "index_groups_on_name"
+    t.index ["name"], name: "index_groups_on_name_trgm", opclass: :gin_trgm_ops, using: :gin
     t.index ["parent_id"], name: "index_groups_on_parent_id"
     t.index ["subscription_id"], name: "groups_subscription_id_idx"
     t.index ["token"], name: "index_groups_on_token", unique: true
@@ -813,6 +820,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_04_20_231026) do
     t.index ["group_id"], name: "index_polls_on_group_id"
     t.index ["key"], name: "index_polls_on_key", unique: true
     t.index ["tags"], name: "index_polls_on_tags", using: :gin
+    t.index ["title"], name: "index_polls_on_title_trgm", opclass: :gin_trgm_ops, using: :gin
   end
 
   create_table "rails_pulse_job_runs", force: :cascade do |t|
@@ -1193,13 +1201,16 @@ ActiveRecord::Schema[8.0].define(version: 2026_04_20_231026) do
     t.integer "bounces_count", default: 0, null: false
     t.index ["api_key"], name: "index_users_on_api_key"
     t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["email"], name: "index_users_on_email_trgm", opclass: :gin_trgm_ops, using: :gin
     t.index ["email_verified"], name: "index_users_on_email_verified"
     t.index ["key"], name: "index_users_on_key", unique: true
+    t.index ["name"], name: "index_users_on_name_trgm", opclass: :gin_trgm_ops, using: :gin
     t.index ["remember_token"], name: "users_remember_token_idx"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
     t.index ["unlock_token"], name: "index_users_on_unlock_token", unique: true
     t.index ["unsubscribe_token"], name: "index_users_on_unsubscribe_token", unique: true
     t.index ["username"], name: "index_users_on_username", unique: true
+    t.index ["username"], name: "index_users_on_username_trgm", opclass: :gin_trgm_ops, using: :gin
   end
 
   create_table "versions", id: :serial, force: :cascade do |t|


### PR DESCRIPTION
## Summary

- Enables `pg_trgm` (on DO managed Postgres allowlist) and adds GIN trigram indexes on the columns currently searched with leading-wildcard `ILIKE '%q%'`.
- Indexed: `users.name/username/email`, `groups.name/handle/description`, `discussions.title`, `polls.title`, `documents.title`, `active_storage_blobs.filename`.
- Indexes built `CONCURRENTLY` (no DDL transaction) — safe to deploy without locking writes. Slowest builds will be `users` and `active_storage_blobs`.
- Zero application code changes — Postgres uses GIN trgm indexes automatically for `ILIKE '%foo%'`. The 8 existing `ilike` scopes across `app/models/{user,group,membership,discussion,poll,document}.rb` and `app/queries/{membership_query,attachment_query}.rb` are unchanged.

## Why

The audit of search code found two layers: (1) `pg_search` multisearch on `pg_search_documents` for the global search box, and (2) leading-wildcard `ILIKE` for every secondary surface (member picker, group lookup, polls list, discussion filter, attachment search). Layer (2) was sequential-scan only. This PR fixes that with the cheapest possible change — extension + indexes, no query rewrites.

## Test plan

- [ ] CI green
- [ ] After deploy, EXPLAIN one of the `ILIKE` queries on prod (e.g. `users` member picker) and confirm `Bitmap Index Scan on index_users_on_name_trgm`
- [ ] Spot-check that the global search box, member picker, and group/poll search still return the expected results