### PR TITLE
Migrate legacy Document records to ActiveStorage attachments

### DIFF
--- a/app/workers/migrate_document_to_attachment_worker.rb
+++ b/app/workers/migrate_document_to_attachment_worker.rb
@@ -1,0 +1,118 @@
+class MigrateDocumentToAttachmentWorker
+  include Sidekiq::Worker
+
+  PARENT_TYPES = %w[Comment Discussion Group Outcome Poll].freeze
+
+  def perform(doc_id)
+    doc = Document.find_by(id: doc_id)
+    return unless doc
+
+    parent = parent_for(doc.model_type, doc.model_id)
+    if parent.nil?
+      drop_doc(doc.id)
+      return
+    end
+
+    existing_asa = ActiveStorage::Attachment.find_by(record_type: 'Document', record_id: doc.id, name: 'file')
+    blob =
+      if existing_asa
+        existing_asa.blob
+      elsif doc.file_file_name.blank? || doc.url.blank?
+        drop_doc(doc.id)
+        return
+      else
+        create_blob_from_url(doc) or return
+      end
+
+    attach_and_finalize(parent, doc, blob)
+  end
+
+  private
+
+  def parent_for(model_type, model_id)
+    return nil unless PARENT_TYPES.include?(model_type) && model_id
+    model_type.constantize.find_by(id: model_id)
+  end
+
+  def attach_and_finalize(parent, doc, blob)
+    parent.with_lock do
+      effective_filename = doc.file_file_name.presence || blob.filename.to_s
+
+      already_attached = ActiveStorage::Attachment.exists?(record: parent, blob_id: blob.id, name: 'files')
+      filename_dup = !already_attached && parent_already_has_filename?(parent, effective_filename)
+
+      unless already_attached || filename_dup
+        ActiveStorage::Attachment.create!(record: parent, blob: blob, name: 'files')
+      end
+
+      ActiveStorage::Attachment.where(record_type: 'Document', record_id: doc.id).delete_all
+      Document.where(id: doc.id).delete_all
+
+      parent.send(:build_attachments)
+      parent.update_column(:attachments, parent[:attachments])
+    end
+  end
+
+  def parent_already_has_filename?(parent, filename)
+    parent.files.attachments
+      .joins(:blob)
+      .where(active_storage_blobs: { filename: filename })
+      .exists?
+  end
+
+  def create_blob_from_url(doc)
+    key = blob_key_from_url(doc.url)
+    return nil if key.blank?
+
+    if (existing_blob = ActiveStorage::Blob.find_by(key: key))
+      return existing_blob
+    end
+
+    metadata = fetch_blob_metadata(key) or return nil
+
+    ActiveStorage::Blob.create!(
+      key: key,
+      filename: doc.file_file_name,
+      content_type: doc.file_content_type.presence || metadata[:content_type],
+      byte_size: metadata[:byte_size],
+      checksum: metadata[:checksum],
+      service_name: ActiveStorage::Blob.service.name.to_s
+    )
+  rescue ActiveRecord::RecordNotUnique
+    ActiveStorage::Blob.find_by(key: key)
+  end
+
+  def blob_key_from_url(url)
+    URI(url).path.to_s.sub(%r{\A/}, '')
+  rescue URI::InvalidURIError
+    nil
+  end
+
+  def fetch_blob_metadata(key)
+    service = ActiveStorage::Blob.service
+    return nil unless service.exist?(key)
+
+    case service.class.name
+    when 'ActiveStorage::Service::S3Service'
+      obj = service.bucket.object(key)
+      { byte_size: obj.content_length,
+        content_type: obj.content_type,
+        checksum: obj.etag.to_s.tr('"', '') }
+    when 'ActiveStorage::Service::DiskService'
+      path = service.send(:path_for, key)
+      { byte_size: File.size(path),
+        content_type: nil,
+        checksum: OpenSSL::Digest::MD5.file(path).base64digest }
+    else
+      nil
+    end
+  rescue => e
+    Sidekiq.logger.warn "MigrateDocumentToAttachmentWorker: blob metadata fetch failed for key=#{key}: #{e.class}: #{e.message}"
+    nil
+  end
+
+  def drop_doc(doc_id)
+    ActiveStorage::Attachment.where(record_type: 'Document', record_id: doc_id).delete_all
+    Document.where(id: doc_id).delete_all
+  end
+end

--- a/app/workers/migrate_documents_to_attachments_worker.rb
+++ b/app/workers/migrate_documents_to_attachments_worker.rb
@@ -1,0 +1,165 @@
+class MigrateDocumentsToAttachmentsWorker
+  include Sidekiq::Worker
+
+  PARENT_TYPES = %w[Comment Discussion Group Outcome Poll].freeze
+  BATCH_SIZE = 200
+
+  def perform(after_id = 0)
+    docs = Document
+      .where('id > ?', after_id)
+      .order(:id)
+      .limit(BATCH_SIZE)
+      .pluck(:id, :model_type, :model_id, :file_file_name, :file_content_type, :url)
+    return if docs.empty?
+
+    affected = Hash.new { |h, k| h[k] = Set.new }
+
+    docs.each { |row| migrate_doc(row, affected) }
+
+    rebuild_attachments_json(affected)
+
+    next_after = docs.last.first
+    self.class.perform_async(next_after) if Document.where('id > ?', next_after).exists?
+  end
+
+  private
+
+  def migrate_doc(row, affected)
+    doc_id, model_type, model_id, filename, content_type, url = row
+    parent = parent_for(model_type, model_id)
+
+    if parent.nil?
+      drop_doc(doc_id)
+      return
+    end
+
+    if (existing = ActiveStorage::Attachment.find_by(record_type: 'Document', record_id: doc_id, name: 'file'))
+      attach_existing_blob(parent, doc_id, existing.blob, filename)
+      affected[model_type] << model_id
+      return
+    end
+
+    if filename.blank? || url.blank?
+      drop_doc(doc_id)
+      return
+    end
+
+    if parent_already_has_filename?(parent, filename)
+      delete_doc_and_orphan_asa(doc_id)
+      affected[model_type] << model_id
+      return
+    end
+
+    blob = create_blob_from_url(filename, content_type, url)
+    return if blob.nil?
+
+    ActiveRecord::Base.transaction do
+      ActiveStorage::Attachment.create!(record: parent, blob: blob, name: 'files')
+      delete_doc_and_orphan_asa(doc_id)
+    end
+
+    affected[model_type] << model_id
+  end
+
+  def attach_existing_blob(parent, doc_id, blob, doc_filename)
+    effective_filename = doc_filename.presence || blob.filename.to_s
+
+    if ActiveStorage::Attachment.exists?(record: parent, blob_id: blob.id, name: 'files')
+      delete_doc_and_orphan_asa(doc_id)
+      return
+    end
+
+    if parent_already_has_filename?(parent, effective_filename)
+      delete_doc_and_orphan_asa(doc_id)
+      return
+    end
+
+    ActiveRecord::Base.transaction do
+      ActiveStorage::Attachment.create!(record: parent, blob: blob, name: 'files')
+      delete_doc_and_orphan_asa(doc_id)
+    end
+  end
+
+  def parent_for(model_type, model_id)
+    return nil unless PARENT_TYPES.include?(model_type) && model_id
+    model_type.constantize.find_by(id: model_id)
+  end
+
+  def parent_already_has_filename?(parent, filename)
+    parent.files.attachments
+      .joins(:blob)
+      .where(active_storage_blobs: { filename: filename })
+      .exists?
+  end
+
+  def create_blob_from_url(filename, content_type, url)
+    key = blob_key_from_url(url)
+    return nil if key.blank?
+
+    if (existing_blob = ActiveStorage::Blob.find_by(key: key))
+      return existing_blob
+    end
+
+    metadata = fetch_blob_metadata(key) or return nil
+
+    ActiveStorage::Blob.create!(
+      key: key,
+      filename: filename,
+      content_type: content_type.presence || metadata[:content_type],
+      byte_size: metadata[:byte_size],
+      checksum: metadata[:checksum],
+      service_name: ActiveStorage::Blob.service.name.to_s
+    )
+  end
+
+  def blob_key_from_url(url)
+    URI(url).path.to_s.sub(%r{\A/}, '')
+  rescue URI::InvalidURIError
+    nil
+  end
+
+  def fetch_blob_metadata(key)
+    service = ActiveStorage::Blob.service
+    return nil unless service.exist?(key)
+
+    case service.class.name
+    when 'ActiveStorage::Service::S3Service'
+      obj = service.bucket.object(key)
+      { byte_size: obj.content_length,
+        content_type: obj.content_type,
+        checksum: obj.etag.to_s.tr('"', '') }
+    when 'ActiveStorage::Service::DiskService'
+      path = service.send(:path_for, key)
+      { byte_size: File.size(path),
+        content_type: nil,
+        checksum: OpenSSL::Digest::MD5.file(path).base64digest }
+    else
+      nil
+    end
+  rescue => e
+    Sidekiq.logger.warn "MigrateDocumentsToAttachmentsWorker: blob metadata fetch failed for key=#{key}: #{e.class}: #{e.message}"
+    nil
+  end
+
+  def delete_doc_and_orphan_asa(doc_id)
+    ActiveStorage::Attachment.where(record_type: 'Document', record_id: doc_id).delete_all
+    Document.where(id: doc_id).delete_all
+  end
+
+  def drop_doc(doc_id)
+    ActiveStorage::Attachment
+      .where(record_type: 'Document', record_id: doc_id)
+      .find_each(&:purge_later)
+    Document.where(id: doc_id).delete_all
+  end
+
+  def rebuild_attachments_json(affected)
+    affected.each do |model_type, ids|
+      klass = model_type.constantize
+      klass.where(id: ids.to_a).with_attached_files.find_each do |parent|
+        parent.send(:build_attachments)
+        parent.update_column(:attachments, parent[:attachments])
+      end
+    end
+  end
+end

--- a/app/workers/migrate_documents_to_attachments_worker.rb
+++ b/app/workers/migrate_documents_to_attachments_worker.rb
@@ -1,165 +1,18 @@
 class MigrateDocumentsToAttachmentsWorker
   include Sidekiq::Worker
 
-  PARENT_TYPES = %w[Comment Discussion Group Outcome Poll].freeze
-  BATCH_SIZE = 200
+  BATCH_SIZE = 500
 
   def perform(after_id = 0)
-    docs = Document
+    doc_ids = Document
       .where('id > ?', after_id)
       .order(:id)
       .limit(BATCH_SIZE)
-      .pluck(:id, :model_type, :model_id, :file_file_name, :file_content_type, :url)
-    return if docs.empty?
+      .pluck(:id)
+    return if doc_ids.empty?
 
-    affected = Hash.new { |h, k| h[k] = Set.new }
+    doc_ids.each { |id| MigrateDocumentToAttachmentWorker.perform_async(id) }
 
-    docs.each { |row| migrate_doc(row, affected) }
-
-    rebuild_attachments_json(affected)
-
-    next_after = docs.last.first
-    self.class.perform_async(next_after) if Document.where('id > ?', next_after).exists?
-  end
-
-  private
-
-  def migrate_doc(row, affected)
-    doc_id, model_type, model_id, filename, content_type, url = row
-    parent = parent_for(model_type, model_id)
-
-    if parent.nil?
-      drop_doc(doc_id)
-      return
-    end
-
-    if (existing = ActiveStorage::Attachment.find_by(record_type: 'Document', record_id: doc_id, name: 'file'))
-      attach_existing_blob(parent, doc_id, existing.blob, filename)
-      affected[model_type] << model_id
-      return
-    end
-
-    if filename.blank? || url.blank?
-      drop_doc(doc_id)
-      return
-    end
-
-    if parent_already_has_filename?(parent, filename)
-      delete_doc_and_orphan_asa(doc_id)
-      affected[model_type] << model_id
-      return
-    end
-
-    blob = create_blob_from_url(filename, content_type, url)
-    return if blob.nil?
-
-    ActiveRecord::Base.transaction do
-      ActiveStorage::Attachment.create!(record: parent, blob: blob, name: 'files')
-      delete_doc_and_orphan_asa(doc_id)
-    end
-
-    affected[model_type] << model_id
-  end
-
-  def attach_existing_blob(parent, doc_id, blob, doc_filename)
-    effective_filename = doc_filename.presence || blob.filename.to_s
-
-    if ActiveStorage::Attachment.exists?(record: parent, blob_id: blob.id, name: 'files')
-      delete_doc_and_orphan_asa(doc_id)
-      return
-    end
-
-    if parent_already_has_filename?(parent, effective_filename)
-      delete_doc_and_orphan_asa(doc_id)
-      return
-    end
-
-    ActiveRecord::Base.transaction do
-      ActiveStorage::Attachment.create!(record: parent, blob: blob, name: 'files')
-      delete_doc_and_orphan_asa(doc_id)
-    end
-  end
-
-  def parent_for(model_type, model_id)
-    return nil unless PARENT_TYPES.include?(model_type) && model_id
-    model_type.constantize.find_by(id: model_id)
-  end
-
-  def parent_already_has_filename?(parent, filename)
-    parent.files.attachments
-      .joins(:blob)
-      .where(active_storage_blobs: { filename: filename })
-      .exists?
-  end
-
-  def create_blob_from_url(filename, content_type, url)
-    key = blob_key_from_url(url)
-    return nil if key.blank?
-
-    if (existing_blob = ActiveStorage::Blob.find_by(key: key))
-      return existing_blob
-    end
-
-    metadata = fetch_blob_metadata(key) or return nil
-
-    ActiveStorage::Blob.create!(
-      key: key,
-      filename: filename,
-      content_type: content_type.presence || metadata[:content_type],
-      byte_size: metadata[:byte_size],
-      checksum: metadata[:checksum],
-      service_name: ActiveStorage::Blob.service.name.to_s
-    )
-  end
-
-  def blob_key_from_url(url)
-    URI(url).path.to_s.sub(%r{\A/}, '')
-  rescue URI::InvalidURIError
-    nil
-  end
-
-  def fetch_blob_metadata(key)
-    service = ActiveStorage::Blob.service
-    return nil unless service.exist?(key)
-
-    case service.class.name
-    when 'ActiveStorage::Service::S3Service'
-      obj = service.bucket.object(key)
-      { byte_size: obj.content_length,
-        content_type: obj.content_type,
-        checksum: obj.etag.to_s.tr('"', '') }
-    when 'ActiveStorage::Service::DiskService'
-      path = service.send(:path_for, key)
-      { byte_size: File.size(path),
-        content_type: nil,
-        checksum: OpenSSL::Digest::MD5.file(path).base64digest }
-    else
-      nil
-    end
-  rescue => e
-    Sidekiq.logger.warn "MigrateDocumentsToAttachmentsWorker: blob metadata fetch failed for key=#{key}: #{e.class}: #{e.message}"
-    nil
-  end
-
-  def delete_doc_and_orphan_asa(doc_id)
-    ActiveStorage::Attachment.where(record_type: 'Document', record_id: doc_id).delete_all
-    Document.where(id: doc_id).delete_all
-  end
-
-  def drop_doc(doc_id)
-    ActiveStorage::Attachment
-      .where(record_type: 'Document', record_id: doc_id)
-      .find_each(&:purge_later)
-    Document.where(id: doc_id).delete_all
-  end
-
-  def rebuild_attachments_json(affected)
-    affected.each do |model_type, ids|
-      klass = model_type.constantize
-      klass.where(id: ids.to_a).with_attached_files.find_each do |parent|
-        parent.send(:build_attachments)
-        parent.update_column(:attachments, parent[:attachments])
-      end
-    end
+    self.class.perform_async(doc_ids.last) if Document.where('id > ?', doc_ids.last).exists?
   end
 end

--- a/lib/tasks/loomio.rake
+++ b/lib/tasks/loomio.rake
@@ -283,4 +283,11 @@ namespace :loomio do
     end
   end
 
+  desc 'Migrate legacy Document records to ActiveStorage attachments on parent records'
+  task migrate_documents_to_attachments: :environment do
+    MigrateDocumentsToAttachmentsWorker.perform_async
+    puts "Enqueued MigrateDocumentsToAttachmentsWorker. Watch Sidekiq for progress."
+    puts "Remaining documents: #{Document.count}"
+  end
+
 end


### PR DESCRIPTION
## Summary

Adds two Sidekiq workers that drain the legacy `documents` table by moving each row into an ActiveStorage attachment on its parent record (Comment, Discussion, Group, Outcome, Poll). This is part one of two; this PR ships the workers only — the `Document` model, controller, etc. stay in place until the data has drained (PR #12387 follows).

- **`MigrateDocumentsToAttachmentsWorker`** — scheduler. Pulls 500 doc ids at a time and enqueues a `MigrateDocumentToAttachmentWorker` per id, then re-enqueues itself with the high-water mark.
- **`MigrateDocumentToAttachmentWorker`** — per-doc. Migrates one document. Parallelism follows Sidekiq concurrency.

## Categories handled

- **A** (~20K): doc has an existing AS attachment → reattach the blob to the parent, delete doc + orphan attachment row.
- **B** (~155K): doc has paperclip metadata + URL but no AS blob → HEAD storage, create a blob with the URL-derived key, attach to parent.
- **C** (~27K): URL-only "documents" → dropped (DB-only).
- **D** (~21): orphan / dangling-parent docs → dropped (DB-only).

## Properties

- **DB-only mutations.** `drop_doc` deletes attachment + document rows but does not call `purge_later` — no S3/disk bytes are removed by this PR. Orphan blobs (estimated ~28K) are left in place; storage cleanup is a separate job once the documents table is empty.
- **Idempotent at every layer.** Blob lookup by key, attachment-existence check, filename de-dup on the parent, plus `rescue ActiveRecord::RecordNotUnique` on blob create.
- **Parent-locked rebuild.** The per-doc worker wraps `attach + delete + rebuild attachments JSON` in \`parent.with_lock\` so two concurrent jobs migrating different docs to the same parent serialize on the parent row and never overwrite the JSON with a stale view.
- **\`after_id\` cursor** in the scheduler advances past docs that can't be migrated (genuine missing storage), so the scheduler doesn't loop forever.
- **Service-backend agnostic.** Dispatches on \`ActiveStorage::Blob.service.class.name\` so the same workers run on disk and S3-backed instances.

## Test plan

- [x] Cat A: re-attach existing blob, parent's \`attachments\` JSON rebuilt
- [x] Cat B (disk service): HEAD file, create blob with URL-derived key, attach
- [x] Cat C/D: doc dropped, no parent side effects
- [x] Dangling parent + ASA blob: doc + attachment row removed, **blob + bytes preserved**
- [x] Idempotency: re-running on the same doc creates no duplicate blobs/attachments
- [x] Scheduler: enqueues 500 per-doc jobs + 1 self re-enqueue per batch
- [ ] Run on production — kick off via \`bin/rake loomio:migrate_documents_to_attachments\`, monitor Sidekiq

## After this lands

PR #12387 removes the \`Document\` model, controller, service, serializer, query, routes, frontend \`DocumentList\` / \`Records.documents\`, and drops the \`documents\` table. That PR shouldn't be merged until the workers here have drained \`documents\` to zero on production. A separate one-off task can purge any orphan blobs left behind.