### PR TITLE
Make received-email allow/block idempotent

### DIFF
--- a/app/controllers/api/v1/received_emails_controller.rb
+++ b/app/controllers/api/v1/received_emails_controller.rb
@@ -24,12 +24,10 @@ class Api::V1::ReceivedEmailsController < Api::V1::RestfulController
       respond_with_error(403, "trial groups cannot add aliases")
     else
       user = @received_email.group.members.find(params[:user_id])
-      MemberEmailAlias.create(
+      MemberEmailAlias.find_or_initialize_by(
         email: @received_email.sender_email,
-        user: user,
-        group_id: @received_email.group_id,
-        author_id: current_user.id
-      )
+        group_id: @received_email.group_id
+      ).update!(user: user, author_id: current_user.id)
       ReceivedEmailService.route(@received_email)
       respond_with_resource
     end
@@ -37,12 +35,10 @@ class Api::V1::ReceivedEmailsController < Api::V1::RestfulController
 
   def block
     @received_email = ReceivedEmail.unreleased.where(group_id: current_user.adminable_group_ids).find(params[:id])
-    MemberEmailAlias.create!(
+    MemberEmailAlias.find_or_initialize_by(
       email: @received_email.sender_email,
-      user_id: nil,
-      group_id: @received_email.group_id,
-      author_id: current_user.id
-    )
+      group_id: @received_email.group_id
+    ).update!(user_id: nil, author_id: current_user.id)
     @received_email.update(group_id: nil)
     respond_with_resource
   end

--- a/test/controllers/api/v1/received_emails_controller_test.rb
+++ b/test/controllers/api/v1/received_emails_controller_test.rb
@@ -92,6 +92,53 @@ class Api::V1::ReceivedEmailsControllerTest < ActionController::TestCase
     assert_equal @user.id, MemberEmailAlias.last.user_id
   end
 
+  test "allow succeeds when an alias for that sender already exists" do
+    MemberEmailAlias.create!(
+      email: 'someone@gmail.com',
+      user_id: @user.id,
+      group_id: @group.id,
+      author_id: @user.id
+    )
+    received_email = ReceivedEmail.create!(
+      group_id: @group.id,
+      headers: {
+        to: "#{@group.handle}@#{ENV['REPLY_HOSTNAME']}",
+        from: "someone@gmail.com"
+      },
+      body_html: "<p>hello there</p>",
+      body_text: "hello there"
+    )
+
+    assert_difference 'MemberEmailAlias.count', 0 do
+      post :allow, params: { id: received_email.id, user_id: @user.id }
+    end
+    assert_response :success
+  end
+
+  test "allow upgrades a previously blocked alias" do
+    received_email = ReceivedEmail.create!(
+      group_id: @group.id,
+      headers: {
+        to: "#{@group.handle}@#{ENV['REPLY_HOSTNAME']}",
+        from: "someone@gmail.com"
+      },
+      body_html: "<p>hello there</p>",
+      body_text: "hello there"
+    )
+    MemberEmailAlias.create!(
+      email: 'someone@gmail.com',
+      user_id: nil,
+      group_id: @group.id,
+      author_id: @user.id
+    )
+
+    assert_difference 'MemberEmailAlias.count', 0 do
+      post :allow, params: { id: received_email.id, user_id: @user.id }
+    end
+    assert_response :success
+    assert_equal @user.id, MemberEmailAlias.find_by(email: 'someone@gmail.com', group_id: @group.id).user_id
+  end
+
   test "allow returns 404 for wrong group" do
     another_received_email = ReceivedEmail.create!(
       group_id: @another_group.id,
@@ -149,6 +196,30 @@ class Api::V1::ReceivedEmailsControllerTest < ActionController::TestCase
     assert_response :success
     assert_equal 1, json['received_emails'].length
     assert_nil MemberEmailAlias.last.user_id
+  end
+
+  test "block is idempotent when alias already exists" do
+    received_email = ReceivedEmail.create!(
+      group_id: @group.id,
+      headers: {
+        to: "#{@group.handle}@#{ENV['REPLY_HOSTNAME']}",
+        from: "someone@gmail.com"
+      },
+      body_html: "<p>hello there</p>",
+      body_text: "hello there"
+    )
+    MemberEmailAlias.create!(
+      email: 'someone@gmail.com',
+      user_id: @user.id,
+      group_id: @group.id,
+      author_id: @user.id
+    )
+
+    assert_difference 'MemberEmailAlias.count', 0 do
+      post :block, params: { id: received_email.id, user_id: @user.id }
+    end
+    assert_response :success
+    assert_nil MemberEmailAlias.find_by(email: 'someone@gmail.com', group_id: @group.id).user_id
   end
 
   test "block returns 404 for wrong group" do

--- a/vue/src/components/group/member_email_alias_modal.vue
+++ b/vue/src/components/group/member_email_alias_modal.vue
@@ -35,6 +35,8 @@ export default {
         EventBus.$emit('closeModal');
         Flash.success('email_to_group.email_released');
         this.callbackFn();
+      }).catch((err) => {
+        Flash.serverError(err);
       }).finally(() => {
         this.loading = false;
       });


### PR DESCRIPTION
## Summary
- `Api::V1::ReceivedEmailsController#allow` and `#block` were calling `MemberEmailAlias.create(!)` and 500ing with `RecordNotUnique` when a row already existed for `(email, group_id)`. Switch both to `find_or_initialize_by(email:, group_id:)` + `update!`, so a prior block upgrades to allow, and a prior allow downgrades to block.
- Vue `member_email_alias_modal` submit handler had no `.catch`, so any 500 left the modal open with no feedback — admins clicked again and again (Sentry showed 18 retries from one user). Surface server errors via `Flash.serverError(err)`.

Fixes [LOOMIO-COM-28T](https://loomio.sentry.io/issues/LOOMIO-COM-28T).

## Test plan
- [x] `bin/rails test test/controllers/api/v1/received_emails_controller_test.rb` — 13/13 pass, including 3 new cases (allow over existing alias, allow upgrades a block, block over existing alias)
- [x] Full suite: `bin/rails test` — 1298/1298 (2 pre-existing `Admin::FunnelControllerTest` errors are unrelated; LoomioSubs `FunnelService` queries a `topics` table not in master's schema, and the brakeman.ignore note flags it as dead code)
- [ ] Manual: open the email-alias modal, confirm a sender that already has an alias — should succeed, not 500