### PR TITLE
[codex] expire and consume login codes

### DIFF
--- a/app/controllers/api/v1/sessions_controller.rb
+++ b/app/controllers/api/v1/sessions_controller.rb
@@ -51,8 +51,24 @@ class Api::V1::SessionsController < Devise::SessionsController
   end
 
   def login_token_user
-    token = LoginToken.unused.find_by(code: resource_params.require(:code))
-    token.user if token&.user&.email == resource_params.require(:email)
+    LoginToken.transaction do
+      token = LoginToken.unused.lock.find_by(code: resource_params.require(:code))
+      next unless login_token_matches?(token)
+
+      token.update!(used: true)
+      token.user
+    end
+  end
+
+  def login_token_matches?(token)
+    resource_params[:email].present? && token&.useable? && token.user.email == resource_params[:email]
+  end
+
+  def usable_login_token_for_code
+    return unless resource_params[:code].present?
+
+    token = LoginToken.unused.find_by(code: resource_params[:code])
+    token if login_token_matches?(token)
   end
 
   def configure_permitted_parameters
@@ -67,7 +83,7 @@ class Api::V1::SessionsController < Devise::SessionsController
   # entropy make code-flow safe without a fresh CAPTCHA.
   def turnstile_ok?
     return true if pending_login_token&.useable?
-    return true if resource_params[:code].present?
+    return true if usable_login_token_for_code
     TurnstileService.verify(params.dig(:user, :turnstile_token) || params[:turnstile_token],
                             remote_ip: request.remote_ip)
   end

--- a/test/controllers/api/v1/sessions_controller_test.rb
+++ b/test/controllers/api/v1/sessions_controller_test.rb
@@ -54,6 +54,24 @@ class Api::V1::SessionsControllerTest < ActionController::TestCase
     assert_response :success
   end
 
+  test "turnstile is skipped only for a valid login code" do
+    ENV['TURNSTILE_SECRET_KEY'] = 'test-secret'
+    user = User.create!(email: "emailcode@example.com", email_verified: true)
+    token = LoginToken.create!(user: user)
+
+    post :create, params: { user: { email: user.email, code: token.code } }
+    assert_response :success
+  end
+
+  test "turnstile is required for an invalid login code" do
+    ENV['TURNSTILE_SECRET_KEY'] = 'test-secret'
+    user = User.create!(email: "bademailcode@example.com", email_verified: true)
+    token = LoginToken.create!(user: user)
+
+    post :create, params: { user: { email: user.email, code: token.code + 1 } }
+    assert_response :forbidden
+  end
+
   test "signs in with password" do
     user = User.create!(
       email: "sessionsuser@example.com",
@@ -93,6 +111,35 @@ class Api::V1::SessionsControllerTest < ActionController::TestCase
     
     json = JSON.parse(response.body)
     assert_equal user.id, json['current_user_id']
+  end
+
+  test "signs in a user via code and marks the token used" do
+    user = User.create!(email: "codeuser@example.com", email_verified: true)
+    token = LoginToken.create!(user: user)
+
+    post :create, params: { user: { email: user.email, code: token.code } }
+    assert token.reload.used
+    assert_response :success
+
+    json = JSON.parse(response.body)
+    assert_equal user.id, json['current_user_id']
+  end
+
+  test "does not sign in with an expired code" do
+    user = User.create!(email: "expiredcodeuser@example.com", email_verified: true)
+    token = LoginToken.create!(user: user, created_at: 25.hours.ago)
+
+    post :create, params: { user: { email: user.email, code: token.code } }
+    refute token.reload.used
+    assert_response :unauthorized
+  end
+
+  test "does not sign in with a used code" do
+    user = User.create!(email: "usedcodeuser@example.com", email_verified: true)
+    token = LoginToken.create!(user: user, used: true)
+
+    post :create, params: { user: { email: user.email, code: token.code } }
+    assert_response :unauthorized
   end
 
   test "does not sign in a user with a used token" do


### PR DESCRIPTION
## Summary
- Require email login codes to match a usable token.
- Mark successful code logins as used under a row lock.
- Only skip Turnstile for a valid usable code.

## Why
Previously 6-digit login codes could bypass Turnstile before validity was known and were not consumed by the code-login path.

## Tests
- bundle exec rails test test/controllers/api/v1/sessions_controller_test.rb