### PR TITLE
[codex] handle invalid auth referrers

### DIFF
--- a/app/controllers/api/v1/login_tokens_controller.rb
+++ b/app/controllers/api/v1/login_tokens_controller.rb
@@ -6,9 +6,17 @@ class Api::V1::LoginTokensController < Api::V1::RestfulController
     end
     if user = User.find_by(email: params.require(:email))
       save_detected_locale(user)
-      service.create(actor: user, uri: URI::parse(request.referrer.to_s))
+      service.create(actor: user, uri: referrer_uri)
     end
     # Always return success to prevent account enumeration
     render json: { success: :ok }
+  end
+
+  private
+
+  def referrer_uri
+    URI.parse(request.referrer.to_s)
+  rescue URI::InvalidURIError
+    nil
   end
 end

--- a/app/controllers/api/v1/registrations_controller.rb
+++ b/app/controllers/api/v1/registrations_controller.rb
@@ -17,7 +17,7 @@ class Api::V1::RegistrationsController < Devise::RegistrationsController
         flash[:notice] = t(:'devise.sessions.signed_in')
         render json: Boot::User.new(resource, root_url: URI(root_url).origin).payload.merge({ success: :ok, signed_in: true })
       else
-        LoginTokenService.create(actor: resource, uri: URI.parse(request.referrer.to_s))
+        LoginTokenService.create(actor: resource, uri: referrer_uri)
         render json: { success: :ok, signed_in: false }
       end
       EventBus.broadcast('registration_create', resource)
@@ -40,6 +40,12 @@ class Api::V1::RegistrationsController < Devise::RegistrationsController
   def pending_user
     user = (pending_membership || pending_login_token || pending_identity)&.user
     user if user && !user.email_verified?
+  end
+
+  def referrer_uri
+    URI.parse(request.referrer.to_s)
+  rescue URI::InvalidURIError
+    nil
   end
 
   def permission_check

--- a/test/controllers/api/v1/login_tokens_controller_test.rb
+++ b/test/controllers/api/v1/login_tokens_controller_test.rb
@@ -17,6 +17,17 @@ class Api::V1::LoginTokensControllerTest < ActionController::TestCase
     assert_response :success
   end
 
+  test "create handles an invalid referrer" do
+    user = users(:normal_user)
+    request.env['HTTP_REFERER'] = 'http://%zz'
+
+    assert_difference -> { user.login_tokens.count }, 1 do
+      post :create, params: { email: user.email }
+    end
+
+    assert_response :success
+  end
+
   test "create updates detected locale" do
     user = users(:normal_user)
     user.update_detected_locale('en')

--- a/test/controllers/api/v1/registrations_controller_test.rb
+++ b/test/controllers/api/v1/registrations_controller_test.rb
@@ -65,6 +65,22 @@ class Api::V1::RegistrationsControllerTest < ActionController::TestCase
     assert u.legal_accepted_at.present?
   end
 
+  test "creates a new user with an invalid referrer" do
+    request.env['HTTP_REFERER'] = 'http://%zz'
+
+    assert_difference 'User.count', 1 do
+      post :create, params: {
+        user: {
+          name: "Bad Referrer",
+          email: "bad-referrer@example.com",
+          legal_accepted: true
+        }
+      }
+    end
+
+    assert_response :success
+  end
+
   test "sign up via email for existing user (email_verified = false)" do
     u = User.create(email: "jon@snow.com", email_verified: false)
 


### PR DESCRIPTION
## Summary
- Parse auth referrer headers safely for registration and login-token creation.
- Fall back to nil redirect context for malformed referrers.

## Why
A malformed Referrer header should not turn auth email flows into a 500.

## Tests
- bundle exec rails test test/controllers/api/v1/registrations_controller_test.rb test/controllers/api/v1/login_tokens_controller_test.rb