### PR TITLE
[codex] redact client access tokens from logs

### DIFF
--- a/app/extras/clients/base.rb
+++ b/app/extras/clients/base.rb
@@ -89,7 +89,7 @@ class Clients::Base
 
   def default_failure
     ->(response) {
-      Rails.logger.info "Failed #{self.class.name.demodulize} api request. response: #{response} token: #{@token}"
+      Rails.logger.info "Failed #{self.class.name.demodulize} api request. response: #{response}"
       response
     }
   end

--- a/test/extras/clients/base_test.rb
+++ b/test/extras/clients/base_test.rb
@@ -1,0 +1,17 @@
+require 'test_helper'
+
+class Clients::BaseTest < ActiveSupport::TestCase
+  test "default failure log does not include access token" do
+    previous_logger = Rails.logger
+    log_output = StringIO.new
+    Rails.logger = ActiveSupport::Logger.new(log_output)
+
+    client = Clients::Base.new(token: 'secret-access-token')
+    response = 'unauthorized'
+
+    assert_equal response, client.send(:default_failure).call(response)
+    refute_includes log_output.string, 'secret-access-token'
+  ensure
+    Rails.logger = previous_logger
+  end
+end


### PR DESCRIPTION
## Summary
- Remove OAuth/API access token interpolation from shared client failure logs.
- Add a focused test covering the failure logger.

## Why
Bearer tokens should not be written to application logs on provider API failures.

## Tests
- bundle exec rails test test/extras/clients/base_test.rb