### PR TITLE
[codex] validate oauth state

### DIFF
--- a/app/controllers/identities/base_controller.rb
+++ b/app/controllers/identities/base_controller.rb
@@ -1,10 +1,13 @@
 class Identities::BaseController < ApplicationController
   def oauth
     session[:back_to] = safe_back_to
+    session[:oauth_state] = SecureRandom.hex(32)
     redirect_to oauth_url
   end
 
   def create
+    return respond_with_error(401, "OAuth state mismatch") unless valid_oauth_state?
+
     if params[:error].present?
       flash[:error] = t(:'auth.oauth_cancelled')
       return redirect_to session.delete(:back_to) || dashboard_path
@@ -71,7 +74,12 @@ class Identities::BaseController < ApplicationController
   end
 
   def oauth_params
-    { client.client_key_name => client.key, redirect_uri: redirect_uri, scope: oauth_scope }
+    {
+      client.client_key_name => client.key,
+      redirect_uri: redirect_uri,
+      scope: oauth_scope,
+      state: session[:oauth_state]
+    }
   end
 
   def client
@@ -89,5 +97,13 @@ class Identities::BaseController < ApplicationController
   def safe_back_to
     path = (params[:back_to] || request.referrer).to_s
     path if path.start_with?('/') && !path.start_with?('//', '/\\')
+  end
+
+  def valid_oauth_state?
+    expected_state = session.delete(:oauth_state).to_s
+    returned_state = params[:state].to_s
+    return false if expected_state.blank? || returned_state.blank?
+
+    ActiveSupport::SecurityUtils.secure_compare(expected_state, returned_state)
   end
 end

--- a/app/controllers/identities/nextcloud_controller.rb
+++ b/app/controllers/identities/nextcloud_controller.rb
@@ -15,7 +15,12 @@ class Identities::NextcloudController < Identities::BaseController
   end
 
   def oauth_params
-    { client.client_key_name => client.key, redirect_uri: redirect_uri, response_type: :code }
+    {
+      client.client_key_name => client.key,
+      redirect_uri: redirect_uri,
+      response_type: :code,
+      state: session[:oauth_state]
+    }
   end
 
   def client

--- a/app/controllers/identities/oauth_controller.rb
+++ b/app/controllers/identities/oauth_controller.rb
@@ -12,6 +12,12 @@ class Identities::OauthController < Identities::BaseController
 
   def oauth_params
     client = Clients::Oauth.instance
-    { client.client_key_name => client.key, redirect_uri: redirect_uri, scope: ENV.fetch('OAUTH_SCOPE'),  response_type: :code }
+    {
+      client.client_key_name => client.key,
+      redirect_uri: redirect_uri,
+      scope: ENV.fetch('OAUTH_SCOPE'),
+      response_type: :code,
+      state: session[:oauth_state]
+    }
   end
 end

--- a/test/controllers/identities/google_controller_test.rb
+++ b/test/controllers/identities/google_controller_test.rb
@@ -45,6 +45,8 @@ class Identities::GoogleControllerTest < ActionController::TestCase
     assert_match(/accounts\.google\.com/, response.location)
     assert_includes response.location, 'client_id=google_client_id'
     assert_includes response.location, 'scope=email+profile'
+    assert_includes response.location, 'state='
+    assert session[:oauth_state].present?
   end
 
   test "rejects external back_to" do
@@ -53,7 +55,7 @@ class Identities::GoogleControllerTest < ActionController::TestCase
   end
 
   test "creates user and signs in" do
-    get :create, params: { code: 'google_auth_code' }
+    get :create, params: oauth_callback_params(code: 'google_auth_code')
 
     user = User.find_by(email: "google-#{@hex}@example.com")
     assert user
@@ -69,7 +71,7 @@ class Identities::GoogleControllerTest < ActionController::TestCase
   test "auto-links to verified user" do
     existing = User.create!(name: 'Existing', email: "google-#{@hex}@example.com", username: "gex#{@hex}", email_verified: true)
 
-    get :create, params: { code: 'google_auth_code' }
+    get :create, params: oauth_callback_params(code: 'google_auth_code')
 
     identity = Identity.find_by(identity_type: 'google', uid: "google_#{@hex}")
     assert_equal existing.id, identity.user_id
@@ -79,10 +81,17 @@ class Identities::GoogleControllerTest < ActionController::TestCase
   test "links to unverified user and verifies email" do
     unverified = User.create!(name: 'Invited', email: "google-#{@hex}@example.com", username: "ginv#{@hex}", email_verified: false)
 
-    get :create, params: { code: 'google_auth_code' }
+    get :create, params: oauth_callback_params(code: 'google_auth_code')
 
     identity = Identity.find_by(identity_type: 'google', uid: "google_#{@hex}")
     assert_equal unverified.id, identity.user_id
     assert unverified.reload.email_verified?
+  end
+
+  private
+
+  def oauth_callback_params(params = {})
+    session[:oauth_state] = 'test-oauth-state'
+    params.merge(state: 'test-oauth-state')
   end
 end

--- a/test/controllers/identities/nextcloud_controller_test.rb
+++ b/test/controllers/identities/nextcloud_controller_test.rb
@@ -47,6 +47,8 @@ class Identities::NextcloudControllerTest < ActionController::TestCase
     assert_equal '/some/path', session[:back_to]
     assert_match(/cloud\.example\.com/, response.location)
     assert_includes response.location, 'client_id=nc_client_id'
+    assert_includes response.location, 'state='
+    assert session[:oauth_state].present?
   end
 
   test "rejects external back_to" do
@@ -55,7 +57,7 @@ class Identities::NextcloudControllerTest < ActionController::TestCase
   end
 
   test "creates user and signs in" do
-    get :create, params: { code: 'nc_auth_code' }
+    get :create, params: oauth_callback_params(code: 'nc_auth_code')
 
     user = User.find_by(email: "nc-#{@hex}@example.com")
     assert user
@@ -70,7 +72,7 @@ class Identities::NextcloudControllerTest < ActionController::TestCase
   test "auto-links to verified user" do
     existing = User.create!(name: 'Existing', email: "nc-#{@hex}@example.com", username: "ncex#{@hex}", email_verified: true)
 
-    get :create, params: { code: 'nc_auth_code' }
+    get :create, params: oauth_callback_params(code: 'nc_auth_code')
 
     identity = Identity.find_by(identity_type: 'nextcloud', uid: "nc_#{@hex}")
     assert_equal existing.id, identity.user_id
@@ -80,10 +82,17 @@ class Identities::NextcloudControllerTest < ActionController::TestCase
   test "links to unverified user and verifies email" do
     unverified = User.create!(name: 'Invited', email: "nc-#{@hex}@example.com", username: "ncinv#{@hex}", email_verified: false)
 
-    get :create, params: { code: 'nc_auth_code' }
+    get :create, params: oauth_callback_params(code: 'nc_auth_code')
 
     identity = Identity.find_by(identity_type: 'nextcloud', uid: "nc_#{@hex}")
     assert_equal unverified.id, identity.user_id
     assert unverified.reload.email_verified?
+  end
+
+  private
+
+  def oauth_callback_params(params = {})
+    session[:oauth_state] = 'test-oauth-state'
+    params.merge(state: 'test-oauth-state')
   end
 end

--- a/test/controllers/identities/oauth_controller_test.rb
+++ b/test/controllers/identities/oauth_controller_test.rb
@@ -51,9 +51,11 @@ class Identities::OauthControllerTest < ActionController::TestCase
   test "redirects to OAuth provider with correct parameters" do
     get :oauth, params: { back_to: '/some/path' }
     assert_equal '/some/path', session[:back_to]
+    assert session[:oauth_state].present?
     assert_match(/https:\/\/oauth\.provider\.com\/authorize/, response.location)
     assert_includes response.location, 'client_id=mock_client_id'
     assert_includes response.location, 'scope=openid+profile+email'
+    assert_includes response.location, 'state='
   end
 
   test "stores referrer as back_to when it is a relative path" do
@@ -73,7 +75,7 @@ class Identities::OauthControllerTest < ActionController::TestCase
     session[:back_to] = '/dashboard'
 
     assert_difference ['Identity.where(identity_type: "oauth").count', 'User.count'], 1 do
-      get :create, params: { code: 'authorization_code_123' }
+      get :create, params: oauth_callback_params(code: 'authorization_code_123')
     end
 
     identity = Identity.where(identity_type: 'oauth').last
@@ -97,7 +99,7 @@ class Identities::OauthControllerTest < ActionController::TestCase
 
     assert_difference 'Identity.where(identity_type: "oauth").count', 1 do
       assert_no_difference 'User.count' do
-        get :create, params: { code: 'authorization_code_123' }
+        get :create, params: oauth_callback_params(code: 'authorization_code_123')
       end
     end
 
@@ -110,7 +112,7 @@ class Identities::OauthControllerTest < ActionController::TestCase
   test "does not overwrite user name by default" do
     hex = SecureRandom.hex(4)
     existing_user = User.create!(name: 'Original Name', email: 'oauth@example.com', username: "oauthex#{hex}", email_verified: true)
-    get :create, params: { code: 'authorization_code_123' }
+    get :create, params: oauth_callback_params(code: 'authorization_code_123')
     assert_equal 'Original Name', existing_user.reload.name
   end
 
@@ -120,7 +122,7 @@ class Identities::OauthControllerTest < ActionController::TestCase
     existing_user = User.create!(name: 'Original Name', email: 'oauth@example.com', username: "oauthex#{hex}", email_verified: true)
     ENV['LOOMIO_SSO_FORCE_USER_ATTRS'] = 'true'
 
-    get :create, params: { code: 'authorization_code_123' }
+    get :create, params: oauth_callback_params(code: 'authorization_code_123')
 
     existing_user.reload
     assert_equal 'OAuth User', existing_user.name
@@ -136,7 +138,7 @@ class Identities::OauthControllerTest < ActionController::TestCase
 
     assert_difference 'Identity.where(identity_type: "oauth").count', 1 do
       assert_no_difference 'User.count' do
-        get :create, params: { code: 'authorization_code_123' }
+        get :create, params: oauth_callback_params(code: 'authorization_code_123')
       end
     end
 
@@ -162,7 +164,7 @@ class Identities::OauthControllerTest < ActionController::TestCase
     session[:back_to] = '/dashboard'
 
     assert_no_difference ['Identity.where(identity_type: "oauth").count', 'User.count'] do
-      get :create, params: { code: 'authorization_code_123' }
+      get :create, params: oauth_callback_params(code: 'authorization_code_123')
     end
 
     existing_identity.reload
@@ -190,7 +192,7 @@ class Identities::OauthControllerTest < ActionController::TestCase
     ENV['LOOMIO_SSO_FORCE_USER_ATTRS'] = 'true'
     session[:back_to] = '/dashboard'
 
-    get :create, params: { code: 'authorization_code_123' }
+    get :create, params: oauth_callback_params(code: 'authorization_code_123')
 
     existing_identity.reload
     assert_equal 'oauth@example.com', existing_identity.email
@@ -213,7 +215,7 @@ class Identities::OauthControllerTest < ActionController::TestCase
 
     assert_difference 'Identity.where(identity_type: "oauth").count', 1 do
       assert_no_difference -> { current_user.identities.count } do
-        get :create, params: { code: 'authorization_code_123' }
+        get :create, params: oauth_callback_params(code: 'authorization_code_123')
       end
     end
 
@@ -229,9 +231,16 @@ class Identities::OauthControllerTest < ActionController::TestCase
   # Auth failure - user cancels
   test "returns to dashboard with error when user cancels" do
     session[:back_to] = '/dashboard'
-    get :create, params: { error: 'access_denied' }
+    get :create, params: oauth_callback_params(error: 'access_denied')
     assert_redirected_to '/dashboard'
     assert_equal I18n.t('auth.oauth_cancelled'), flash[:error]
+  end
+
+  test "returns 401 when oauth state does not match" do
+    session[:oauth_state] = 'expected-state'
+    get :create, params: { code: 'authorization_code_123', state: 'wrong-state' }, format: :json
+    assert_response 401
+    assert_equal 'OAuth state mismatch', JSON.parse(response.body)['error']
   end
 
   # Auth failure - token not returned
@@ -243,7 +252,7 @@ class Identities::OauthControllerTest < ActionController::TestCase
         headers: { 'Content-Type' => 'application/json' }
       )
 
-    get :create, params: { code: 'invalid_code' }, format: :json
+    get :create, params: oauth_callback_params(code: 'invalid_code'), format: :json
     assert_response 401
     json = JSON.parse(response.body)
     assert_equal 'OAuth authorization failed', json['error']
@@ -258,7 +267,7 @@ class Identities::OauthControllerTest < ActionController::TestCase
         headers: { 'Content-Type' => 'application/json' }
       )
 
-    get :create, params: { code: 'valid_code' }, format: :json
+    get :create, params: oauth_callback_params(code: 'valid_code'), format: :json
     assert_response 401
     json = JSON.parse(response.body)
     assert_equal 'Could not fetch user profile from OAuth provider', json['error']
@@ -266,7 +275,7 @@ class Identities::OauthControllerTest < ActionController::TestCase
 
   # Fallback redirect
   test "redirects to dashboard when no back_to is set" do
-    get :create, params: { code: 'authorization_code_123' }
+    get :create, params: oauth_callback_params(code: 'authorization_code_123')
     assert_redirected_to dashboard_path
   end
 
@@ -303,5 +312,12 @@ class Identities::OauthControllerTest < ActionController::TestCase
     assert_response 500
     json = JSON.parse(response.body)
     assert json['error'].present?
+  end
+
+  private
+
+  def oauth_callback_params(params = {})
+    session[:oauth_state] = 'test-oauth-state'
+    params.merge(state: 'test-oauth-state')
   end
 end


### PR DESCRIPTION
## Summary
- Generate a session-bound OAuth state before provider redirect.
- Include state in OAuth provider params.
- Reject callbacks whose returned state does not match.

## Why
OAuth callbacks need browser-session correlation to prevent login CSRF/account switching.

## Tests
- bundle exec rails test test/controllers/identities/oauth_controller_test.rb test/controllers/identities/google_controller_test.rb test/controllers/identities/nextcloud_controller_test.rb