### PR TITLE
[codex] protect identity disconnect routes

### DIFF
--- a/app/controllers/identities/saml_controller.rb
+++ b/app/controllers/identities/saml_controller.rb
@@ -1,5 +1,5 @@
 class Identities::SamlController < ApplicationController
-  skip_before_action :verify_authenticity_token
+  skip_before_action :verify_authenticity_token, only: :create
   include Routing
   
   def oauth

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -455,7 +455,7 @@ Rails.application.routes.draw do
     scope provider do
       get :oauth,                           to: "identities/#{provider}#oauth",       as: :"#{provider}_oauth"
       get :authorize,                       to: "identities/#{provider}#create",      as: :"#{provider}_authorize"
-      get '/',                              to: "identities/#{provider}#destroy",     as: :"#{provider}_unauthorize"
+      delete '/',                           to: "identities/#{provider}#destroy",     as: :"#{provider}_unauthorize"
     end
   end
 

--- a/test/controllers/identities/oauth_controller_test.rb
+++ b/test/controllers/identities/oauth_controller_test.rb
@@ -279,7 +279,7 @@ class Identities::OauthControllerTest < ActionController::TestCase
     request.env['HTTP_REFERER'] = 'http://test.host/settings'
 
     assert_difference -> { user.identities.count }, -1 do
-      get :destroy
+      delete :destroy
     end
 
     assert_nil Identity.find_by(id: identity.id, identity_type: 'oauth')
@@ -291,7 +291,7 @@ class Identities::OauthControllerTest < ActionController::TestCase
     user = User.create!(name: "oauser#{hex}", email: "oauser#{hex}@example.com", username: "oauser#{hex}", email_verified: true)
     Identity.create!(identity_type: 'oauth', uid: 'oauth_user_123', email: 'oauth@example.com', access_token: 'token', user: user)
     sign_in user
-    get :destroy
+    delete :destroy
     assert_redirected_to root_path
   end
 
@@ -299,7 +299,7 @@ class Identities::OauthControllerTest < ActionController::TestCase
     hex = SecureRandom.hex(4)
     user = User.create!(name: "oauser#{hex}", email: "oauser#{hex}@example.com", username: "oauser#{hex}", email_verified: true)
     sign_in user
-    get :destroy, format: :json
+    delete :destroy, format: :json
     assert_response 500
     json = JSON.parse(response.body)
     assert json['error'].present?

--- a/test/controllers/identities/saml_controller_test.rb
+++ b/test/controllers/identities/saml_controller_test.rb
@@ -338,7 +338,7 @@ class Identities::SamlControllerTest < ActionController::TestCase
     request.env['HTTP_REFERER'] = 'http://test.host/settings'
 
     assert_difference -> { user.identities.count }, -1 do
-      get :destroy
+      delete :destroy
     end
 
     assert_nil Identity.find_by(id: identity.id, identity_type: 'saml')
@@ -350,7 +350,7 @@ class Identities::SamlControllerTest < ActionController::TestCase
     user = User.create!(name: "samluser#{hex}", email: "samluser#{hex}@example.com", username: "samluser#{hex}", email_verified: true)
     Identity.create!(identity_type: 'saml', uid: 'saml_user_123', email: 'saml@example.com', access_token: nil, user: user)
     sign_in user
-    get :destroy
+    delete :destroy
     assert_redirected_to root_path
   end
 
@@ -358,7 +358,7 @@ class Identities::SamlControllerTest < ActionController::TestCase
     hex = SecureRandom.hex(4)
     user = User.create!(name: "samluser#{hex}", email: "samluser#{hex}@example.com", username: "samluser#{hex}", email_verified: true)
     sign_in user
-    get :destroy, format: :json
+    delete :destroy, format: :json
     assert_response 500
     json = JSON.parse(response.body)
     assert json['error'].present?


### PR DESCRIPTION
## Summary
- Move identity disconnect routes from GET to DELETE.
- Narrow SAML CSRF skipping to the ACS callback only.
- Update controller tests to use DELETE for disconnect.

## Why
Disconnecting SSO identities is a state-changing action and should not be triggerable by a cross-site GET.

## Tests
- bundle exec rails test test/controllers/identities/oauth_controller_test.rb test/controllers/identities/saml_controller_test.rb