### PR TITLE
[codex] require verified email for generic oauth

### DIFF
--- a/app/controllers/identities/base_controller.rb
+++ b/app/controllers/identities/base_controller.rb
@@ -15,9 +15,10 @@ class Identities::BaseController < ApplicationController
 
     identity_params = fetch_identity_params(access_token)
     return respond_with_error(401, "Could not fetch user profile from OAuth provider") unless identity_params[:uid].present? && identity_params[:email].present?
+    return respond_with_error(401, "OAuth provider did not verify email") unless email_verified_by_provider?(identity_params)
 
     identity = IdentityService.link_or_create(
-      identity_params: identity_params,
+      identity_params: identity_params.except(:email_verified),
       current_user: current_user
     )
 
@@ -56,6 +57,10 @@ class Identities::BaseController < ApplicationController
   def fetch_identity_params(token)
     client = "Clients::#{controller_name.classify}".constantize.new(token: token)
     client.fetch_identity_params.merge({ access_token: token, identity_type: controller_name })
+  end
+
+  def email_verified_by_provider?(_identity_params)
+    true
   end
 
   def redirect_uri

--- a/app/controllers/identities/oauth_controller.rb
+++ b/app/controllers/identities/oauth_controller.rb
@@ -14,4 +14,10 @@ class Identities::OauthController < Identities::BaseController
     client = Clients::Oauth.instance
     { client.client_key_name => client.key, redirect_uri: redirect_uri, scope: ENV.fetch('OAUTH_SCOPE'),  response_type: :code }
   end
+
+  def email_verified_by_provider?(identity_params)
+    return true if ActiveModel::Type::Boolean.new.cast(ENV.fetch('OAUTH_SKIP_EMAIL_VERIFIED_CHECK', false))
+
+    ActiveModel::Type::Boolean.new.cast(identity_params[:email_verified])
+  end
 end

--- a/app/extras/clients/oauth.rb
+++ b/app/extras/clients/oauth.rb
@@ -13,6 +13,7 @@ class Clients::Oauth < Clients::Base
       uid: data.dig(ENV.fetch('OAUTH_ATTR_UID', 'sub')),
       name: data.dig(ENV.fetch('OAUTH_ATTR_NAME', 'name')),
       email: data.dig(ENV.fetch('OAUTH_ATTR_EMAIL', 'email')),
+      email_verified: data.dig(ENV.fetch('OAUTH_ATTR_EMAIL_VERIFIED', 'email_verified')),
       logo: data.dig(ENV.fetch('OAUTH_ATTR_PICTURE', 'picture'))
     }.compact
   end

--- a/test/controllers/identities/oauth_controller_test.rb
+++ b/test/controllers/identities/oauth_controller_test.rb
@@ -7,6 +7,7 @@ class Identities::OauthControllerTest < ActionController::TestCase
     @saved_env = {}
     %w[OAUTH_AUTH_URL OAUTH_TOKEN_URL OAUTH_PROFILE_URL OAUTH_SCOPE
        OAUTH_ATTR_UID OAUTH_ATTR_NAME OAUTH_ATTR_EMAIL OAUTH_APP_KEY OAUTH_APP_SECRET
+       OAUTH_ATTR_EMAIL_VERIFIED OAUTH_SKIP_EMAIL_VERIFIED_CHECK
        LOOMIO_SSO_FORCE_USER_ATTRS].each do |key|
       @saved_env[key] = ENV[key]
     end
@@ -18,6 +19,7 @@ class Identities::OauthControllerTest < ActionController::TestCase
     ENV['OAUTH_ATTR_UID'] = 'sub'
     ENV['OAUTH_ATTR_NAME'] = 'name'
     ENV['OAUTH_ATTR_EMAIL'] = 'email'
+    ENV['OAUTH_ATTR_EMAIL_VERIFIED'] = 'email_verified'
     ENV['OAUTH_APP_KEY'] = 'mock_client_id'
     ENV['OAUTH_APP_SECRET'] = 'mock_client_secret'
 
@@ -34,7 +36,8 @@ class Identities::OauthControllerTest < ActionController::TestCase
         body: {
           sub: 'oauth_user_123',
           name: 'OAuth User',
-          email: 'oauth@example.com'
+          email: 'oauth@example.com',
+          email_verified: true
         }.to_json,
         headers: { 'Content-Type' => 'application/json' }
       )
@@ -262,6 +265,49 @@ class Identities::OauthControllerTest < ActionController::TestCase
     assert_response 401
     json = JSON.parse(response.body)
     assert_equal 'Could not fetch user profile from OAuth provider', json['error']
+  end
+
+  test "returns 401 when OAuth provider has not verified email" do
+    stub_request(:get, 'https://oauth.provider.com/userinfo')
+      .to_return(
+        status: 200,
+        body: {
+          sub: 'oauth_user_123',
+          name: 'OAuth User',
+          email: 'oauth@example.com',
+          email_verified: false
+        }.to_json,
+        headers: { 'Content-Type' => 'application/json' }
+      )
+
+    assert_no_difference ['Identity.where(identity_type: "oauth").count', 'User.count'] do
+      get :create, params: { code: 'authorization_code_123' }, format: :json
+    end
+
+    assert_response 401
+    json = JSON.parse(response.body)
+    assert_equal 'OAuth provider did not verify email', json['error']
+  end
+
+  test "allows unverified OAuth email when explicitly configured" do
+    ENV['OAUTH_SKIP_EMAIL_VERIFIED_CHECK'] = 'true'
+    stub_request(:get, 'https://oauth.provider.com/userinfo')
+      .to_return(
+        status: 200,
+        body: {
+          sub: 'oauth_user_unverified',
+          name: 'OAuth User',
+          email: 'oauth-unverified@example.com',
+          email_verified: false
+        }.to_json,
+        headers: { 'Content-Type' => 'application/json' }
+      )
+
+    assert_difference ['Identity.where(identity_type: "oauth").count', 'User.count'], 1 do
+      get :create, params: { code: 'authorization_code_123' }
+    end
+
+    assert_response :redirect
   end
 
   # Fallback redirect


### PR DESCRIPTION
## Summary
- Read the generic OAuth verified-email claim.
- Reject generic OAuth callbacks when the provider has not verified the email.
- Add an explicit override for providers that cannot supply this claim.

## Why
Generic OAuth should not auto-link or verify local accounts from an unverified email claim.

## Tests
- bundle exec rails test test/controllers/identities/oauth_controller_test.rb test/controllers/identities/google_controller_test.rb test/controllers/identities/nextcloud_controller_test.rb