### PR TITLE
Rate limit audio transcription

### DIFF
--- a/app/services/transcription_service.rb
+++ b/app/services/transcription_service.rb
@@ -3,7 +3,12 @@ class TranscriptionService
     ENV['OPENAI_API_KEY'].present?
   end
 
-  def self.transcribe(file)
+  TRIAL_DAILY_LIMIT = 3
+  PAID_DAILY_LIMIT = 30
+
+  def self.transcribe(file, user: nil)
+    return unless within_daily_limit?(user)
+
     client = OpenAI::Client.new(access_token: ENV.fetch('OPENAI_API_KEY'))
     client.audio.transcribe(
       parameters: {
@@ -12,5 +17,21 @@ class TranscriptionService
         response_format: :verbose_json,
       }
     )
+  rescue Faraday::TooManyRequestsError => e
+    Rails.logger.warn("OpenAI transcription skipped after rate limit: #{e.message}")
+    nil
+  end
+
+  def self.within_daily_limit?(user)
+    return true unless user
+
+    limit = daily_limit_for(user)
+    allowed = ThrottleService.can?(key: 'Transcription', id: user.id, max: limit, per: 'day')
+    Rails.logger.info("OpenAI transcription skipped after daily limit reached for user #{user.id}") unless allowed
+    allowed
+  end
+
+  def self.daily_limit_for(user)
+    user.is_paying? ? PAID_DAILY_LIMIT : TRIAL_DAILY_LIMIT
   end
 end

--- a/lib/transcription_analyzer.rb
+++ b/lib/transcription_analyzer.rb
@@ -15,14 +15,30 @@ class TranscriptionAnalyzer < ActiveStorage::Analyzer::AudioAnalyzer
       next unless attachment.name.in?(%w[files image_files]) && record.class.respond_to?(:rich_text_fields)
 
       field = record.class.rich_text_fields.first
-      response = TranscriptionService.transcribe(file)
+      response = TranscriptionService.transcribe(file, user: transcription_user_for(record))
+      next unless response
+
       @text = response["text"]
       @language = response["language"]
+      next if @text.blank?
+
       record[field] = "#{record[field]}<p>#{@text}</p>"
       record.save!
       if record.respond_to?(:group_id) && record.respond_to?(:author_id)
         MessageChannelService.publish_models(Array(record), group_id: record.group_id, user_id: record.author_id)
       end
+    end
+  end
+
+  def transcription_user_for(record)
+    if record.respond_to?(:author) && record.author
+      record.author
+    elsif record.respond_to?(:user) && record.user
+      record.user
+    elsif record.respond_to?(:author_id) && record.author_id
+      User.find_by(id: record.author_id)
+    elsif record.respond_to?(:user_id) && record.user_id
+      User.find_by(id: record.user_id)
     end
   end
 end

--- a/test/services/transcription_service_test.rb
+++ b/test/services/transcription_service_test.rb
@@ -1,0 +1,117 @@
+require "test_helper"
+require "stringio"
+
+class TranscriptionServiceTest < ActiveSupport::TestCase
+  setup do
+    CACHE_REDIS_POOL.with { |client| client.flushall }
+  end
+
+  test "returns transcription response" do
+    with_openai_key do
+      audio = Object.new
+      audio.define_singleton_method(:transcribe) do |parameters:|
+        { "text" => "hello", "language" => "en" }
+      end
+
+      client = Object.new
+      client.define_singleton_method(:audio) { audio }
+
+      OpenAI::Client.stub(:new, client) do
+        response = TranscriptionService.transcribe(StringIO.new("audio"))
+
+        assert_equal "hello", response["text"]
+        assert_equal "en", response["language"]
+      end
+    end
+  end
+
+  test "limits trial users to 3 transcriptions per day" do
+    with_openai_key do
+      user = fake_user(id: 101, paying: false)
+      transcriptions = 0
+      client = fake_openai_client { transcriptions += 1 }
+
+      OpenAI::Client.stub(:new, client) do
+        Rails.logger.stub(:info, nil) do
+          3.times do
+            assert_equal "hello", TranscriptionService.transcribe(StringIO.new("audio"), user: user)["text"]
+          end
+
+          assert_nil TranscriptionService.transcribe(StringIO.new("audio"), user: user)
+        end
+      end
+
+      assert_equal 3, transcriptions
+    end
+  end
+
+  test "limits paying users to 30 transcriptions per day" do
+    with_openai_key do
+      user = fake_user(id: 201, paying: true)
+      transcriptions = 0
+      client = fake_openai_client { transcriptions += 1 }
+
+      OpenAI::Client.stub(:new, client) do
+        Rails.logger.stub(:info, nil) do
+          30.times do
+            assert_equal "hello", TranscriptionService.transcribe(StringIO.new("audio"), user: user)["text"]
+          end
+
+          assert_nil TranscriptionService.transcribe(StringIO.new("audio"), user: user)
+        end
+      end
+
+      assert_equal 30, transcriptions
+    end
+  end
+
+  test "returns nil when OpenAI rate limits transcription" do
+    with_openai_key do
+      audio = Object.new
+      audio.define_singleton_method(:transcribe) do |parameters:|
+        raise Faraday::TooManyRequestsError.new("rate limit")
+      end
+
+      client = Object.new
+      client.define_singleton_method(:audio) { audio }
+
+      OpenAI::Client.stub(:new, client) do
+        Rails.logger.stub(:warn, nil) do
+          assert_nil TranscriptionService.transcribe(StringIO.new("audio"))
+        end
+      end
+    end
+  end
+
+  private
+
+  FakeUser = Struct.new(:id, :paying) do
+    def is_paying?
+      paying
+    end
+  end
+
+  def fake_user(id:, paying:)
+    FakeUser.new(id, paying)
+  end
+
+  def fake_openai_client
+    audio = Object.new
+    audio.define_singleton_method(:transcribe) do |parameters:|
+      yield
+      { "text" => "hello", "language" => "en" }
+    end
+
+    client = Object.new
+    client.define_singleton_method(:audio) { audio }
+    client
+  end
+
+  def with_openai_key
+    previous_key = ENV["OPENAI_API_KEY"]
+    ENV["OPENAI_API_KEY"] = "test-key"
+    yield
+  ensure
+    ENV["OPENAI_API_KEY"] = previous_key
+  end
+end


### PR DESCRIPTION
## Summary
- add daily transcription limits for trial and paying users
- skip transcription cleanly when OpenAI rate limits requests
- pass the record author/user through the audio analyzer for per-user throttling
- add service tests for transcription responses, daily limits, and OpenAI rate limits

## Testing
- Attempted focused service test for `test/services/transcription_service_test.rb`
- It failed before exercising these tests because current master fixtures reference `comments.discussion_id`, which is not present in the comments table.
