### PR TITLE
fix: skip serializing NullGroup

### DIFF
--- a/app/models/concerns/null/group.rb
+++ b/app/models/concerns/null/group.rb
@@ -189,11 +189,16 @@ module Null::Group
 
 
   def subscription
-    {
+    OpenStruct.new(
       max_members:     nil,
       max_threads:     nil,
-      active:          true,
+      allow_subgroups: true,
+      plan:            nil,
+      state:           nil,
+      is_active?:      true,
+      renews_at:       nil,
+      expires_at:      nil,
       members_count:   0
-    }
+    )
   end
 end


### PR DESCRIPTION
…type Subscription

TopicSerializer#include_group? now checks whether the referenced group actually exists (in the record cache or via the association) before embedding it. This prevents orphaned topics from triggering a NullGroup serialization that the client doesn't need.

NullGroup#subscription now returns an OpenStruct instead of a plain Hash, so any code path that does call .subscription.max_members etc. won't crash with NoMethodError.

Fixes LOOMIO-COM-2AZ.