### PR TITLE
Add bookmarks for comments, threads, polls, votes and outcomes

### DIFF
--- a/app/controllers/api/v1/bookmarks_controller.rb
+++ b/app/controllers/api/v1/bookmarks_controller.rb
@@ -1,0 +1,25 @@
+class Api::V1::BookmarksController < Api::V1::RestfulController
+  alias :create :update
+
+  def index
+    self.collection = current_user.bookmarks.order(created_at: :desc)
+    respond_with_collection
+  end
+
+  private
+
+  def accessible_records
+    current_user.bookmarks
+  end
+
+  def load_resource
+    self.resource = case action_name
+    when 'create', 'update' then resource_class.find_or_initialize_by(user: current_user, bookmarkable: bookmarkable)
+    else super
+    end
+  end
+
+  def bookmarkable
+    @bookmarkable ||= resource_params[:bookmarkable_type].classify.constantize.find(resource_params[:bookmarkable_id])
+  end
+end

--- a/app/controllers/api/v1/bookmarks_controller.rb
+++ b/app/controllers/api/v1/bookmarks_controller.rb
@@ -2,7 +2,7 @@ class Api::V1::BookmarksController < Api::V1::RestfulController
   alias :create :update
 
   def index
-    self.collection = current_user.bookmarks.order(created_at: :desc)
+    self.collection = current_user.bookmarks.kept.order(created_at: :desc)
     respond_with_collection
   end
 

--- a/app/models/ability/base.rb
+++ b/app/models/ability/base.rb
@@ -12,6 +12,7 @@ module Ability
     prepend Ability::Poll
     prepend Ability::PollOption
     prepend Ability::Reaction
+    prepend Ability::Bookmark
     prepend Ability::Stance
     prepend Ability::User
     prepend Ability::Tag

--- a/app/models/ability/bookmark.rb
+++ b/app/models/ability/bookmark.rb
@@ -1,0 +1,19 @@
+module Ability::Bookmark
+  def initialize(user)
+    super(user)
+
+    can :show, ::Bookmark do |bookmark|
+      user_is_author_of?(bookmark)
+    end
+
+    can :update, ::Bookmark do |bookmark|
+      user.is_logged_in? &&
+      user_is_author_of?(bookmark) &&
+      can?(:show, bookmark.bookmarkable)
+    end
+
+    can :destroy, ::Bookmark do |bookmark|
+      user_is_author_of?(bookmark)
+    end
+  end
+end

--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -1,0 +1,50 @@
+class Bookmark < ApplicationRecord
+  include PrettyUrlHelper
+
+  belongs_to :bookmarkable, polymorphic: true
+  belongs_to :user
+
+  validates_presence_of :user, :bookmarkable
+  validates_uniqueness_of :user_id, scope: [:bookmarkable_type, :bookmarkable_id]
+
+  delegate :group, to: :bookmarkable
+  delegate :group_id, to: :bookmarkable
+  delegate :title_model, to: :bookmarkable
+
+  alias :author :user
+
+  def author_id
+    user_id
+  end
+
+  # The poll the bookmarked item belongs to, when it is poll-related
+  # (the poll itself, a vote on it, or its outcome). Nil for threads/comments.
+  def poll
+    case bookmarkable
+    when Poll            then bookmarkable
+    when Stance, Outcome then bookmarkable.poll
+    end
+  end
+
+  # For poll-related items always use the poll's own title; otherwise the title
+  # of the thread (or poll) the item belongs to.
+  def title
+    (poll || title_model).title
+  end
+
+  # The name of the person who authored the bookmarked item.
+  def author_name
+    bookmarkable.author.name
+  end
+
+  # The poll type (eg. 'proposal') when the bookmarked item is poll-related, so
+  # the client can label it "Proposal by …" rather than a generic "Poll by …".
+  def poll_type
+    poll&.poll_type
+  end
+
+  # A relative path back to the bookmarked subject.
+  def url
+    polymorphic_path(bookmarkable)
+  end
+end

--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -1,4 +1,5 @@
 class Bookmark < ApplicationRecord
+  include Discard::Model
   include PrettyUrlHelper
 
   belongs_to :bookmarkable, polymorphic: true

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -3,6 +3,7 @@ class Comment < ApplicationRecord
   include CustomCounterCache::Model
   include Translatable
   include Reactable
+  include Bookmarkable
   include HasMentions
   include HasCreatedEvent
   include HasEvents

--- a/app/models/concerns/bookmarkable.rb
+++ b/app/models/concerns/bookmarkable.rb
@@ -1,0 +1,5 @@
+module Bookmarkable
+  def self.included(base)
+    base.has_many :bookmarks, -> { joins(:user).where("users.deactivated_at": nil) }, dependent: :destroy, as: :bookmarkable
+  end
+end

--- a/app/models/discussion.rb
+++ b/app/models/discussion.rb
@@ -3,6 +3,7 @@ class Discussion < ApplicationRecord
   include ReadableUnguessableUrls
   include Translatable
   include Reactable
+  include Bookmarkable
   include HasTimeframe
   include HasEvents
   include HasMentions

--- a/app/models/outcome.rb
+++ b/app/models/outcome.rb
@@ -4,6 +4,7 @@ class Outcome < ApplicationRecord
   include HasEvents
   include HasMentions
   include Reactable
+  include Bookmarkable
   include Translatable
   include HasCreatedEvent
   include HasEvents

--- a/app/models/permitted_params.rb
+++ b/app/models/permitted_params.rb
@@ -2,7 +2,7 @@ class PermittedParams < Struct.new(:params)
   MODELS = %w(
     user group membership_request membership poll poll_template outcome
     stance discussion discussion_template topic_reader topic comment
-    contact_message webhook chatbot contact_request reaction tag
+    contact_message webhook chatbot contact_request reaction bookmark tag
   )
 
   MODELS.each do |kind|
@@ -257,6 +257,10 @@ class PermittedParams < Struct.new(:params)
       :link_previews, {link_previews: [:image, :title, :description, :url, :hostname, :fit, :align]},
       :files, {files: []},
       :image_files, {image_files: []}]
+  end
+
+  def bookmark_attributes
+    [:bookmarkable_id, :bookmarkable_type]
   end
 
   def reaction_attributes

--- a/app/models/poll.rb
+++ b/app/models/poll.rb
@@ -6,6 +6,7 @@ class Poll < ApplicationRecord
   include HasMentions
   include SelfReferencing
   include Reactable
+  include Bookmarkable
   include HasCreatedEvent
   include HasRichText
   include Discard::Model

--- a/app/models/stance.rb
+++ b/app/models/stance.rb
@@ -2,6 +2,7 @@ class Stance < ApplicationRecord
   include CustomCounterCache::Model
   include HasMentions
   include Reactable
+  include Bookmarkable
   include HasEvents
   include HasCreatedEvent
   include Searchable

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -85,6 +85,7 @@ class User < ApplicationRecord
   has_many :identities, class_name: "Identity", dependent: :destroy
 
   has_many :reactions, dependent: :destroy
+  has_many :bookmarks, dependent: :destroy
   has_many :stances, foreign_key: :participant_id, dependent: :destroy
   has_many :participated_polls, through: :stances, source: :poll
   has_many :group_polls, through: :groups, source: :polls

--- a/app/serializers/bookmark_serializer.rb
+++ b/app/serializers/bookmark_serializer.rb
@@ -2,5 +2,5 @@ class BookmarkSerializer < ApplicationSerializer
   # Bookmarks are a flat, self-contained list — title and url are computed so
   # the client can render and link to the subject without loading the full
   # bookmarkable record.
-  attributes :id, :bookmarkable_id, :bookmarkable_type, :user_id, :created_at, :title, :url, :author_name, :poll_type
+  attributes :id, :bookmarkable_id, :bookmarkable_type, :user_id, :created_at, :discarded_at, :title, :url, :author_name, :poll_type
 end

--- a/app/serializers/bookmark_serializer.rb
+++ b/app/serializers/bookmark_serializer.rb
@@ -1,0 +1,6 @@
+class BookmarkSerializer < ApplicationSerializer
+  # Bookmarks are a flat, self-contained list — title and url are computed so
+  # the client can render and link to the subject without loading the full
+  # bookmarkable record.
+  attributes :id, :bookmarkable_id, :bookmarkable_type, :user_id, :created_at, :title, :url, :author_name, :poll_type
+end

--- a/app/services/bookmark_service.rb
+++ b/app/services/bookmark_service.rb
@@ -1,0 +1,20 @@
+class BookmarkService
+  def self.update(bookmark:, params:, actor:)
+    actor.ability.authorize! :update, bookmark
+
+    bookmark.user = actor
+
+    return false unless bookmark.valid?
+    bookmark.save!
+
+    MessageChannelService.publish_models([bookmark], user_id: actor.id)
+
+    bookmark
+  end
+
+  def self.destroy(bookmark:, actor:)
+    actor.ability.authorize! :destroy, bookmark
+
+    bookmark.destroy
+  end
+end

--- a/app/services/bookmark_service.rb
+++ b/app/services/bookmark_service.rb
@@ -3,6 +3,7 @@ class BookmarkService
     actor.ability.authorize! :update, bookmark
 
     bookmark.user = actor
+    bookmark.discarded_at = nil # re-bookmarking an item that was removed
 
     return false unless bookmark.valid?
     bookmark.save!
@@ -12,9 +13,14 @@ class BookmarkService
     bookmark
   end
 
+  # Removing a bookmark soft-discards it and broadcasts the discarded record, so
+  # the user's open sessions drop it from their bookmark list and count. A nightly
+  # task hard-deletes records discarded more than 24 hours ago.
   def self.destroy(bookmark:, actor:)
     actor.ability.authorize! :destroy, bookmark
 
-    bookmark.destroy
+    bookmark.discard
+
+    MessageChannelService.publish_models([bookmark], user_id: actor.id)
   end
 end

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1080,6 +1080,8 @@ en:
   action_dock:
     actions_menu: Actions menu
     more_actions: More actions
+    save_bookmark: Save bookmark
+    remove_bookmark: Remove bookmark
     react: React
     notify: Notify
     add_resource: Add an attachment
@@ -1186,6 +1188,19 @@ en:
     edit_markdown: Edit Markdown
     markdown_confirm: Some formatting may be lost converting wysiwyg content to markdown.
     upload_failed: Upload failed
+  bookmarks:
+    bookmarks: Bookmarks
+    saved: Bookmark saved
+    removed: Bookmark removed
+    empty: No bookmarks yet
+    empty_help: Bookmarks are a way to keep track of things you want to return to.
+    subtitle: "%{type} by %{name}"
+    types:
+      Discussion: Discussion
+      Poll: Poll
+      Comment: Comment
+      Stance: Vote
+      Outcome: Outcome
   cover_photo_form:
     heading: New cover photo
     upload_link: Upload new cover photo

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -279,6 +279,7 @@ Rails.application.routes.draw do
         post :undiscard, on: :member
       end
       resources :reactions,   only: [:create, :update, :index, :destroy]
+      resources :bookmarks,   only: [:create, :update, :index, :destroy]
 
       resource :translations, only: [] do
         get :inline, to: 'translations#inline'

--- a/db/migrate/20260609000002_create_bookmarks.rb
+++ b/db/migrate/20260609000002_create_bookmarks.rb
@@ -1,0 +1,11 @@
+class CreateBookmarks < ActiveRecord::Migration[8.0]
+  def change
+    create_table :bookmarks do |t|
+      t.references :user, null: false
+      t.references :bookmarkable, polymorphic: true, null: false
+      t.timestamps
+    end
+
+    add_index :bookmarks, [:user_id, :bookmarkable_type, :bookmarkable_id], unique: true, name: 'index_bookmarks_on_user_and_bookmarkable'
+  end
+end

--- a/db/migrate/20260610000001_add_discarded_at_to_bookmarks.rb
+++ b/db/migrate/20260610000001_add_discarded_at_to_bookmarks.rb
@@ -1,0 +1,6 @@
+class AddDiscardedAtToBookmarks < ActiveRecord::Migration[8.0]
+  def change
+    add_column :bookmarks, :discarded_at, :datetime
+    add_index :bookmarks, :discarded_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_06_09_000001) do
+ActiveRecord::Schema[8.0].define(version: 2026_06_09_000002) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "hstore"
@@ -149,6 +149,17 @@ ActiveRecord::Schema[8.0].define(version: 2026_06_09_000001) do
   create_table "blocked_domains", force: :cascade do |t|
     t.string "name"
     t.index ["name"], name: "index_blocked_domains_on_name", unique: true
+  end
+
+  create_table "bookmarks", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "bookmarkable_type", null: false
+    t.bigint "bookmarkable_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["bookmarkable_type", "bookmarkable_id"], name: "index_bookmarks_on_bookmarkable"
+    t.index ["user_id", "bookmarkable_type", "bookmarkable_id"], name: "index_bookmarks_on_user_and_bookmarkable", unique: true
+    t.index ["user_id"], name: "index_bookmarks_on_user_id"
   end
 
   create_table "chatbots", force: :cascade do |t|
@@ -926,6 +937,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_06_09_000001) do
     t.index ["inviter_id"], name: "inviter_id_not_null", where: "(inviter_id IS NOT NULL)"
     t.index ["token"], name: "index_discussion_readers_on_token", unique: true
     t.index ["topic_id", "user_id"], name: "index_topic_readers_on_topic_id_and_user_id", unique: true
+    t.index ["user_id", "topic_id"], name: "index_topic_readers_guest_user_id", where: "(guest = true)"
   end
 
   create_table "topics", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_06_09_000002) do
+ActiveRecord::Schema[8.0].define(version: 2026_06_10_000001) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "hstore"
@@ -157,7 +157,9 @@ ActiveRecord::Schema[8.0].define(version: 2026_06_09_000002) do
     t.bigint "bookmarkable_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "discarded_at"
     t.index ["bookmarkable_type", "bookmarkable_id"], name: "index_bookmarks_on_bookmarkable"
+    t.index ["discarded_at"], name: "index_bookmarks_on_discarded_at"
     t.index ["user_id", "bookmarkable_type", "bookmarkable_id"], name: "index_bookmarks_on_user_and_bookmarkable", unique: true
     t.index ["user_id"], name: "index_bookmarks_on_user_id"
   end

--- a/lib/tasks/loomio.rake
+++ b/lib/tasks/loomio.rake
@@ -284,6 +284,7 @@ namespace :loomio do
     GenericWorker.perform_async('ReceivedEmailService', 'route_all')
     LoginToken.where("created_at < ?", 1.hours.ago).delete_all
     Identity.stale(days: 7).delete_all
+    Bookmark.discarded.where("discarded_at < ?", 24.hours.ago).delete_all
     GeoLocationWorker.perform_async
 
     SendDailyCatchUpEmailWorker.perform_async

--- a/test/controllers/api/v1/bookmarks_controller_test.rb
+++ b/test/controllers/api/v1/bookmarks_controller_test.rb
@@ -1,0 +1,91 @@
+require 'test_helper'
+
+class Api::V1::BookmarksControllerTest < ActionController::TestCase
+  def build_comment(author)
+    comment = Comment.new(body: "Test comment", parent: discussions(:discussion), author: author)
+    CommentService.create(comment: comment, actor: author)
+    comment
+  end
+
+  test "create bookmarks the comment when authorized" do
+    user = users(:admin)
+    comment = build_comment(user)
+
+    sign_in user
+    assert_difference 'Bookmark.count', 1 do
+      post :create, params: { bookmark: { bookmarkable_id: comment.id, bookmarkable_type: 'Comment' } }
+    end
+    assert_response :success
+    assert Bookmark.exists?(user: user, bookmarkable: comment)
+  end
+
+  test "create is idempotent — bookmarking twice keeps a single bookmark" do
+    user = users(:admin)
+    comment = build_comment(user)
+
+    sign_in user
+    post :create, params: { bookmark: { bookmarkable_id: comment.id, bookmarkable_type: 'Comment' } }
+    assert_no_difference 'Bookmark.count' do
+      post :create, params: { bookmark: { bookmarkable_id: comment.id, bookmarkable_type: 'Comment' } }
+    end
+    assert_response :success
+  end
+
+  test "create responds forbidden when user cannot see the record" do
+    author = users(:admin)
+    comment = build_comment(author)
+
+    outsider = User.create!(
+      name: "Outsider",
+      email: "outsider-#{SecureRandom.hex(4)}@example.com",
+      username: "outsider#{SecureRandom.hex(4)}",
+      email_verified: true
+    )
+
+    sign_in outsider
+    assert_no_difference 'Bookmark.count' do
+      post :create, params: { bookmark: { bookmarkable_id: comment.id, bookmarkable_type: 'Comment' } }
+    end
+    assert_response :forbidden
+  end
+
+  test "index returns only the current user's bookmarks" do
+    user = users(:admin)
+    other = users(:user)
+    comment = build_comment(user)
+
+    mine = Bookmark.create!(user: user, bookmarkable: comment)
+    Bookmark.create!(user: other, bookmarkable: comment)
+
+    sign_in user
+    get :index
+    assert_response :success
+    ids = JSON.parse(response.body)['bookmarks'].map { |b| b['id'] }
+    assert_equal [mine.id], ids
+  end
+
+  test "destroy removes the bookmark" do
+    user = users(:admin)
+    comment = build_comment(user)
+    bookmark = Bookmark.create!(user: user, bookmarkable: comment)
+
+    sign_in user
+    assert_difference 'Bookmark.count', -1 do
+      delete :destroy, params: { id: bookmark.id }
+    end
+    assert_response :success
+  end
+
+  test "destroy forbidden for another user's bookmark" do
+    user = users(:admin)
+    other = users(:user)
+    comment = build_comment(user)
+    bookmark = Bookmark.create!(user: other, bookmarkable: comment)
+
+    sign_in user
+    assert_no_difference 'Bookmark.count' do
+      delete :destroy, params: { id: bookmark.id }
+    end
+    assert_response :forbidden
+  end
+end

--- a/test/controllers/api/v1/bookmarks_controller_test.rb
+++ b/test/controllers/api/v1/bookmarks_controller_test.rb
@@ -64,16 +64,33 @@ class Api::V1::BookmarksControllerTest < ActionController::TestCase
     assert_equal [mine.id], ids
   end
 
-  test "destroy removes the bookmark" do
+  test "destroy soft-discards the bookmark and drops it from the index" do
     user = users(:admin)
     comment = build_comment(user)
     bookmark = Bookmark.create!(user: user, bookmarkable: comment)
 
     sign_in user
-    assert_difference 'Bookmark.count', -1 do
+    assert_no_difference 'Bookmark.count' do
       delete :destroy, params: { id: bookmark.id }
     end
     assert_response :success
+    assert bookmark.reload.discarded?
+
+    get :index
+    refute_includes JSON.parse(response.body)['bookmarks'].map { |b| b['id'] }, bookmark.id
+  end
+
+  test "re-bookmarking a discarded item undiscards the same row" do
+    user = users(:admin)
+    comment = build_comment(user)
+    bookmark = Bookmark.create!(user: user, bookmarkable: comment, discarded_at: Time.now)
+
+    sign_in user
+    assert_no_difference 'Bookmark.count' do
+      post :create, params: { bookmark: { bookmarkable_id: comment.id, bookmarkable_type: 'Comment' } }
+    end
+    assert_response :success
+    refute bookmark.reload.discarded?
   end
 
   test "destroy forbidden for another user's bookmark" do

--- a/vue/src/components/bookmarks/page.vue
+++ b/vue/src/components/bookmarks/page.vue
@@ -15,7 +15,7 @@ const loading = ref(true);
 
 const findRecords = () => {
   bookmarks.value = orderBy(
-    Records.bookmarks.find({userId: Session.userId}),
+    Records.bookmarks.find({userId: Session.userId, discardedAt: null}),
     ['createdAt'],
     ['desc']
   );

--- a/vue/src/components/bookmarks/page.vue
+++ b/vue/src/components/bookmarks/page.vue
@@ -1,0 +1,83 @@
+<script setup lang="js">
+import { ref, onMounted } from 'vue';
+import { orderBy } from 'lodash-es';
+
+import Records from '@/shared/services/records';
+import Session from '@/shared/services/session';
+import EventBus from '@/shared/services/event_bus';
+import Flash from '@/shared/services/flash';
+import { useWatchRecords } from '@/composables/useWatchRecords';
+
+const { watchRecords } = useWatchRecords();
+
+const bookmarks = ref([]);
+const loading = ref(true);
+
+const findRecords = () => {
+  bookmarks.value = orderBy(
+    Records.bookmarks.find({userId: Session.userId}),
+    ['createdAt'],
+    ['desc']
+  );
+};
+
+const remove = (bookmark) => {
+  bookmark.destroy().then(() => Flash.success('bookmarks.removed'));
+};
+
+watchRecords({
+  collections: ['bookmarks'],
+  query: () => findRecords()
+});
+
+onMounted(() => {
+  EventBus.$emit('currentComponent', {
+    titleKey: 'bookmarks.bookmarks',
+    page: 'bookmarksPage'
+  });
+
+  Records.bookmarks.fetch({}).finally(() => {
+    loading.value = false;
+    findRecords();
+  });
+});
+
+const titleVisible = (visible) => {
+  EventBus.$emit('content-title-visible', visible);
+};
+</script>
+
+<template lang="pug">
+v-main
+  v-container.bookmarks-page.max-width-1024.px-0.px-sm-3
+    h1.text-headline-large.my-4(tabindex="-1" v-intersect="{handler: titleVisible}" v-t="'bookmarks.bookmarks'")
+
+    section.bookmarks-page__loading(v-if='loading && bookmarks.length == 0')
+      v-card.mb-2
+        v-list(lines="two")
+          loading-content(:lineCount='2' v-for='(item, index) in [1,2,3]' :key='index')
+
+    template(v-else)
+      v-card.mb-2(v-if='bookmarks.length > 0')
+        v-list(lines="two")
+          v-list-item(
+            v-for="bookmark in bookmarks"
+            :key="bookmark.id"
+            :to="bookmark.url"
+          )
+            template(v-slot:prepend)
+              common-icon(:name="bookmark.icon()")
+            v-list-item-title {{ bookmark.title }}
+            v-list-item-subtitle {{ $t('bookmarks.subtitle', {type: bookmark.typeLabel(), name: bookmark.authorName}) }}
+            template(v-slot:append)
+              v-btn(
+                icon
+                variant="text"
+                :title="$t('action_dock.remove_bookmark')"
+                @click.prevent.stop="remove(bookmark)"
+              )
+                common-icon(name="mdi-bookmark-remove-outline")
+
+      v-alert.mb-2(v-else type="info" variant="tonal" :title="$t('bookmarks.empty')")
+        span(v-t="'bookmarks.empty_help'")
+</template>

--- a/vue/src/components/common/icon.vue
+++ b/vue/src/components/common/icon.vue
@@ -174,7 +174,12 @@ import {
   mdiWebhook,
   mdiWhiteBalanceSunny,
   mdiWindowClose,
-  mdiYoutube
+  mdiYoutube,
+  mdiBookmark,
+  mdiBookmarkOutline,
+  mdiBookmarkRemoveOutline,
+  mdiCheckboxMarkedCircleOutline,
+  mdiForumOutline
 } from '@mdi/js';
 
 const icons = {
@@ -349,6 +354,11 @@ const icons = {
   mdiWhiteBalanceSunny,
   mdiWindowClose,
   mdiYoutube,
+  mdiBookmark,
+  mdiBookmarkOutline,
+  mdiBookmarkRemoveOutline,
+  mdiCheckboxMarkedCircleOutline,
+  mdiForumOutline,
   webex
 };
 

--- a/vue/src/components/sidebar/panel.vue
+++ b/vue/src/components/sidebar/panel.vue
@@ -18,6 +18,7 @@ import SidebarSettings from '@/components/sidebar/settings';
 import SidebarHelp from '@/components/sidebar/help';
 import { useWatchRecords } from '@/composables/useWatchRecords';
 import { useCurrentUserGroups } from '@/composables/useCurrentUserGroups';
+import { useBookmarks } from '@/composables/useBookmarks';
 
 import { mdiCog } from '@mdi/js';
 
@@ -37,11 +38,13 @@ const pollsToVoteOnCount = ref(0);
 const openGroups = ref([]);
 const openCounts = ref({});
 const showSettings = ref(false);
+const bookmarksCount = ref(0);
 const isSignedIn = ref(Session.isSignedIn());
 const canStartGroups = ref(AbilityService.canStartGroups());
 
 const { watchRecords } = useWatchRecords();
 const { loadGroups } = useCurrentUserGroups();
+const { loadBookmarks } = useBookmarks();
 
 // Computed properties
 const greySidebarLogo = computed(() =>
@@ -98,6 +101,11 @@ const fetchData = () => {
   });
   Records.topics.fetch({ params: { unread: 1, exclude_types: 'reaction', last_activity_gte: subWeeks(new Date(), 6).toISOString() } })
   Records.stances.fetch({ path: 'my_stances' })
+  loadBookmarks();
+};
+
+const updateBookmarks = () => {
+  bookmarksCount.value = Records.bookmarks.find({userId: Session.userId}).length;
 };
 
 
@@ -151,6 +159,11 @@ watchRecords({
 watchRecords({
   collections: ['stances'],
   query: () => { updatePollsToVoteOnCount() }
+});
+
+watchRecords({
+  collections: ['bookmarks'],
+  query: () => { updateBookmarks() }
 });
 
 let hasFetched = false;
@@ -208,6 +221,12 @@ v-navigation-drawer.sidenav-left.lmo-no-print(app v-model="open")
           template(v-if="unreadTopicCounts['direct']")
             | &nbsp;
             span ({{unreadTopicCounts['direct']}})
+      v-list-item.sidebar__list-item-button--bookmarks(to="/bookmarks")
+        v-list-item-title(:class="{'text-medium-emphasis': !bookmarksCount}")
+          span(v-t="'bookmarks.bookmarks'")
+          template(v-if="bookmarksCount")
+            | &nbsp;
+            span ({{bookmarksCount}})
       v-list-item(to="/tasks" :disabled="organizations.length == 0" :title="$t('tasks.tasks')")
 
     v-divider

--- a/vue/src/components/sidebar/panel.vue
+++ b/vue/src/components/sidebar/panel.vue
@@ -105,7 +105,7 @@ const fetchData = () => {
 };
 
 const updateBookmarks = () => {
-  bookmarksCount.value = Records.bookmarks.find({userId: Session.userId}).length;
+  bookmarksCount.value = Records.bookmarks.find({userId: Session.userId, discardedAt: null}).length;
 };
 
 

--- a/vue/src/components/strand/item/new_comment.vue
+++ b/vue/src/components/strand/item/new_comment.vue
@@ -55,7 +55,7 @@ export default {
       ,
         pickBy(this.commentActions, v => v.menu)
       );
-      return pick(actions, ['pin_event', 'unpin_event', 'reply_to_comment',  'admin_edit_comment', 'copy_url', 'notification_history', 'move_event', 'discard_comment', 'undiscard_comment']);
+      return pick(actions, ['save_bookmark', 'remove_bookmark', 'pin_event', 'unpin_event', 'reply_to_comment',  'admin_edit_comment', 'copy_url', 'notification_history', 'move_event', 'discard_comment', 'undiscard_comment']);
     }
   }
 };

--- a/vue/src/components/strand/item/stance_created.vue
+++ b/vue/src/components/strand/item/stance_created.vue
@@ -2,6 +2,7 @@
 import StanceService  from '@/shared/services/stance_service';
 import LmoUrlService  from '@/shared/services/lmo_url_service';
 import UrlFor from '@/mixins/url_for';
+import { pickBy } from 'lodash-es';
 
 export default {
   mixins: [UrlFor],
@@ -18,6 +19,7 @@ export default {
     actorName() { return this.event.actorName(); },
     poll() { return this.eventable.poll(); },
     actions() { return StanceService.actions(this.eventable, this, this.event); },
+    menuActions() { return pickBy(this.actions, v => v.menu); },
     componentType() {
       if (this.actor) {
         return 'router-link';
@@ -56,7 +58,7 @@ section.strand-item__stance-created.stance-created
       formatted-text.poll-common-stance-created__reason(:model="eventable" field="reason")
       link-previews(:model="eventable")
       attachment-list(:attachments="eventable.attachments")
-    action-dock(:model='eventable' :actions='actions' size="small" left)
+    action-dock(:model='eventable' :actions='actions' :menu-actions='menuActions' size="small" left)
   template(v-if="!eventable.castAt && !eventable.revokedAt")
     .d-flex
       component.text-medium-emphasis(:is="componentType" :to="actor && urlFor(actor)") {{actorName}}
@@ -65,7 +67,7 @@ section.strand-item__stance-created.stance-created
       mid-dot.text-medium-emphasis
       router-link.text-medium-emphasis(:to='link')
         time-ago(:date='eventable.updatedAt')
-    action-dock(:model='eventable', :actions='actions' size="small")
+    action-dock(:model='eventable', :actions='actions' :menu-actions='menuActions' size="small")
   template(v-if="eventable.revokedAt")
     .d-flex
       component.text-medium-emphasis(:is="componentType" :to="actor && urlFor(actor)") {{actorName}}
@@ -74,5 +76,5 @@ section.strand-item__stance-created.stance-created
       mid-dot.text-medium-emphasis
       router-link.text-medium-emphasis(:to='link')
         time-ago(:date='eventable.updatedAt')
-    action-dock(:model='eventable' :actions='actions' size="small")
+    action-dock(:model='eventable' :actions='actions' :menu-actions='menuActions' size="small")
 </template>

--- a/vue/src/components/strand/item/stance_created.vue
+++ b/vue/src/components/strand/item/stance_created.vue
@@ -19,6 +19,7 @@ export default {
     actorName() { return this.event.actorName(); },
     poll() { return this.eventable.poll(); },
     actions() { return StanceService.actions(this.eventable, this, this.event); },
+    dockActions() { return pickBy(this.actions, v => !v.menu); },
     menuActions() { return pickBy(this.actions, v => v.menu); },
     componentType() {
       if (this.actor) {
@@ -40,11 +41,11 @@ section.strand-item__stance-created.stance-created
   template(v-if="eventable.castAt && !eventable.revokedAt")
     template(v-if="eventable.hasOptionIcon()")
       .d-flex.text-body-medium.align-center.pb-1
-        component.text-medium-emphasis(:is="componentType" :to="actor && urlFor(actor)") {{actorName}}
+        component.text-medium-emphasis.text-decoration-none(:is="componentType" :to="actor && urlFor(actor)") {{actorName}}
         space
         poll-common-stance-choice(v-if="poll.showResults()" :poll="poll" :stance-choice="eventable.stanceChoice()")
         space
-        router-link.text-medium-emphasis(:to='link')
+        router-link.text-medium-emphasis.text-decoration-none(:to='link')
           space
           time-ago(:date='eventable.updatedAt || eventable.castAt')
         v-badge(v-if="unread" variant="tonal" color="info" inline location="right" :content="$t('thread_item.new')")
@@ -58,7 +59,7 @@ section.strand-item__stance-created.stance-created
       formatted-text.poll-common-stance-created__reason(:model="eventable" field="reason")
       link-previews(:model="eventable")
       attachment-list(:attachments="eventable.attachments")
-    action-dock(:model='eventable' :actions='actions' :menu-actions='menuActions' size="small" left)
+    action-dock(:model='eventable' :actions='dockActions' :menu-actions='menuActions' size="small" left)
   template(v-if="!eventable.castAt && !eventable.revokedAt")
     .d-flex
       component.text-medium-emphasis(:is="componentType" :to="actor && urlFor(actor)") {{actorName}}
@@ -67,7 +68,7 @@ section.strand-item__stance-created.stance-created
       mid-dot.text-medium-emphasis
       router-link.text-medium-emphasis(:to='link')
         time-ago(:date='eventable.updatedAt')
-    action-dock(:model='eventable', :actions='actions' :menu-actions='menuActions' size="small")
+    action-dock(:model='eventable', :actions='dockActions' :menu-actions='menuActions' size="small")
   template(v-if="eventable.revokedAt")
     .d-flex
       component.text-medium-emphasis(:is="componentType" :to="actor && urlFor(actor)") {{actorName}}
@@ -76,5 +77,5 @@ section.strand-item__stance-created.stance-created
       mid-dot.text-medium-emphasis
       router-link.text-medium-emphasis(:to='link')
         time-ago(:date='eventable.updatedAt')
-    action-dock(:model='eventable' :actions='actions' :menu-actions='menuActions' size="small")
+    action-dock(:model='eventable' :actions='dockActions' :menu-actions='menuActions' size="small")
 </template>

--- a/vue/src/composables/useBookmarks.js
+++ b/vue/src/composables/useBookmarks.js
@@ -1,0 +1,18 @@
+import Records from '@/shared/services/records';
+
+// Fetches the current user's bookmarks exactly once for the whole frontend.
+// Bookmarks are private to the user and self-contained (each carries its own
+// title and url), so a single fetch is enough to know what is bookmarked and to
+// render the bookmarks list. Always returns the same promise, so any component
+// can await it to be sure the bookmarks are in the record store before reading
+// them.
+let bookmarksPromise = null;
+
+export function useBookmarks() {
+  function loadBookmarks() {
+    bookmarksPromise ||= Records.bookmarks.fetch({});
+    return bookmarksPromise;
+  }
+
+  return { loadBookmarks };
+}

--- a/vue/src/routes.js
+++ b/vue/src/routes.js
@@ -12,6 +12,7 @@ const PollFormPage = wrapAsyncLoader(() => import('./components/poll/form_page')
 const PollTemplateFormPage = wrapAsyncLoader(() => import('./components/poll_template/form_page'));
 const PollTemplateBrowsePage = wrapAsyncLoader(() => import('./components/poll_template/browse_page'));
 const TasksPage = wrapAsyncLoader(() => import('./components/tasks/page'));
+const BookmarksPage = wrapAsyncLoader(() => import('./components/bookmarks/page'));
 const GroupDiscussionsPanel = wrapAsyncLoader(() => import('./components/group/discussions_panel'));
 const GroupPollsPanel = wrapAsyncLoader(() => import('./components/group/polls_panel'));
 const GroupEmailsPanel = wrapAsyncLoader(() => import('./components/group/emails_panel'));
@@ -65,6 +66,7 @@ const router = createRouter({
     {path: '/users/sign_in', redirect: '/dashboard' },
     {path: '/users/sign_up', redirect: '/dashboard' },
     {path: '/tasks', component: TasksPage},
+    {path: '/bookmarks', component: BookmarksPage},
     {path: '/report', component: ReportPage},
     {path: '/dashboard', component: DashboardPage},
     {path: '/dashboard/polls_to_vote_on', component: PollsToVoteOnPage},

--- a/vue/src/shared/interfaces/bookmark_records_interface.js
+++ b/vue/src/shared/interfaces/bookmark_records_interface.js
@@ -1,0 +1,10 @@
+import BaseRecordsInterface from '@/shared/record_store/base_records_interface';
+import BookmarkModel        from '@/shared/models/bookmark_model';
+
+export default class BookmarkRecordsInterface extends BaseRecordsInterface {
+  constructor(recordStore) {
+    super(recordStore);
+    this.model = BookmarkModel;
+    this.baseConstructor(recordStore);
+  }
+}

--- a/vue/src/shared/models/bookmark_model.js
+++ b/vue/src/shared/models/bookmark_model.js
@@ -1,0 +1,35 @@
+import BaseModel from '@/shared/record_store/base_model';
+import { I18n } from '@/i18n';
+
+export default class BookmarkModel extends BaseModel {
+  static singular = 'bookmark';
+  static plural = 'bookmarks';
+  static indices = ['userId', 'bookmarkableId', 'bookmarkableType'];
+
+  // title, url, authorName and pollType are provided by the server so a bookmark
+  // is self-contained — the bookmarked record itself does not need to be loaded
+  // to render the list.
+
+  relationships() {
+    this.belongsTo('user');
+  }
+
+  // A human label for the kind of item, eg. "Proposal" for a proposal poll,
+  // otherwise the generic type name ("Discussion", "Comment", "Vote"…).
+  typeLabel() {
+    if (this.bookmarkableType === 'Poll' && this.pollType) {
+      return I18n.global.t(`decision_tools_card.${this.pollType}_title`);
+    }
+    return I18n.global.t(`bookmarks.types.${this.bookmarkableType}`);
+  }
+
+  icon() {
+    return {
+      Discussion: 'mdi-forum-outline',
+      Poll: 'mdi-poll',
+      Comment: 'mdi-comment-outline',
+      Stance: 'mdi-checkbox-marked-circle-outline',
+      Outcome: 'mdi-bullhorn-outline'
+    }[this.bookmarkableType];
+  }
+};

--- a/vue/src/shared/services/bookmark_service.js
+++ b/vue/src/shared/services/bookmark_service.js
@@ -1,0 +1,61 @@
+import Records from '@/shared/services/records';
+import Session from '@/shared/services/session';
+import Flash   from '@/shared/services/flash';
+import { useBookmarks } from '@/composables/useBookmarks';
+import { capitalize } from 'lodash-es';
+
+const { loadBookmarks } = useBookmarks();
+
+export default new class BookmarkService {
+  // The polymorphic type stored on the bookmark, e.g. 'Comment', 'Poll'.
+  typeFor(model) {
+    return capitalize(model.constructor.singular);
+  }
+
+  bookmarkFor(model) {
+    if (!model || !model.id) { return null; }
+    return Records.bookmarks.find({
+      userId: Session.userId,
+      bookmarkableType: this.typeFor(model),
+      bookmarkableId: model.id
+    })[0];
+  }
+
+  // Returns the save/remove bookmark menu actions for a bookmarkable model.
+  // Only one is performable at a time, depending on whether a bookmark exists.
+  actions(model) {
+    // Ensure the user's bookmarks are loaded once per session so the toggle
+    // reflects the correct save/remove state.
+    loadBookmarks();
+
+    const service = this;
+    return {
+      save_bookmark: {
+        icon: 'mdi-bookmark-outline',
+        name: 'action_dock.save_bookmark',
+        menu: true,
+        canPerform() { return Session.isSignedIn() && !service.bookmarkFor(model); },
+        perform() {
+          return Records.bookmarks.build({
+            userId: Session.userId,
+            bookmarkableType: service.typeFor(model),
+            bookmarkableId: model.id
+          }).save().then(() => Flash.success('bookmarks.saved'));
+        }
+      },
+
+      remove_bookmark: {
+        icon: 'mdi-bookmark',
+        name: 'action_dock.remove_bookmark',
+        menu: true,
+        canPerform() { return Session.isSignedIn() && !!service.bookmarkFor(model); },
+        perform() {
+          const bookmark = service.bookmarkFor(model);
+          if (bookmark) {
+            return bookmark.destroy().then(() => Flash.success('bookmarks.removed'));
+          }
+        }
+      }
+    };
+  }
+};

--- a/vue/src/shared/services/bookmark_service.js
+++ b/vue/src/shared/services/bookmark_service.js
@@ -17,7 +17,8 @@ export default new class BookmarkService {
     return Records.bookmarks.find({
       userId: Session.userId,
       bookmarkableType: this.typeFor(model),
-      bookmarkableId: model.id
+      bookmarkableId: model.id,
+      discardedAt: null
     })[0];
   }
 

--- a/vue/src/shared/services/comment_service.js
+++ b/vue/src/shared/services/comment_service.js
@@ -4,11 +4,14 @@ import Session from '@/shared/services/session';
 import Records from '@/shared/services/records';
 import openModal from '@/shared/helpers/open_modal';
 import Flash from '@/shared/services/flash';
+import BookmarkService from '@/shared/services/bookmark_service';
 
 export default new class CommentService {
   actions(comment, vm, event) {
     const isOwnComment = comment.authorId === Session.userId;
     return {
+      ...BookmarkService.actions(comment),
+
       react: {
         dock: 1,
         canPerform() {

--- a/vue/src/shared/services/discussion_service.js
+++ b/vue/src/shared/services/discussion_service.js
@@ -2,10 +2,13 @@ import Session       from '@/shared/services/session';
 import Records       from '@/shared/services/records';
 import AbilityService from '@/shared/services/ability_service';
 import openModal      from '@/shared/helpers/open_modal';
+import BookmarkService from '@/shared/services/bookmark_service';
 
 export default new class DiscussionService {
   actions(discussion, vm) {
     return {
+      ...BookmarkService.actions(discussion),
+
       // make_a_copy: {
       //   icon: 'mdi-content-copy',
       //   name: 'templates.make_a_copy',

--- a/vue/src/shared/services/outcome_service.js
+++ b/vue/src/shared/services/outcome_service.js
@@ -2,6 +2,7 @@ import openModal from '@/shared/helpers/open_modal';
 import AbilityService from '@/shared/services/ability_service';
 import Records from '@/shared/services/records';
 import Session from '@/shared/services/session';
+import BookmarkService from '@/shared/services/bookmark_service';
 
 export default new class OutcomeService {
   actions(outcome) {
@@ -9,6 +10,8 @@ export default new class OutcomeService {
     const user = Session.user();
 
     return {
+      ...BookmarkService.actions(outcome),
+
       translate_outcome: {
         name: 'common.action.translate',
         icon: 'mdi-translate',

--- a/vue/src/shared/services/poll_service.js
+++ b/vue/src/shared/services/poll_service.js
@@ -7,6 +7,7 @@ import openModal      from '@/shared/helpers/open_modal';
 import { I18n }          from '@/i18n';
 import AppConfig      from '@/shared/services/app_config';
 import { hardReload } from '@/shared/helpers/window';
+import BookmarkService from '@/shared/services/bookmark_service';
 import { startOfHour, addDays, format } from 'date-fns';
 
 function openSetOutcomeModal(poll) {
@@ -42,6 +43,8 @@ export default new class PollService {
   actions(poll, vm, event) {
     if (!poll || !poll.config()) { return {}; }
     return {
+      ...BookmarkService.actions(poll),
+
       translate_poll: {
         icon: 'mdi-translate',
         name: 'common.action.translate',

--- a/vue/src/shared/services/records.js
+++ b/vue/src/shared/services/records.js
@@ -24,6 +24,7 @@ import StanceRecordsInterface from '@/shared/interfaces/stance_records_interface
 import OutcomeRecordsInterface from '@/shared/interfaces/outcome_records_interface';
 import ContactMessageRecordsInterface from '@/shared/interfaces/contact_message_records_interface';
 import ReactionRecordsInterface from '@/shared/interfaces/reaction_records_interface';
+import BookmarkRecordsInterface from '@/shared/interfaces/bookmark_records_interface';
 import AttachmentRecordsInterface from '@/shared/interfaces/attachment_records_interface';
 import LoginTokenRecordsInterface from '@/shared/interfaces/login_token_records_interface';
 import MessageChannelRecordsInterface from '@/shared/interfaces/message_channel_records_interface';
@@ -58,6 +59,7 @@ records.addRecordsInterface(StanceRecordsInterface);
 records.addRecordsInterface(OutcomeRecordsInterface);
 records.addRecordsInterface(ContactMessageRecordsInterface);
 records.addRecordsInterface(ReactionRecordsInterface);
+records.addRecordsInterface(BookmarkRecordsInterface);
 records.addRecordsInterface(AttachmentRecordsInterface);
 records.addRecordsInterface(LoginTokenRecordsInterface);
 records.addRecordsInterface(MessageChannelRecordsInterface);

--- a/vue/src/shared/services/stance_service.js
+++ b/vue/src/shared/services/stance_service.js
@@ -6,6 +6,7 @@ import EventBus       from '@/shared/services/event_bus';
 import AbilityService from '@/shared/services/ability_service';
 import LmoUrlService  from '@/shared/services/lmo_url_service';
 import openModal      from '@/shared/helpers/open_modal';
+import BookmarkService from '@/shared/services/bookmark_service';
 
 export default new class StanceService {
   revoke = {
@@ -26,6 +27,8 @@ export default new class StanceService {
 
   actions(stance, vm, event) {
     return {
+      ...BookmarkService.actions(stance),
+
       react: {
         dock: 1,
         canPerform() {


### PR DESCRIPTION
Users can save a private bookmark on any comment, discussion, poll, stance or outcome via its actions menu, and see them on a `/bookmarks` page (also surfaced as a count in the sidebar), ordered most-recent first, where they can remove or navigate to each item.

## Backend
- Polymorphic `Bookmark` model + `Bookmarkable` concern (included in Comment, Discussion, Poll, Stance, Outcome)
- Controller / service / ability authorization mirroring reactions (idempotent create, private-to-user index, destroy)
- Flat `BookmarkSerializer` computing `title` / `url` / `author_name` / `poll_type` per record — poll-related items always use the poll's own title and decision type
- Saving broadcasts the bookmark to the user's own channel

## Frontend
- `BookmarkModel` / records interface / registration
- Shared `BookmarkService` providing save/remove menu actions (wired into all five item menus)
- `useBookmarks` composable — loads the list once per session (on sidebar open or when a bookmark action initializes)
- `/bookmarks` page + sidebar count entry; bookmark icons registered in `common-icon`

## Notes
- Titles are computed live server-side (no stored columns); the page refetches on open, so edits appear on next visit
- Full test suite green; new controller test covers create/idempotency/index/destroy + authorization

🤖 Generated with [Claude Code](https://claude.com/claude-code)