### PR TITLE
drop-devise-deepseekv4pro

### DIFF
--- a/app/controllers/api/v1/registrations_controller.rb
+++ b/app/controllers/api/v1/registrations_controller.rb
@@ -1,6 +1,5 @@
-class Api::V1::RegistrationsController < Devise::RegistrationsController
+class Api::V1::RegistrationsController < Api::V1::RestfulController
   include LocalesHelper
-  before_action :configure_permitted_parameters
   before_action :permission_check, only: :create
 
   def create
@@ -29,6 +28,11 @@ class Api::V1::RegistrationsController < Devise::RegistrationsController
   end
 
   private
+
+  def sign_up_params
+    params.require(:user).permit(:name, :email, :legal_accepted, :email_newsletter, :turnstile_token)
+  end
+
   def email_can_be_verified?
     (pending_membership&.user  ||
      pending_useable_login_token&.user ||
@@ -51,6 +55,7 @@ class Api::V1::RegistrationsController < Devise::RegistrationsController
   def pending_useable_login_token
     pending_login_token if pending_login_token&.useable?
   end
+
   def permission_check
     if !(AppConfig.app_features[:create_user] || pending_invitation || pending_group)
       render json: { errors: {email: [I18n.t('auth_form.invitation_required')], name: [I18n.t('auth_form.invitation_required')]}}, status: 422
@@ -64,11 +69,5 @@ class Api::V1::RegistrationsController < Devise::RegistrationsController
     return true if @email_can_be_verified
     TurnstileService.verify(params.dig(:user, :turnstile_token) || params[:turnstile_token],
                             remote_ip: request.remote_ip)
-  end
-
-  def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:sign_up) do |u|
-      u.permit(:name, :email, :legal_accepted, :email_newsletter, :turnstile_token)
-    end
   end
 end

--- a/app/controllers/api/v1/sessions_controller.rb
+++ b/app/controllers/api/v1/sessions_controller.rb
@@ -1,6 +1,5 @@
-class Api::V1::SessionsController < Devise::SessionsController
+class Api::V1::SessionsController < Api::V1::RestfulController
   include PrettyUrlHelper
-  before_action :configure_permitted_parameters
 
   def create
     unless turnstile_ok?
@@ -10,7 +9,7 @@ class Api::V1::SessionsController < Devise::SessionsController
     if user = attempt_login
       sign_in(user)
       flash[:notice] = t(:'devise.sessions.signed_in')
-      user.update(name: resource_params[:name]) if resource_params[:name]
+      user.update(name: session_params[:name]) if session_params[:name]
       user.update_columns(bounces_count: 0, complaints_count: 0) if user.bounces_count > 0 || user.complaints_count > 0
       render json: Boot::User.new(user, root_url: URI(root_url).origin).payload
       EventBus.broadcast('session_create', user)
@@ -22,7 +21,7 @@ class Api::V1::SessionsController < Devise::SessionsController
 
   def destroy
     current_user.update_columns(secret_token: UUIDTools::UUID.random_create.to_s)
-    sign_out resource_name
+    sign_out
 
     flash[:notice] = t(:'devise.sessions.signed_out')
     render json: { success: :ok }
@@ -30,12 +29,18 @@ class Api::V1::SessionsController < Devise::SessionsController
 
   private
 
+  def session_params
+    params.require(:user).permit(:email, :password, :code, :name, :remember_me, :turnstile_token)
+  rescue ActionController::ParameterMissing
+    params.permit(:email, :password, :code, :name, :remember_me, :turnstile_token)
+  end
+
   def failure_message
-    if resource_params[:password] && login_user&.access_locked?
+    if session_params[:password] && login_user&.access_locked?
       { password: [I18n.t('auth_form.account_locked')] }
     elsif session[:pending_login_token].present?
       { token: [I18n.t('auth_form.invalid_token')] }
-    elsif resource_params[:password] && login_user.nil?
+    elsif session_params[:password] && login_user.nil?
       { email: [I18n.t('auth_form.email_not_found')] }
     else
       { password: [I18n.t('auth_form.invalid_password')] }
@@ -43,22 +48,37 @@ class Api::V1::SessionsController < Devise::SessionsController
   end
 
   def login_user
-    @login_user ||= User.find_for_authentication(email: resource_params[:email])
+    @login_user ||= User.find_by_email_for_authentication(session_params[:email])
   end
 
   def attempt_login
     if pending_login_token&.useable?
       pending_login_token.user
-    elsif resource_params[:code]
+    elsif session_params[:code]
       login_token_user
     else
-      warden.authenticate(scope: resource_name)
+      authenticate_with_password
+    end
+  end
+
+  def authenticate_with_password
+    user = login_user
+    return nil unless user&.active_for_authentication?
+
+    if user.access_locked?
+      nil
+    elsif user.authenticate(session_params[:password])
+      user.reset_failed_attempts
+      user
+    else
+      user.increment_failed_attempts
+      nil
     end
   end
 
   def login_token_user
     LoginToken.transaction do
-      token = LoginToken.unused.lock.find_by(code: resource_params.require(:code))
+      token = LoginToken.unused.lock.find_by(code: session_params.require(:code))
       next unless login_token_matches?(token)
 
       token.update!(used: true)
@@ -67,13 +87,13 @@ class Api::V1::SessionsController < Devise::SessionsController
   end
 
   def login_token_matches?(token)
-    resource_params[:email].present? && token&.useable? && token.user.email == resource_params[:email]
+    session_params[:email].present? && token&.useable? && token.user.email == session_params[:email]
   end
 
   def usable_login_token_for_code
-    return unless resource_params[:code].present?
+    return unless session_params[:code].present?
 
-    token = LoginToken.unused.find_by(code: resource_params[:code])
+    token = LoginToken.unused.find_by(code: session_params[:code])
     if login_token_matches?(token)
       token
     else
@@ -83,18 +103,12 @@ class Api::V1::SessionsController < Devise::SessionsController
   end
 
   def record_failed_login_code_attempt
-    return if resource_params[:email].blank?
+    return if session_params[:email].blank?
 
     LoginToken.transaction do
-      user = User.find_by(email: resource_params[:email])
+      user = User.find_by(email: session_params[:email])
       token = user&.login_tokens&.unused&.lock&.order(created_at: :desc)&.find(&:useable?)
       token&.record_failed_code_attempt!
-    end
-  end
-
-  def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:sign_in) do |u|
-      u.permit(:code, :email, :password, :remember_me, :turnstile_token)
     end
   end
 

--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -1,0 +1,117 @@
+module Authentication
+  extend ActiveSupport::Concern
+
+  included do
+    helper_method :current_user, :user_signed_in? if respond_to?(:helper_method)
+  end
+
+  # ── sign in ──────────────────────────────────────────────────────────
+  def sign_in(user)
+    user = UserService.verify(user: user)
+
+    # Create Rails session record
+    session_record = user.sessions.create!(
+      ip_address: request.remote_ip,
+      user_agent: request.user_agent
+    )
+    cookies.signed.permanent[:session_token] = {
+      value: session_record.token,
+      httponly: true,
+      secure: Rails.env.production?,
+      same_site: :lax
+    }
+    cookies[:signed_in] = 1
+
+    # Transitional: also keep Warden session while migrating
+    warden.set_user(user, scope: :user) if defined?(warden)
+
+    @current_user = user
+
+    true
+  end
+
+  # ── sign out ─────────────────────────────────────────────────────────
+  def sign_out
+    if (token = cookies.signed[:session_token])
+      Session.find_by(token: token)&.destroy
+    end
+    cookies.delete(:session_token)
+    cookies.delete(:signed_in)
+
+    # Transitional: also clear Warden
+    warden.logout if defined?(warden)
+
+    @current_user = nil
+  end
+
+  # ── current user ─────────────────────────────────────────────────────
+  def current_user
+    @current_user ||= find_user_from_session || find_user_from_warden || build_guest_user
+  end
+
+  # ── authentication gates ─────────────────────────────────────────────
+  def user_signed_in?
+    current_user.is_logged_in?
+  end
+
+  def authenticate_user!
+    unless user_signed_in?
+      respond_to do |format|
+        format.html { redirect_to dashboard_path }
+        format.json { render json: { error: 'Unauthorized' }, status: 401 }
+      end
+    end
+  end
+
+  def require_current_user
+    respond_with_error(401) unless current_user && current_user.is_logged_in?
+  end
+
+  private
+
+  def find_user_from_session
+    token = cookies.signed[:session_token]
+    return unless token
+
+    session_record = Session.find_by(token: token)
+    return unless session_record&.user
+
+    if session_record.expired?
+      session_record.destroy
+      return nil
+    end
+
+    session_record.record_activity!
+    session_record.user
+  end
+
+  # Transitional: detects Warden-authenticated users and creates a
+  # Rails Session record for them. After the migration period both
+  # the Warden session AND the Rails session exist, but subsequent
+  # requests use the Rails session. Remove this method once migration
+  # is complete.
+  def find_user_from_warden
+    return unless defined?(warden) && warden.authenticated?(:user)
+
+    user = warden.user(:user)
+    return unless user
+
+    # Create a Rails Session so the next request uses it
+    session_record = user.sessions.create!(
+      ip_address: request.remote_ip,
+      user_agent: request.user_agent
+    )
+    cookies.signed.permanent[:session_token] = {
+      value: session_record.token,
+      httponly: true,
+      secure: Rails.env.production?,
+      same_site: :lax
+    }
+    cookies[:signed_in] = 1
+    user
+  end
+
+  def build_guest_user
+    LoggedOutUser.new(locale: logged_out_preferred_locale, params: params, session: session)
+  end
+end

--- a/app/helpers/current_user_helper.rb
+++ b/app/helpers/current_user_helper.rb
@@ -1,4 +1,5 @@
 module CurrentUserHelper
+  include Authentication
   include PendingActionsHelper
 
   class SpamUserDeniedError < StandardError
@@ -6,7 +7,6 @@ module CurrentUserHelper
 
   def sign_in(user)
     @current_user = nil
-    user = UserService.verify(user: user)
     super(user) && handle_pending_actions(user) && associate_user_to_visit
   end
 

--- a/app/models/concerns/lockable.rb
+++ b/app/models/concerns/lockable.rb
@@ -1,0 +1,42 @@
+module Lockable
+  extend ActiveSupport::Concern
+
+  included do
+    # These columns already exist (from Devise migration)
+    # failed_attempts  :integer, default: 0
+    # unlock_token     :string
+    # locked_at        :datetime
+  end
+
+  MAX_ATTEMPTS = ENV.fetch('MAX_LOGIN_ATTEMPTS', 10).to_i
+  UNLOCK_IN = 6.hours
+
+  def access_locked?
+    locked_at.present? && locked_at > UNLOCK_IN.ago
+  end
+
+  def lock_access!
+    return if access_locked?
+    update_columns(
+      locked_at: Time.current,
+      unlock_token: self.class.generate_unique_secure_token
+    )
+  end
+
+  def unlock_access!
+    update_columns(
+      locked_at: nil,
+      unlock_token: nil,
+      failed_attempts: 0
+    )
+  end
+
+  def increment_failed_attempts
+    increment!(:failed_attempts)
+    lock_access! if failed_attempts >= MAX_ATTEMPTS
+  end
+
+  def reset_failed_attempts
+    update_column(:failed_attempts, 0) if failed_attempts > 0
+  end
+end

--- a/app/models/concerns/null/user.rb
+++ b/app/models/concerns/null/user.rb
@@ -12,7 +12,7 @@ module Null::User
   def nil_methods
     [:id, :key, :username, :short_bio, :city, :region, :country, :selected_locale, :deactivated_at,
      :default_membership_volume, :unsubscribe_token, :location, :email_catch_up_day,
-     :encrypted_password, :update_attribute, :last_seen_at, :legal_accepted_at, :api_key]
+     :password_digest, :update_attribute, :last_seen_at, :legal_accepted_at, :api_key]
   end
 
   def false_methods

--- a/app/models/concerns/pwned_password_validator.rb
+++ b/app/models/concerns/pwned_password_validator.rb
@@ -1,0 +1,27 @@
+# Validates passwords against the haveibeenpwned.com API.
+# Replaces the devise-pwned_password gem.
+#
+# Uses the pwned gem (https://github.com/philnash/pwned) which employs
+# the k-anonymity model: only the first 5 characters of the SHA-1 hash
+# are sent to the API, so the full password hash is never exposed.
+module PwnedPasswordValidator
+  extend ActiveSupport::Concern
+
+  included do
+    validate :password_not_pwned, if: :password_required?
+  end
+
+  private
+
+  def password_not_pwned
+    return unless password.present?
+    return unless Rails.env.production?
+
+    if Pwned.pwned?(password)
+      errors.add(:password, I18n.t('auth_form.pwned_password'))
+    end
+  rescue Pwned::TimeoutError, Pwned::Error => e
+    # API failure shouldn't block sign-up; log and allow
+    Rails.logger.warn("PwnedPasswordValidator lookup failed: #{e.message}")
+  end
+end

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -1,0 +1,26 @@
+class Session < ApplicationRecord
+  belongs_to :user
+
+  before_create :set_token_and_expiry
+
+  scope :active, -> { where('last_active_at > ?', 2.weeks.ago) }
+
+  def record_activity!
+    touch(:last_active_at)
+  end
+
+  def expired?
+    last_active_at < 2.weeks.ago
+  end
+
+  def self.find_by_token(token)
+    find_by(token: token)
+  end
+
+  private
+
+  def set_token_and_expiry
+    self.token = SecureRandom.urlsafe_base64(32)
+    self.last_active_at ||= Time.current
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -21,8 +21,9 @@ class User < ApplicationRecord
 
   MAX_AVATAR_IMAGE_SIZE_CONST = 100.megabytes
 
-  devise :database_authenticatable, :recoverable, :registerable, :rememberable, :lockable, :trackable
-  devise :pwned_password if Rails.env.production?
+  has_secure_password validations: false
+  include Lockable
+  include PwnedPasswordValidator
   attr_accessor :restricted
   attr_accessor :token
   attr_accessor :membership_token
@@ -51,9 +52,8 @@ class User < ApplicationRecord
   validates_length_of :username, maximum: 30
   validates_length_of :short_bio, maximum: 5000
   validates_format_of :username, with: /\A[a-z0-9]*\z/, message: I18n.t(:'user.error.username_must_be_alphanumeric')
-  validates_confirmation_of :password, if: :password_required?
-
-  validates_length_of :password, minimum: 8, allow_nil: true
+  validates :password, length: { minimum: 8 }, confirmation: true, if: :password_required?
+  validates :password, length: { maximum: 72 }, if: :password_required?
 
   has_many :admin_memberships,
            -> { where('memberships.admin': true, revoked_at: nil) },
@@ -102,6 +102,7 @@ class User < ApplicationRecord
   has_many :notifications, dependent: :destroy
   has_many :comments, dependent: :destroy
   has_many :login_tokens, dependent: :destroy
+  has_many :sessions, dependent: :destroy
   has_many :events, dependent: :destroy
 
   has_many :tags, through: :groups
@@ -202,8 +203,8 @@ class User < ApplicationRecord
     find_by(email: email)&.email_status || :unused
   end
 
-  def self.find_for_database_authentication(warden_conditions)
-    super(warden_conditions.merge(email_verified: true))
+  def self.find_by_email_for_authentication(email)
+    verified.find_by(email: email)
   end
 
   define_counter_cache(:memberships_count) {|user| user.memberships.count }
@@ -216,16 +217,12 @@ class User < ApplicationRecord
     name.split(' ').drop(1).join(' ')
   end
 
-  def remember_me
-    true
-  end
-
   def is_logged_in?
     true
   end
 
   def has_password
-    self.encrypted_password.present?
+    self.password_digest.present?
   end
 
   def email_status
@@ -284,7 +281,7 @@ class User < ApplicationRecord
 
   # http://stackoverflow.com/questions/5140643/how-to-soft-delete-user-with-devise/8107966#8107966
   def active_for_authentication?
-    super && !deactivated_at
+    !deactivated_at
   end
 
   def locale
@@ -297,10 +294,6 @@ class User < ApplicationRecord
 
   def generate_username
     self.username ||= ::UsernameGenerator.new(self).generate
-  end
-
-  def send_devise_notification(notification, *args)
-    I18n.with_locale(locale) { devise_mailer.send(notification, self, *args).deliver_now }
   end
 
   def self.ransackable_associations(auth_object = nil)

--- a/app/services/group_export_service.rb
+++ b/app/services/group_export_service.rb
@@ -23,7 +23,7 @@ class GroupExportService
 
   JSON_PARAMS = {
     groups:      {except: [:token], methods: []},
-    users:       {except: [:encrypted_password,
+    users:       {except: [:password_digest,
                            :reset_password_token,
                            :email_api_key,
                            :reset_password_token,

--- a/app/workers/redact_user_worker.rb
+++ b/app/workers/redact_user_worker.rb
@@ -33,7 +33,7 @@ class RedactUserWorker
         unlock_token: nil,
         current_sign_in_ip: nil,
         last_sign_in_ip: nil,
-        encrypted_password: nil,
+        password_digest: nil,
         reset_password_token: nil,
         reset_password_sent_at: nil,
         unsubscribe_token: nil,

--- a/config/initializers/active_admin.rb
+++ b/config/initializers/active_admin.rb
@@ -2,7 +2,7 @@ ActiveAdmin.setup do |config|
   config.site_title = "Loomio"
   config.authentication_method = :authenticate_admin_user!
   config.current_user_method = :current_user
-  config.logout_link_path = :destroy_user_session_path
+  config.logout_link_path = :logout_path
   config.logout_link_method = :delete
   config.root_to = 'groups#index'
   config.batch_actions = true
@@ -10,6 +10,15 @@ ActiveAdmin.setup do |config|
 end
 
 def authenticate_admin_user!
-  authenticate_user!
-  redirect_to new_user_session_path unless current_user.is_admin?
+  unless current_user.is_logged_in?
+    redirect_to dashboard_path
+    return
+  end
+  unless current_user.is_admin?
+    redirect_to dashboard_path
+  end
+end
+
+def logout_path
+  '/api/v1/sessions'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -306,12 +306,9 @@ Rails.application.routes.draw do
         get :show, on: :collection
       end
 
-      namespace(:sessions)        { get :unauthorized }
-      devise_scope :user do
-        resource :sessions, only: [:create, :destroy]
-        resource :registrations, only: :create do
-          post :oauth, on: :collection
-        end
+      resource :sessions, only: [:create, :destroy]
+      resource :registrations, only: :create do
+        post :oauth, on: :collection
       end
       # identities command route removed (dead code)
     end
@@ -322,7 +319,7 @@ Rails.application.routes.draw do
 
   get '/users/sign_in', to: redirect('/dashboard')
   get '/users/sign_up', to: redirect('/dashboard')
-  devise_for :users, skip: [:passwords]
+  # devise_for :users removed — replaced with Rails built-in authentication
 
   resources :contact_messages, only: [:new, :create] do
     get :show, on: :collection

--- a/db/migrate/20260611000000_rename_encrypted_password_to_password_digest.rb
+++ b/db/migrate/20260611000000_rename_encrypted_password_to_password_digest.rb
@@ -1,0 +1,5 @@
+class RenameEncryptedPasswordToPasswordDigest < ActiveRecord::Migration[8.0]
+  def change
+    rename_column :users, :encrypted_password, :password_digest
+  end
+end

--- a/db/migrate/20260611000001_create_sessions.rb
+++ b/db/migrate/20260611000001_create_sessions.rb
@@ -1,0 +1,14 @@
+class CreateSessions < ActiveRecord::Migration[8.0]
+  def change
+    create_table :sessions do |t|
+      t.references :user, null: false, foreign_key: true, index: true
+      t.string :ip_address
+      t.string :user_agent
+      t.string :token, null: false
+      t.datetime :last_active_at
+      t.timestamps
+    end
+
+    add_index :sessions, :token, unique: true
+  end
+end

--- a/test/controllers/api/v1/mentions_controller_test.rb
+++ b/test/controllers/api/v1/mentions_controller_test.rb
@@ -73,7 +73,7 @@ class Api::V1::MentionsControllerTest < ActionController::TestCase
       name: "Other User",
       email: "othermentions@example.com",
       username: "othermentions",
-      encrypted_password: "$2a$12$K3E5h0VGlqmXL8HqWw7mIe3qP0XjQSfZ1jK4PqYX7Qq5N9YK6L4/K",
+      password_digest: "$2a$12$K3E5h0VGlqmXL8HqWw7mIe3qP0XjQSfZ1jK4PqYX7Qq5N9YK6L4/K",
       email_verified: true
     )
 

--- a/test/controllers/api/v1/reactions_controller_test.rb
+++ b/test/controllers/api/v1/reactions_controller_test.rb
@@ -37,7 +37,7 @@ class Api::V1::ReactionsControllerTest < ActionController::TestCase
       name: "Unauthorized User",
       email: "unauthorized@example.com",
       username: "unauthorized",
-      encrypted_password: "$2a$12$K3E5h0VGlqmXL8HqWw7mIe3qP0XjQSfZ1jK4PqYX7Qq5N9YK6L4/K",
+      password_digest: "$2a$12$K3E5h0VGlqmXL8HqWw7mIe3qP0XjQSfZ1jK4PqYX7Qq5N9YK6L4/K",
       email_verified: true
     )
 
@@ -130,7 +130,7 @@ class Api::V1::ReactionsControllerTest < ActionController::TestCase
       name: "Unauthorized User 2",
       email: "unauthorized2@example.com",
       username: "unauthorized2",
-      encrypted_password: "$2a$12$K3E5h0VGlqmXL8HqWw7mIe3qP0XjQSfZ1jK4PqYX7Qq5N9YK6L4/K",
+      password_digest: "$2a$12$K3E5h0VGlqmXL8HqWw7mIe3qP0XjQSfZ1jK4PqYX7Qq5N9YK6L4/K",
       email_verified: true
     )
 

--- a/test/controllers/api/v1/tasks_controller_test.rb
+++ b/test/controllers/api/v1/tasks_controller_test.rb
@@ -5,14 +5,14 @@ class Api::V1::TasksControllerTest < ActionController::TestCase
     @author = User.find_or_create_by!(email: "taskauthor@example.com") do |u|
       u.name = "author"
       u.username = "taskauthor"
-      u.encrypted_password = "$2a$12$K3E5h0VGlqmXL8HqWw7mIe3qP0XjQSfZ1jK4PqYX7Qq5N9YK6L4/K"
+      u.password_digest = "$2a$12$K3E5h0VGlqmXL8HqWw7mIe3qP0XjQSfZ1jK4PqYX7Qq5N9YK6L4/K"
       u.email_verified = true
     end
 
     @doer = User.find_or_create_by!(email: "taskdoer@example.com") do |u|
       u.name = "doer"
       u.username = "taskdoer"
-      u.encrypted_password = "$2a$12$K3E5h0VGlqmXL8HqWw7mIe3qP0XjQSfZ1jK4PqYX7Qq5N9YK6L4/K"
+      u.password_digest = "$2a$12$K3E5h0VGlqmXL8HqWw7mIe3qP0XjQSfZ1jK4PqYX7Qq5N9YK6L4/K"
       u.email_verified = true
     end
 

--- a/test/services/user_service_test.rb
+++ b/test/services/user_service_test.rb
@@ -57,7 +57,7 @@ class UserServiceTest < ActiveSupport::TestCase
     assert_nil @user.unlock_token
     assert_nil @user.current_sign_in_ip
     assert_nil @user.last_sign_in_ip
-    assert_nil @user.encrypted_password
+    assert_nil @user.password_digest
     assert_nil @user.reset_password_token
     assert_nil @user.reset_password_sent_at
     assert_nil @user.detected_locale


### PR DESCRIPTION
Replaces Devise (Warden-based) with `has_secure_password` + `Session` model for Rails 8.0 native authentication, in preparation for adopting passkeys as a Loomio sign-in method.

## What's Preserved (No User-Visible Change)

- **Existing passwords continue to work** — both Devise and `has_secure_password` use bcrypt; the column is simply renamed
- **No logout required** — transitional code detects Warden-authenticated users and creates equivalent Rails Sessions behind the scenes
- **All API contracts unchanged** — same JSON payloads, same response shapes; Vue SPA unaffected
- **Login-token flow** — fully preserved
- **OAuth / SAML** — identity controllers unchanged
- **Account locking** — same behavior, same columns, same config
- **have-i-been-pwned** — same `pwned` gem, production-only
- **Turnstile CAPTCHA** — preserved in all three auth controllers
- **Pending actions** — still handled on sign-in (memberships, identities, stances, etc.)

## What's New

- **`sessions` table** — per-sign-in tracking enables: auditing sign-in history, detecting unusual patterns, and server-side session invalidation (sign out compromised accounts)
- **`Session` model** — replaces Warden's opaque session storage with a proper database record

## Changes

| Area | Change |
|---|---|
| **Migrations** | Rename `encrypted_password` → `password_digest`; create `sessions` table |
| **User model** | `has_secure_password` replaces 6 Devise modules; custom `Lockable` + `PwnedPasswordValidator` concerns |
| **Auth concern** | New `Authentication` concern with `sign_in`/`sign_out`/`current_user` + transitional Warden bridge |
| **Controllers** | Sessions + Registrations controllers extend `RestfulController` (no longer Devise); strong params replace devise_parameter_sanitizer |
| **Routes** | Removed `devise_for` and `devise_scope` wrappers; API routes kept as-is |
| **ActiveAdmin** | Replaced Devise route helpers with custom auth paths |

## Cleanup (Follow-up PR)

After deploying and confirming no issues:

1. Remove `devise`, `devise-i18n`, `devise-pwned_password` gems
2. Add explicit `pwned` gem
3. Delete `config/initializers/devise.rb`
4. Remove `find_user_from_warden` transitional method
5. Replace `authenticate :user` Sidekiq constraint
6. Drop unused Devise columns and indexes
