### PR TITLE
Group handle redirects

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,7 @@
 ## Git commits
 
 - Do not run `git commit` unless the user explicitly asks for a specific commit.
+- Permission to commit once does not grant permission to commit again later without asking.
 
 ## i18n / Localization
 

--- a/app/admin/groups.rb
+++ b/app/admin/groups.rb
@@ -240,7 +240,10 @@ ActiveAdmin.register Group, as: 'Group' do
   member_action :handle, method: :post do
     params.permit(:id, :handle)
     group = Group.friendly.find(params[:id])
-    group.update(handle: params[:handle])
+    old_handle = GroupService.update_handle(group: group, handle: params[:handle], actor: current_user)
+    if old_handle.present? && old_handle != group.handle
+      flash[:notice] = "Handle changed from '#{old_handle}' to '#{group.handle}'. Requests to the old URL will redirect."
+    end
     redirect_to admin_group_path(group)
   end
 

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -15,6 +15,22 @@ class GroupsController < ApplicationController
   end
 
   def show
+    if params[:id].present?
+      if group = Group.find_by(handle: params[:id])
+        return render_group(group)
+      end
+
+      if redirect = GroupHandleRedirect.includes(:group).find_by(handle: params[:id])
+        group = redirect.group
+        unless current_user.can?(:show, group)
+          return respond_with_error 403
+        end
+
+        return redirect_to group_handle_path(group.handle, request.query_parameters), status: :moved_permanently
+      end
+    end
+
+    # existing fallback behavior
     resource = ModelLocator.new(resource_name, params).locate!
     @recipient = current_user
     if current_user.can? :show, resource
@@ -41,6 +57,24 @@ class GroupsController < ApplicationController
   end
 
   private
+
+  def render_group(group)
+    @group = group
+    @recipient = current_user
+    if current_user.can? :show, @group
+      respond_to do |format|
+        format.html do
+          render Views::Groups::Show.new(
+            group: @group, recipient: @recipient,
+            metadata: metadata, export: !!params[:export], bot: browser.bot?
+          )
+        end
+        format.xml
+      end
+    else
+      respond_with_error 403
+    end
+  end
 
   def require_signed_in_user_for_explore
     require_current_user if AppConfig.app_features[:restrict_explore_to_signed_in_users]

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -58,6 +58,10 @@ class Group < ApplicationRecord
 
   has_many :chatbots, dependent: :destroy
 
+  has_many :handle_redirects,
+           class_name: 'GroupHandleRedirect',
+           dependent: :destroy
+
   has_many :tags, foreign_key: :group_id
 
   belongs_to :subscription
@@ -98,6 +102,7 @@ class Group < ApplicationRecord
   validates :subscription, absence: true, if: :is_subgroup?
   validate :handle_is_valid
   validates :handle, uniqueness: true, allow_nil: true
+  validate :handle_is_not_retired_handle
 
   delegate :locale, to: :creator, allow_nil: true
   delegate :time_zone, to: :creator, allow_nil: true
@@ -473,6 +478,14 @@ class Group < ApplicationRecord
     self.handle = handle.parameterize
     if is_subgroup? && parent.handle && !handle.starts_with?("#{parent.handle}-")
       errors.add(:handle, I18n.t(:'group.error.handle_must_begin_with_parent_handle', parent_handle: parent.handle))
+    end
+  end
+
+  def handle_is_not_retired_handle
+    return if handle.blank?
+
+    if GroupHandleRedirect.where(handle: handle).where.not(group_id: id).exists?
+      errors.add(:handle, :taken)
     end
   end
 

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -475,7 +475,10 @@ class Group < ApplicationRecord
   def handle_is_valid
     self.handle = nil if self.handle.to_s.strip == "" || (is_subgroup? && parent.handle.nil?)
     return if handle.nil?
-    self.handle = handle.parameterize
+    if handle != handle.parameterize
+      errors.add(:handle, I18n.t(:'group.error.handle_must_be_url_friendly'))
+      return
+    end
     if is_subgroup? && parent.handle && !handle.starts_with?("#{parent.handle}-")
       errors.add(:handle, I18n.t(:'group.error.handle_must_begin_with_parent_handle', parent_handle: parent.handle))
     end

--- a/app/models/group_handle_redirect.rb
+++ b/app/models/group_handle_redirect.rb
@@ -1,0 +1,23 @@
+class GroupHandleRedirect < ApplicationRecord
+  belongs_to :group
+
+  validates :handle, presence: true, uniqueness: true
+  validate :handle_is_not_current_group_handle
+  validate :handle_is_not_current_handle_of_any_group
+
+  before_validation :parameterize_handle
+
+  private
+
+  def parameterize_handle
+    self.handle = handle.to_s.strip.parameterize.presence if handle.present?
+  end
+
+  def handle_is_not_current_group_handle
+    errors.add(:handle, :taken) if group&.handle == handle
+  end
+
+  def handle_is_not_current_handle_of_any_group
+    errors.add(:handle, :taken) if Group.where(handle: handle).where.not(id: group_id).exists?
+  end
+end

--- a/app/services/group_service.rb
+++ b/app/services/group_service.rb
@@ -200,6 +200,7 @@ module GroupService
           handle: old_handle
         )
         trim_handle_redirects(group)
+        update_descendant_handles(group, old_handle, new_handle)
       end
     end
 
@@ -211,6 +212,28 @@ module GroupService
   def self.trim_handle_redirects(group)
     excess = group.handle_redirects.order(created_at: :desc).offset(3)
     excess.destroy_all if excess.any?
+  end
+
+  def self.update_descendant_handles(group, old_parent_handle, new_parent_handle)
+    group.all_subgroups.each do |subgroup|
+      old_sub_handle = subgroup.handle
+      next unless old_sub_handle&.starts_with?("#{old_parent_handle}-")
+
+      new_sub_handle = old_sub_handle.sub(
+        /\A#{Regexp.escape(old_parent_handle)}-/,
+        "#{new_parent_handle}-"
+      )
+
+      subgroup.update!(handle: new_sub_handle)
+
+      GroupHandleRedirect.find_or_create_by!(
+        group: subgroup,
+        handle: old_sub_handle
+      )
+      trim_handle_redirects(subgroup)
+
+      update_descendant_handles(subgroup, old_sub_handle, new_sub_handle)
+    end
   end
 
   def self.generate_handle(name, parent_handle, attempt)

--- a/app/services/group_service.rb
+++ b/app/services/group_service.rb
@@ -102,12 +102,23 @@ module GroupService
   def self.update(group:, params:, actor:)
     actor.ability.authorize! :update, group
 
+    old_handle = group.handle
     group.assign_attributes_and_files(params.except(:parent_id))
     group.group_privacy = params[:group_privacy] if params.has_key?(:group_privacy)
     privacy_change = PrivacyChange.new(group)
 
     return false unless group.valid?
-    group.save!
+
+    Group.transaction do
+      group.save!
+
+      new_handle = group.handle
+      if old_handle.present? && new_handle.present? && old_handle != new_handle
+        GroupHandleRedirect.find_or_create_by!(group: group, handle: old_handle)
+        trim_handle_redirects(group)
+      end
+    end
+
     privacy_change.commit!
 
     EventBus.broadcast('group_update', group, params, actor)
@@ -133,7 +144,15 @@ module GroupService
 
   def self.move(group:, parent:, actor:)
     actor.ability.authorize! :move, group
-    group.update(handle: "#{parent.handle}-#{group.handle}") if group.handle?
+    old_handle = group.handle
+    if group.handle?
+      new_handle = "#{parent.handle}-#{group.handle}"
+      group.update(handle: new_handle)
+      if old_handle.present? && old_handle != new_handle
+        GroupHandleRedirect.find_or_create_by!(group: group, handle: old_handle)
+        trim_handle_redirects(group)
+      end
+    end
     group.update(parent: parent, subscription_id: nil)
     EventBus.broadcast('group_move', group, parent, actor)
   end
@@ -159,13 +178,40 @@ module GroupService
 
   def self.suggest_handle(name:, parent_handle:)
     attempt = 0
-    while(Group.where(handle: generate_handle(name, parent_handle, attempt)).exists?) do
+    while(Group.where(handle: generate_handle(name, parent_handle, attempt)).exists? ||
+         GroupHandleRedirect.where(handle: generate_handle(name, parent_handle, attempt)).exists?) do
       attempt += 1
     end
     generate_handle(name, parent_handle, attempt)
   end
 
+  def self.update_handle(group:, handle:, actor:)
+    actor.ability.authorize! :update, group
+
+    old_handle = group.handle
+    new_handle = handle.to_s.strip.parameterize.presence
+
+    Group.transaction do
+      group.update!(handle: new_handle)
+
+      if old_handle.present? && old_handle != new_handle
+        GroupHandleRedirect.find_or_create_by!(
+          group: group,
+          handle: old_handle
+        )
+        trim_handle_redirects(group)
+      end
+    end
+
+    old_handle
+  end
+
   private
+
+  def self.trim_handle_redirects(group)
+    excess = group.handle_redirects.order(created_at: :desc).offset(3)
+    excess.destroy_all if excess.any?
+  end
 
   def self.generate_handle(name, parent_handle, attempt)
     [parent_handle,

--- a/app/services/group_service.rb
+++ b/app/services/group_service.rb
@@ -200,21 +200,18 @@ module GroupService
           handle: old_handle
         )
         trim_handle_redirects(group)
-        update_descendant_handles(group, old_handle, new_handle)
       end
+    end
+
+    if old_handle.present? && old_handle != new_handle
+      GenericWorker.perform_async('GroupService', 'update_descendant_handles', group.id, old_handle, new_handle)
     end
 
     old_handle
   end
 
-  private
-
-  def self.trim_handle_redirects(group)
-    excess = group.handle_redirects.order(created_at: :desc).offset(3)
-    excess.destroy_all if excess.any?
-  end
-
-  def self.update_descendant_handles(group, old_parent_handle, new_parent_handle)
+  def self.update_descendant_handles(group_id, old_parent_handle, new_parent_handle)
+    group = Group.find(group_id)
     group.all_subgroups.each do |subgroup|
       old_sub_handle = subgroup.handle
       next unless old_sub_handle&.starts_with?("#{old_parent_handle}-")
@@ -232,8 +229,15 @@ module GroupService
       )
       trim_handle_redirects(subgroup)
 
-      update_descendant_handles(subgroup, old_sub_handle, new_sub_handle)
+      update_descendant_handles(subgroup.id, old_sub_handle, new_sub_handle)
     end
+  end
+
+  private
+
+  def self.trim_handle_redirects(group)
+    excess = group.handle_redirects.order(created_at: :desc).offset(3)
+    excess.destroy_all if excess.any?
   end
 
   def self.generate_handle(name, parent_handle, attempt)

--- a/app/services/received_email_service.rb
+++ b/app/services/received_email_service.rb
@@ -98,7 +98,7 @@ class ReceivedEmailService
     end
 
     # Group by handle
-    if group = Group.find_by(handle: email.route_path)
+    if group = group_from_route_path(email.route_path)
       unless address_is_blocked(email, group)
         email.update(group_id: group.id)
         if actor = actor_from_email_and_group(email, group)
@@ -198,9 +198,15 @@ class ReceivedEmailService
     nil
   end
 
+  def self.group_from_route_path(route_path)
+    Group.find_by(handle: route_path) ||
+      GroupHandleRedirect.find_by(handle: route_path)&.group
+  end
+
   def self.discussion_params(email)
     params = parse_route_params(email.route_path)
-    group = Group.find_by!(handle: (params['handle'] || email.route_path))
+    group = group_from_route_path(params['handle'] || email.route_path)
+    group || raise(ActiveRecord::RecordNotFound)
     {
       group_id: group.id,
       private: group.discussion_private_default,

--- a/config/locales/client.ca.yml
+++ b/config/locales/client.ca.yml
@@ -1294,6 +1294,7 @@ ca:
     organization_name: Nom de l'organització
     handle: Gestionar
     group_handle_placeholder: 'S''utilitza a l''URL del vostre grup: %{host}/%{handle}'
+    handle_redirect_notice: 'If you change this handle, links using the old address will redirect here.'
     start_organization_heading: Nova organització
     edit_organization_heading: Edita la configuració de l'organització
     group_name_placeholder: Quin és el nom del vostre grup?

--- a/config/locales/client.ca.yml
+++ b/config/locales/client.ca.yml
@@ -1294,7 +1294,7 @@ ca:
     organization_name: Nom de l'organització
     handle: Gestionar
     group_handle_placeholder: 'S''utilitza a l''URL del vostre grup: %{host}/%{handle}'
-    handle_redirect_notice: 'If you change this handle, links using the old address will redirect here.'
+    handle_redirect_notice: If you change this handle, links using the old address will redirect here.
     start_organization_heading: Nova organització
     edit_organization_heading: Edita la configuració de l'organització
     group_name_placeholder: Quin és el nom del vostre grup?
@@ -1385,6 +1385,8 @@ ca:
     members_can_start_discussions_help_v2: Permetre que els membres iniciïn noves discussions dins del grup
     members_can_edit_discussions_v2: Els membres poden gestionar debats i comentaris
     members_can_edit_discussions_help_v2: Permetre que els membres editin, moguin, fixin, etiquetin o tanquin qualsevol discussió o comentari del grup
+    group_handle_hint_new: L'URL i el correu electrònic del vostre grup seran %{host}/%{handle} i %{handle}{'@'}%{host}
+    handle_changed_hint: L'URL i l'adreça electrònica anteriors redirigiran a la nova adreça.
   group_export_modal:
     title: Exporta dades del grup
     body: |

--- a/config/locales/client.ca.yml
+++ b/config/locales/client.ca.yml
@@ -1294,7 +1294,6 @@ ca:
     organization_name: Nom de l'organització
     handle: Gestionar
     group_handle_placeholder: 'S''utilitza a l''URL del vostre grup: %{host}/%{handle}'
-    handle_redirect_notice: If you change this handle, links using the old address will redirect here.
     start_organization_heading: Nova organització
     edit_organization_heading: Edita la configuració de l'organització
     group_name_placeholder: Quin és el nom del vostre grup?

--- a/config/locales/client.da.yml
+++ b/config/locales/client.da.yml
@@ -1288,6 +1288,7 @@ da:
     organization_name: Organisationens navn
     handle: Håndtere
     group_handle_placeholder: 'Brugt i din gruppe-URL: %{host}/%{handle}'
+    handle_redirect_notice: 'If you change this handle, links using the old address will redirect here.'
     start_organization_heading: Ny organisation
     edit_organization_heading: Rediger organisationsindstillinger
     group_name_placeholder: Hvad er navnet på din gruppe?

--- a/config/locales/client.da.yml
+++ b/config/locales/client.da.yml
@@ -1288,7 +1288,7 @@ da:
     organization_name: Organisationens navn
     handle: Håndtere
     group_handle_placeholder: 'Brugt i din gruppe-URL: %{host}/%{handle}'
-    handle_redirect_notice: 'If you change this handle, links using the old address will redirect here.'
+    handle_redirect_notice: If you change this handle, links using the old address will redirect here.
     start_organization_heading: Ny organisation
     edit_organization_heading: Rediger organisationsindstillinger
     group_name_placeholder: Hvad er navnet på din gruppe?
@@ -1379,6 +1379,8 @@ da:
     members_can_start_discussions_help_v2: Tillad medlemmer at starte nye diskussioner i gruppen
     members_can_edit_discussions_v2: Medlemmer kan administrere diskussioner og kommentarer
     members_can_edit_discussions_help_v2: Tillad medlemmer at redigere, flytte, fastgøre, tagge eller lukke enhver diskussion eller kommentar i gruppen
+    group_handle_hint_new: Din gruppes URL og e-mailadresse vil være %{host}/%{handle} og %{handle}{'@'}%{host}
+    handle_changed_hint: Din tidligere URL og e-mailadresse vil omdirigere til din nye adresse.
   group_export_modal:
     title: Eksporter gruppedata
     body: <p>Du kan til enhver tid downloade en kopi af din gruppes data. <a href="https://help.loomio.org/en/user_manual/groups/data_export/">Find ud af mere.</a></p><p> Det tager et par minutter at gennemføre, afhængigt af størrelsen på din gruppe. Når den er klar, modtager du en e-mail med et link til at downloade filen.</p>

--- a/config/locales/client.da.yml
+++ b/config/locales/client.da.yml
@@ -1288,7 +1288,6 @@ da:
     organization_name: Organisationens navn
     handle: Håndtere
     group_handle_placeholder: 'Brugt i din gruppe-URL: %{host}/%{handle}'
-    handle_redirect_notice: If you change this handle, links using the old address will redirect here.
     start_organization_heading: Ny organisation
     edit_organization_heading: Rediger organisationsindstillinger
     group_name_placeholder: Hvad er navnet på din gruppe?

--- a/config/locales/client.de.yml
+++ b/config/locales/client.de.yml
@@ -1302,7 +1302,7 @@ de:
     organization_name: Organizationsname
     handle: Kürzel
     group_handle_placeholder: 'Wird in Ihrer Gruppen-URL verwendet: %{host}/%{handle}'
-    handle_redirect_notice: 'If you change this handle, links using the old address will redirect here.'
+    handle_redirect_notice: If you change this handle, links using the old address will redirect here.
     start_organization_heading: Neue Organisation
     edit_organization_heading: Organisationseinstellungen ändern
     group_name_placeholder: Wie heißt deine Gruppe?
@@ -1393,6 +1393,8 @@ de:
     members_can_start_discussions_help_v2: Erlauben Sie den Mitgliedern, neue Diskussionen innerhalb der Gruppe zu starten.
     members_can_edit_discussions_v2: Mitglieder können Diskussionen und Kommentare verwalten.
     members_can_edit_discussions_help_v2: Erlauben Sie den Mitgliedern, Diskussionen oder Kommentare in der Gruppe zu bearbeiten, zu verschieben, anzuheften, zu taggen oder zu schließen.
+    group_handle_hint_new: Ihre Gruppen-URL und E-Mail-Adresse lauten %{host}/%{handle} und %{handle}{'@'}%{host}.
+    handle_changed_hint: Ihre bisherige URL und E-Mail-Adresse werden auf Ihre neue Adresse weitergeleitet.
   group_export_modal:
     title: Gruppendaten exportieren
     body: |

--- a/config/locales/client.de.yml
+++ b/config/locales/client.de.yml
@@ -1302,6 +1302,7 @@ de:
     organization_name: Organizationsname
     handle: Kürzel
     group_handle_placeholder: 'Wird in Ihrer Gruppen-URL verwendet: %{host}/%{handle}'
+    handle_redirect_notice: 'If you change this handle, links using the old address will redirect here.'
     start_organization_heading: Neue Organisation
     edit_organization_heading: Organisationseinstellungen ändern
     group_name_placeholder: Wie heißt deine Gruppe?

--- a/config/locales/client.de.yml
+++ b/config/locales/client.de.yml
@@ -1302,7 +1302,6 @@ de:
     organization_name: Organizationsname
     handle: Kürzel
     group_handle_placeholder: 'Wird in Ihrer Gruppen-URL verwendet: %{host}/%{handle}'
-    handle_redirect_notice: If you change this handle, links using the old address will redirect here.
     start_organization_heading: Neue Organisation
     edit_organization_heading: Organisationseinstellungen ändern
     group_name_placeholder: Wie heißt deine Gruppe?

--- a/config/locales/client.el.yml
+++ b/config/locales/client.el.yml
@@ -1288,7 +1288,7 @@ el:
     organization_name: Ονομα Οργανισμού
     handle: Λαβή
     group_handle_placeholder: 'Χρησιμοποιείται στη διεύθυνση URL της ομάδας σας: %{host}/%{handle}'
-    handle_redirect_notice: 'If you change this handle, links using the old address will redirect here.'
+    handle_redirect_notice: If you change this handle, links using the old address will redirect here.
     start_organization_heading: Νέα οργάνωση
     edit_organization_heading: Επεξεργασία ρυθμίσεων οργανισμού
     group_name_placeholder: Ποιο είναι το όνομα της ομάδα σας?
@@ -1379,6 +1379,8 @@ el:
     members_can_start_discussions_help_v2: Επιτρέψτε στα μέλη να ξεκινούν νέες συζητήσεις εντός της ομάδας
     members_can_edit_discussions_v2: Τα μέλη μπορούν να διαχειρίζονται συζητήσεις και σχόλια
     members_can_edit_discussions_help_v2: Επιτρέψτε στα μέλη να επεξεργάζονται, να μετακινούν, να καρφιτσώνουν, να προσθέτουν ετικέτες ή να κλείνουν οποιαδήποτε συζήτηση ή σχόλιο στην ομάδα
+    group_handle_hint_new: Η διεύθυνση URL και το email της ομάδας σας θα είναι %{host}/%{handle} και %{handle}{'@'}%{host}
+    handle_changed_hint: Η προηγούμενη διεύθυνση URL και η διεύθυνση email σας θα ανακατευθύνουν στη νέα σας διεύθυνση.
   group_export_modal:
     title: Εξαγωγή δεδομένων ομάδας
     body: <p>Μπορείτε να κάνετε λήψη ενός αντιγράφου των δεδομένων της ομάδας σας ανά πάσα στιγμή. <a href="https://help.loomio.org/en/user_manual/groups/data_export/">Μάθετε περισσότερα.</a></p><p> Χρειάζονται λίγα λεπτά για να ολοκληρωθεί, ανάλογα με το μέγεθος της ομάδας σας. Όταν είναι έτοιμο, θα λάβετε ένα email με έναν σύνδεσμο για τη λήψη του αρχείου.</p>

--- a/config/locales/client.el.yml
+++ b/config/locales/client.el.yml
@@ -1288,7 +1288,6 @@ el:
     organization_name: Ονομα Οργανισμού
     handle: Λαβή
     group_handle_placeholder: 'Χρησιμοποιείται στη διεύθυνση URL της ομάδας σας: %{host}/%{handle}'
-    handle_redirect_notice: If you change this handle, links using the old address will redirect here.
     start_organization_heading: Νέα οργάνωση
     edit_organization_heading: Επεξεργασία ρυθμίσεων οργανισμού
     group_name_placeholder: Ποιο είναι το όνομα της ομάδα σας?

--- a/config/locales/client.el.yml
+++ b/config/locales/client.el.yml
@@ -1288,6 +1288,7 @@ el:
     organization_name: Ονομα Οργανισμού
     handle: Λαβή
     group_handle_placeholder: 'Χρησιμοποιείται στη διεύθυνση URL της ομάδας σας: %{host}/%{handle}'
+    handle_redirect_notice: 'If you change this handle, links using the old address will redirect here.'
     start_organization_heading: Νέα οργάνωση
     edit_organization_heading: Επεξεργασία ρυθμίσεων οργανισμού
     group_name_placeholder: Ποιο είναι το όνομα της ομάδα σας?

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1422,6 +1422,8 @@ en:
     organization_name: Organization name
     handle: Handle
     group_handle_placeholder: 'For your group URL and email: %{host}/%{handle}, %{handle}{''@''}%{host}'
+    group_handle_hint_new: 'Your group URL and email will be %{host}/%{handle} and %{handle}{''@''}%{host}'
+    handle_changed_hint: Your previous URL and email address will redirect to your new address.
     handle_redirect_notice: 'If you change this handle, links using the old address will redirect here.'
     start_organization_heading: New organization
     edit_organization_heading: Edit organization settings

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1424,7 +1424,6 @@ en:
     group_handle_placeholder: 'For your group URL and email: %{host}/%{handle}, %{handle}{''@''}%{host}'
     group_handle_hint_new: 'Your group URL and email will be %{host}/%{handle} and %{handle}{''@''}%{host}'
     handle_changed_hint: Your previous URL and email address will redirect to your new address.
-    handle_redirect_notice: 'If you change this handle, links using the old address will redirect here.'
     start_organization_heading: New organization
     edit_organization_heading: Edit organization settings
     group_name_placeholder: What is the name of your group?

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1422,6 +1422,7 @@ en:
     organization_name: Organization name
     handle: Handle
     group_handle_placeholder: 'For your group URL and email: %{host}/%{handle}, %{handle}{''@''}%{host}'
+    handle_redirect_notice: 'If you change this handle, links using the old address will redirect here.'
     start_organization_heading: New organization
     edit_organization_heading: Edit organization settings
     group_name_placeholder: What is the name of your group?

--- a/config/locales/client.es.yml
+++ b/config/locales/client.es.yml
@@ -1303,6 +1303,7 @@ es:
     organization_name: Nombre de la organización
     handle: Gestionar
     group_handle_placeholder: 'Usado en la URL de tu grupo: %{host}/%{handle}'
+    handle_redirect_notice: 'If you change this handle, links using the old address will redirect here.'
     start_organization_heading: Nueva organización
     edit_organization_heading: Editar los ajustes de la organización
     group_name_placeholder: "¿Cuál es el nombre de tu grupo?"

--- a/config/locales/client.es.yml
+++ b/config/locales/client.es.yml
@@ -1303,7 +1303,7 @@ es:
     organization_name: Nombre de la organización
     handle: Gestionar
     group_handle_placeholder: 'Usado en la URL de tu grupo: %{host}/%{handle}'
-    handle_redirect_notice: 'If you change this handle, links using the old address will redirect here.'
+    handle_redirect_notice: If you change this handle, links using the old address will redirect here.
     start_organization_heading: Nueva organización
     edit_organization_heading: Editar los ajustes de la organización
     group_name_placeholder: "¿Cuál es el nombre de tu grupo?"
@@ -1394,6 +1394,8 @@ es:
     members_can_start_discussions_help_v2: Permitir que los miembros inicien nuevas discusiones dentro del grupo
     members_can_edit_discussions_v2: Los miembros pueden gestionar discusiones y comentarios.
     members_can_edit_discussions_help_v2: Permitir a los miembros editar, mover, fijar, etiquetar o cerrar cualquier discusión o comentario en el grupo
+    group_handle_hint_new: La URL y el correo electrónico de tu grupo serán %{host}/%{handle} y %{handle}{'@'}%{host}.
+    handle_changed_hint: Tu URL y dirección de correo electrónico anteriores se redirigirán a tu nueva dirección.
   group_export_modal:
     title: Exportar la data grupal
     body: |

--- a/config/locales/client.es.yml
+++ b/config/locales/client.es.yml
@@ -1303,7 +1303,6 @@ es:
     organization_name: Nombre de la organización
     handle: Gestionar
     group_handle_placeholder: 'Usado en la URL de tu grupo: %{host}/%{handle}'
-    handle_redirect_notice: If you change this handle, links using the old address will redirect here.
     start_organization_heading: Nueva organización
     edit_organization_heading: Editar los ajustes de la organización
     group_name_placeholder: "¿Cuál es el nombre de tu grupo?"

--- a/config/locales/client.fi.yml
+++ b/config/locales/client.fi.yml
@@ -1288,7 +1288,7 @@ fi:
     organization_name: Organisaation nimi
     handle: Kahva
     group_handle_placeholder: 'Käytetty ryhmäsi URL-osoitteessa: %{host}/%{handle}'
-    handle_redirect_notice: 'If you change this handle, links using the old address will redirect here.'
+    handle_redirect_notice: If you change this handle, links using the old address will redirect here.
     start_organization_heading: Uusi organisaatio
     edit_organization_heading: Muokkaa organisaation asetuksia
     group_name_placeholder: Mikä on ryhmäsi nimi?
@@ -1379,6 +1379,8 @@ fi:
     members_can_start_discussions_help_v2: Salli jäsenten aloittaa uusia keskusteluja ryhmässä
     members_can_edit_discussions_v2: Jäsenet voivat hallita keskusteluja ja kommentteja
     members_can_edit_discussions_help_v2: Salli jäsenten muokata, siirtää, kiinnittää, merkitä tai sulkea mitä tahansa keskustelua tai kommenttia ryhmässä
+    group_handle_hint_new: Ryhmäsi URL-osoite ja sähköpostiosoite ovat %{host}/%{handle} ja %{handle}{'@'}%{host}
+    handle_changed_hint: Edellinen URL-osoitteesi ja sähköpostiosoitteesi ohjaavat sinut uuteen osoitteeseesi.
   group_export_modal:
     title: Vie ryhmätiedot
     body: <p>Voit ladata kopion ryhmäsi tiedoista milloin tahansa. <a href="https://help.loomio.org/en/user_manual/groups/data_export/">Lue lisää.</a></p><p> Suorittaminen kestää muutaman minuutin ryhmäsi koosta riippuen. Kun se on valmis, saat sähköpostin, jossa on linkki tiedoston lataamiseen.</p>

--- a/config/locales/client.fi.yml
+++ b/config/locales/client.fi.yml
@@ -1288,6 +1288,7 @@ fi:
     organization_name: Organisaation nimi
     handle: Kahva
     group_handle_placeholder: 'Käytetty ryhmäsi URL-osoitteessa: %{host}/%{handle}'
+    handle_redirect_notice: 'If you change this handle, links using the old address will redirect here.'
     start_organization_heading: Uusi organisaatio
     edit_organization_heading: Muokkaa organisaation asetuksia
     group_name_placeholder: Mikä on ryhmäsi nimi?

--- a/config/locales/client.fi.yml
+++ b/config/locales/client.fi.yml
@@ -1288,7 +1288,6 @@ fi:
     organization_name: Organisaation nimi
     handle: Kahva
     group_handle_placeholder: 'Käytetty ryhmäsi URL-osoitteessa: %{host}/%{handle}'
-    handle_redirect_notice: If you change this handle, links using the old address will redirect here.
     start_organization_heading: Uusi organisaatio
     edit_organization_heading: Muokkaa organisaation asetuksia
     group_name_placeholder: Mikä on ryhmäsi nimi?

--- a/config/locales/client.fr.yml
+++ b/config/locales/client.fr.yml
@@ -1315,7 +1315,6 @@ fr:
     organization_name: Nom de l’organisation
     handle: Gérer
     group_handle_placeholder: 'Utilisé dans l''URL de votre groupe : %{host}/%{handle}'
-    handle_redirect_notice: If you change this handle, links using the old address will redirect here.
     start_organization_heading: Nouveau groupe
     edit_organization_heading: Modifier les paramètres de l'organisation
     group_name_placeholder: Quel est le nom de votre groupe ?

--- a/config/locales/client.fr.yml
+++ b/config/locales/client.fr.yml
@@ -1315,7 +1315,7 @@ fr:
     organization_name: Nom de l’organisation
     handle: Gérer
     group_handle_placeholder: 'Utilisé dans l''URL de votre groupe : %{host}/%{handle}'
-    handle_redirect_notice: 'If you change this handle, links using the old address will redirect here.'
+    handle_redirect_notice: If you change this handle, links using the old address will redirect here.
     start_organization_heading: Nouveau groupe
     edit_organization_heading: Modifier les paramètres de l'organisation
     group_name_placeholder: Quel est le nom de votre groupe ?
@@ -1406,6 +1406,8 @@ fr:
     members_can_start_discussions_help_v2: Autoriser les membres à entamer de nouvelles discussions au sein du groupe
     members_can_edit_discussions_v2: Les membres peuvent gérer les discussions et les commentaires.
     members_can_edit_discussions_help_v2: Autoriser les membres à modifier, déplacer, épingler, étiqueter ou fermer toute discussion ou tout commentaire dans le groupe
+    group_handle_hint_new: L'URL et l'adresse e-mail de votre groupe seront %{host}/%{handle} et %{handle}{'@'}%{host}
+    handle_changed_hint: Votre ancienne URL et votre adresse e-mail seront redirigées vers votre nouvelle adresse.
   group_export_modal:
     title: Exporter les données de votre groupe
     body: |

--- a/config/locales/client.fr.yml
+++ b/config/locales/client.fr.yml
@@ -1315,6 +1315,7 @@ fr:
     organization_name: Nom de l’organisation
     handle: Gérer
     group_handle_placeholder: 'Utilisé dans l''URL de votre groupe : %{host}/%{handle}'
+    handle_redirect_notice: 'If you change this handle, links using the old address will redirect here.'
     start_organization_heading: Nouveau groupe
     edit_organization_heading: Modifier les paramètres de l'organisation
     group_name_placeholder: Quel est le nom de votre groupe ?

--- a/config/locales/client.he.yml
+++ b/config/locales/client.he.yml
@@ -1292,6 +1292,7 @@ he:
     organization_name: שם ארגון
     handle: ידית
     group_handle_placeholder: 'בשימוש בכתובת האתר של הקבוצה שלך: %{host}/%{handle}'
+    handle_redirect_notice: 'If you change this handle, links using the old address will redirect here.'
     start_organization_heading: ארגון חדש
     edit_organization_heading: ערוך את הגדרות הארגון
     group_name_placeholder: מה שם הקבוצה שלך?

--- a/config/locales/client.he.yml
+++ b/config/locales/client.he.yml
@@ -1292,7 +1292,6 @@ he:
     organization_name: שם ארגון
     handle: ידית
     group_handle_placeholder: 'בשימוש בכתובת האתר של הקבוצה שלך: %{host}/%{handle}'
-    handle_redirect_notice: If you change this handle, links using the old address will redirect here.
     start_organization_heading: ארגון חדש
     edit_organization_heading: ערוך את הגדרות הארגון
     group_name_placeholder: מה שם הקבוצה שלך?

--- a/config/locales/client.he.yml
+++ b/config/locales/client.he.yml
@@ -1292,7 +1292,7 @@ he:
     organization_name: שם ארגון
     handle: ידית
     group_handle_placeholder: 'בשימוש בכתובת האתר של הקבוצה שלך: %{host}/%{handle}'
-    handle_redirect_notice: 'If you change this handle, links using the old address will redirect here.'
+    handle_redirect_notice: If you change this handle, links using the old address will redirect here.
     start_organization_heading: ארגון חדש
     edit_organization_heading: ערוך את הגדרות הארגון
     group_name_placeholder: מה שם הקבוצה שלך?
@@ -1383,6 +1383,8 @@ he:
     members_can_start_discussions_help_v2: לאפשר לחברים להתחיל דיונים חדשים בתוך הקבוצה
     members_can_edit_discussions_v2: חברים יכולים לנהל דיונים ותגובות
     members_can_edit_discussions_help_v2: אפשר לחברים לערוך, להעביר, להצמיד, לתייג או לסגור כל דיון או תגובה בקבוצה
+    group_handle_hint_new: כתובת ה-URL והאימייל של הקבוצה שלך יהיו %{host}/%{handle} ו-%{handle}{'@'}%{host}
+    handle_changed_hint: כתובת ה-URL וכתובת הדוא"ל הקודמים שלך יפנו לכתובת החדשה שלך.
   group_export_modal:
     title: יצוא נתונים מהקבוצה
     body: |

--- a/config/locales/client.hr.yml
+++ b/config/locales/client.hr.yml
@@ -1288,6 +1288,7 @@ hr:
     organization_name: Naziv organizacije
     handle: Ručka
     group_handle_placeholder: 'Koristi se u URL-u vaše grupe: %{host}/%{handle}'
+    handle_redirect_notice: 'If you change this handle, links using the old address will redirect here.'
     start_organization_heading: Nova organizacija
     edit_organization_heading: Uredite postavke organizacije
     group_name_placeholder: Kako se zove vaša grupa?

--- a/config/locales/client.hr.yml
+++ b/config/locales/client.hr.yml
@@ -1288,7 +1288,7 @@ hr:
     organization_name: Naziv organizacije
     handle: Ručka
     group_handle_placeholder: 'Koristi se u URL-u vaše grupe: %{host}/%{handle}'
-    handle_redirect_notice: 'If you change this handle, links using the old address will redirect here.'
+    handle_redirect_notice: If you change this handle, links using the old address will redirect here.
     start_organization_heading: Nova organizacija
     edit_organization_heading: Uredite postavke organizacije
     group_name_placeholder: Kako se zove vaša grupa?
@@ -1379,6 +1379,8 @@ hr:
     members_can_start_discussions_help_v2: Omogućite članovima da započnu nove rasprave unutar grupe
     members_can_edit_discussions_v2: Članovi mogu upravljati raspravama i komentarima
     members_can_edit_discussions_help_v2: Omogući članovima uređivanje, premještanje, prikvačivanje, označavanje ili zatvaranje bilo koje rasprave ili komentara u grupi
+    group_handle_hint_new: URL i e-adresa vaše grupe bit će %{host}/%{handle} i %{handle}{'@'}%{host}
+    handle_changed_hint: Vaš prethodni URL i adresa e-pošte preusmjeravat će vas na vašu novu adresu.
   group_export_modal:
     title: Izvoz grupnih podataka
     body: <p>U bilo kojem trenutku možete preuzeti kopiju podataka svoje grupe. <a href="https://help.loomio.org/en/user_manual/groups/data_export/">Saznaj više.</a></p><p> Za dovršetak je potrebno nekoliko minuta, ovisno o veličini vaše grupe. Kada bude spremna, primit ćete e-poruku s vezom za preuzimanje datoteke.</p>

--- a/config/locales/client.hr.yml
+++ b/config/locales/client.hr.yml
@@ -1288,7 +1288,6 @@ hr:
     organization_name: Naziv organizacije
     handle: Ručka
     group_handle_placeholder: 'Koristi se u URL-u vaše grupe: %{host}/%{handle}'
-    handle_redirect_notice: If you change this handle, links using the old address will redirect here.
     start_organization_heading: Nova organizacija
     edit_organization_heading: Uredite postavke organizacije
     group_name_placeholder: Kako se zove vaša grupa?

--- a/config/locales/client.hu.yml
+++ b/config/locales/client.hu.yml
@@ -1292,7 +1292,6 @@ hu:
     organization_name: Szervezet neve
     handle: Fogantyú
     group_handle_placeholder: 'A csoport URL-jében használva: %{host}/%{handle}'
-    handle_redirect_notice: If you change this handle, links using the old address will redirect here.
     start_organization_heading: Új szervezet
     edit_organization_heading: Szervezet beállításainak szerkesztése
     group_name_placeholder: Csoportod neve?

--- a/config/locales/client.hu.yml
+++ b/config/locales/client.hu.yml
@@ -1292,6 +1292,7 @@ hu:
     organization_name: Szervezet neve
     handle: Fogantyú
     group_handle_placeholder: 'A csoport URL-jében használva: %{host}/%{handle}'
+    handle_redirect_notice: 'If you change this handle, links using the old address will redirect here.'
     start_organization_heading: Új szervezet
     edit_organization_heading: Szervezet beállításainak szerkesztése
     group_name_placeholder: Csoportod neve?

--- a/config/locales/client.hu.yml
+++ b/config/locales/client.hu.yml
@@ -1292,7 +1292,7 @@ hu:
     organization_name: Szervezet neve
     handle: Fogantyú
     group_handle_placeholder: 'A csoport URL-jében használva: %{host}/%{handle}'
-    handle_redirect_notice: 'If you change this handle, links using the old address will redirect here.'
+    handle_redirect_notice: If you change this handle, links using the old address will redirect here.
     start_organization_heading: Új szervezet
     edit_organization_heading: Szervezet beállításainak szerkesztése
     group_name_placeholder: Csoportod neve?
@@ -1383,6 +1383,8 @@ hu:
     members_can_start_discussions_help_v2: Engedélyezd a tagok számára új beszélgetések indítását a csoporton belül
     members_can_edit_discussions_v2: A tagok kezelhetik a beszélgetéseket és a hozzászólásokat
     members_can_edit_discussions_help_v2: A tagok szerkeszthetik, áthelyezhetik, rögzíthetik, címkézhetik vagy lezárhatják a csoportban található beszélgetéseket vagy hozzászólásokat.
+    group_handle_hint_new: 'A csoportod URL-címe és e-mail címe a következő lesz: %{host}/%{handle} és %{handle}{''@''}%{host}'
+    handle_changed_hint: Az előző URL-címed és e-mail címed átirányít az új címedre.
   group_export_modal:
     title: Csoport adatok letöltése
     body: <p>A csoport adatainak másolatát bármikor letöltheti. <a href="https://help.loomio.org/en/user_manual/groups/data_export/">Tudj meg többet.</a></p><p> A kitöltése a csoport méretétől függően néhány percet vesz igénybe. Ha készen áll, e-mailben kap egy linket a fájl letöltéséhez.</p>

--- a/config/locales/client.it.yml
+++ b/config/locales/client.it.yml
@@ -1314,7 +1314,7 @@ it:
     organization_name: Nome organizzazione
     handle: Gestire
     group_handle_placeholder: 'Utilizzato nell''URL del tuo gruppo: %{host}/%{handle}'
-    handle_redirect_notice: 'If you change this handle, links using the old address will redirect here.'
+    handle_redirect_notice: If you change this handle, links using the old address will redirect here.
     start_organization_heading: Nuova organizzazione
     edit_organization_heading: Modificare le impostazioni dell'organizzazione
     group_name_placeholder: Qual'é il nome del tuo gruppo?
@@ -1405,6 +1405,8 @@ it:
     members_can_start_discussions_help_v2: Consenti ai membri di avviare nuove discussioni all'interno del gruppo
     members_can_edit_discussions_v2: I membri possono gestire discussioni e commenti
     members_can_edit_discussions_help_v2: Consenti ai membri di modificare, spostare, aggiungere, taggare o chiudere qualsiasi discussione o commento nel gruppo
+    group_handle_hint_new: L'URL e l'indirizzo email del tuo gruppo saranno %{host}/%{handle} e %{handle}{'@'}%{host}
+    handle_changed_hint: Il tuo precedente URL e indirizzo email verranno reindirizzati al nuovo indirizzo.
   group_export_modal:
     title: Esporta i dati del gruppo
     body: <p>Puoi scaricare una copia dei dati del tuo gruppo in qualsiasi momento. <a href="https://help.loomio.org/en/user_manual/groups/data_export/">Scopri di più.</a></p><p> Il completamento richiede alcuni minuti, a seconda delle dimensioni del gruppo. Quando sarà pronto riceverai un'e-mail con un link per scaricare il file.</p>

--- a/config/locales/client.it.yml
+++ b/config/locales/client.it.yml
@@ -1314,6 +1314,7 @@ it:
     organization_name: Nome organizzazione
     handle: Gestire
     group_handle_placeholder: 'Utilizzato nell''URL del tuo gruppo: %{host}/%{handle}'
+    handle_redirect_notice: 'If you change this handle, links using the old address will redirect here.'
     start_organization_heading: Nuova organizzazione
     edit_organization_heading: Modificare le impostazioni dell'organizzazione
     group_name_placeholder: Qual'é il nome del tuo gruppo?

--- a/config/locales/client.it.yml
+++ b/config/locales/client.it.yml
@@ -1314,7 +1314,6 @@ it:
     organization_name: Nome organizzazione
     handle: Gestire
     group_handle_placeholder: 'Utilizzato nell''URL del tuo gruppo: %{host}/%{handle}'
-    handle_redirect_notice: If you change this handle, links using the old address will redirect here.
     start_organization_heading: Nuova organizzazione
     edit_organization_heading: Modificare le impostazioni dell'organizzazione
     group_name_placeholder: Qual'é il nome del tuo gruppo?

--- a/config/locales/client.ja.yml
+++ b/config/locales/client.ja.yml
@@ -1287,7 +1287,6 @@ ja:
     organization_name: 組織名
     handle: ハンドル
     group_handle_placeholder: 'グループ URL で使用: %{host}/%{handle}'
-    handle_redirect_notice: If you change this handle, links using the old address will redirect here.
     start_organization_heading: 新組織
     edit_organization_heading: 組織設定の編集
     group_name_placeholder: あなたのグループの名前は何ですか？

--- a/config/locales/client.ja.yml
+++ b/config/locales/client.ja.yml
@@ -1287,7 +1287,7 @@ ja:
     organization_name: 組織名
     handle: ハンドル
     group_handle_placeholder: 'グループ URL で使用: %{host}/%{handle}'
-    handle_redirect_notice: 'If you change this handle, links using the old address will redirect here.'
+    handle_redirect_notice: If you change this handle, links using the old address will redirect here.
     start_organization_heading: 新組織
     edit_organization_heading: 組織設定の編集
     group_name_placeholder: あなたのグループの名前は何ですか？
@@ -1378,6 +1378,8 @@ ja:
     members_can_start_discussions_help_v2: メンバーがグループ内で新しいディスカッションを開始できるようにする
     members_can_edit_discussions_v2: メンバーはディスカッションやコメントを管理できる
     members_can_edit_discussions_help_v2: メンバーがグループ内のあらゆるディスカッションやコメントを編集、移動、ピン留め、タグ付け、または閉じることを許可します
+    group_handle_hint_new: グループのURLとメールアドレスは、それぞれ %{host}/%{handle} と %{handle}{'@'}%{host} になります。
+    handle_changed_hint: 以前ご利用いただいていたURLとメールアドレスは、新しいアドレスにリダイレクトされます。
   group_export_modal:
     title: グループデータのエクスポート
     body: <p>グループのデータのコピーはいつでもダウンロードできます。<a href="https://help.loomio.org/en/user_manual/groups/data_export/">もっと詳しく調べてください。</a></p><p>グループの規模に応じて、完了までに数分かかります。準備が完了すると、ファイルをダウンロードするためのリンクが記載された電子メールが届きます。</p>

--- a/config/locales/client.ja.yml
+++ b/config/locales/client.ja.yml
@@ -1287,6 +1287,7 @@ ja:
     organization_name: 組織名
     handle: ハンドル
     group_handle_placeholder: 'グループ URL で使用: %{host}/%{handle}'
+    handle_redirect_notice: 'If you change this handle, links using the old address will redirect here.'
     start_organization_heading: 新組織
     edit_organization_heading: 組織設定の編集
     group_name_placeholder: あなたのグループの名前は何ですか？

--- a/config/locales/client.nl_NL.yml
+++ b/config/locales/client.nl_NL.yml
@@ -1294,6 +1294,7 @@ nl_NL:
     organization_name: Organisatienaam
     handle: Gebruikersnaam
     group_handle_placeholder: 'Gebruikt in uw groeps-URL: %{host}/%{handle}'
+    handle_redirect_notice: 'If you change this handle, links using the old address will redirect here.'
     start_organization_heading: Nieuwe organisatie
     edit_organization_heading: Bewerk organisatie instellingen
     group_name_placeholder: Wat is de naam van je groep?

--- a/config/locales/client.nl_NL.yml
+++ b/config/locales/client.nl_NL.yml
@@ -1294,7 +1294,7 @@ nl_NL:
     organization_name: Organisatienaam
     handle: Gebruikersnaam
     group_handle_placeholder: 'Gebruikt in uw groeps-URL: %{host}/%{handle}'
-    handle_redirect_notice: 'If you change this handle, links using the old address will redirect here.'
+    handle_redirect_notice: If you change this handle, links using the old address will redirect here.
     start_organization_heading: Nieuwe organisatie
     edit_organization_heading: Bewerk organisatie instellingen
     group_name_placeholder: Wat is de naam van je groep?
@@ -1385,6 +1385,8 @@ nl_NL:
     members_can_start_discussions_help_v2: Sta leden toe om nieuwe discussies binnen de groep te starten.
     members_can_edit_discussions_v2: Leden kunnen discussies en reacties beheren.
     members_can_edit_discussions_help_v2: Geef leden de mogelijkheid om discussies en reacties in de groep te bewerken, verplaatsen, vastzetten, taggen of sluiten.
+    group_handle_hint_new: De URL en het e-mailadres van uw groep zijn %{host}/%{handle} en %{handle}{'@'}%{host}.
+    handle_changed_hint: Je vorige URL en e-mailadres worden doorverwezen naar je nieuwe adres.
   group_export_modal:
     title: Groepsdata exporteren
     body: |

--- a/config/locales/client.nl_NL.yml
+++ b/config/locales/client.nl_NL.yml
@@ -1294,7 +1294,6 @@ nl_NL:
     organization_name: Organisatienaam
     handle: Gebruikersnaam
     group_handle_placeholder: 'Gebruikt in uw groeps-URL: %{host}/%{handle}'
-    handle_redirect_notice: If you change this handle, links using the old address will redirect here.
     start_organization_heading: Nieuwe organisatie
     edit_organization_heading: Bewerk organisatie instellingen
     group_name_placeholder: Wat is de naam van je groep?

--- a/config/locales/client.pl.yml
+++ b/config/locales/client.pl.yml
@@ -1294,7 +1294,7 @@ pl:
     organization_name: Nazwa organizacji
     handle: Adres
     group_handle_placeholder: 'Używany w adresie URL Twojej grupy: %{host}/%{handle}'
-    handle_redirect_notice: 'If you change this handle, links using the old address will redirect here.'
+    handle_redirect_notice: If you change this handle, links using the old address will redirect here.
     start_organization_heading: Nowa grupa
     edit_organization_heading: Edytuj ustawienia organizacji
     group_name_placeholder: " Jak nazywa się Twoja grupa?"
@@ -1385,6 +1385,8 @@ pl:
     members_can_start_discussions_help_v2: Zezwól członkom na rozpoczynanie nowych dyskusji w grupie
     members_can_edit_discussions_v2: Członkowie mogą zarządzać dyskusjami i komentarzami
     members_can_edit_discussions_help_v2: Zezwalaj członkom na edytowanie, przenoszenie, przypinanie, oznaczanie lub zamykanie dowolnej dyskusji lub komentarza w grupie
+    group_handle_hint_new: 'Adres URL i adres e-mail Twojej grupy będą następujące: %{host}/%{handle} i %{handle}{''@''}%{host}'
+    handle_changed_hint: Twój poprzedni adres URL i adres e-mail będą przekierowywać na nowy adres.
   group_export_modal:
     title: Eksportuj dane grupy
     body: |

--- a/config/locales/client.pl.yml
+++ b/config/locales/client.pl.yml
@@ -1294,7 +1294,6 @@ pl:
     organization_name: Nazwa organizacji
     handle: Adres
     group_handle_placeholder: 'Używany w adresie URL Twojej grupy: %{host}/%{handle}'
-    handle_redirect_notice: If you change this handle, links using the old address will redirect here.
     start_organization_heading: Nowa grupa
     edit_organization_heading: Edytuj ustawienia organizacji
     group_name_placeholder: " Jak nazywa się Twoja grupa?"

--- a/config/locales/client.pl.yml
+++ b/config/locales/client.pl.yml
@@ -1294,6 +1294,7 @@ pl:
     organization_name: Nazwa organizacji
     handle: Adres
     group_handle_placeholder: 'Używany w adresie URL Twojej grupy: %{host}/%{handle}'
+    handle_redirect_notice: 'If you change this handle, links using the old address will redirect here.'
     start_organization_heading: Nowa grupa
     edit_organization_heading: Edytuj ustawienia organizacji
     group_name_placeholder: " Jak nazywa się Twoja grupa?"

--- a/config/locales/client.pt_BR.yml
+++ b/config/locales/client.pt_BR.yml
@@ -1315,7 +1315,7 @@ pt_BR:
     organization_name: Nome da organização
     handle: Sigla da organização
     group_handle_placeholder: 'Usado no URL do seu grupo: %{host}/%{handle}'
-    handle_redirect_notice: 'If you change this handle, links using the old address will redirect here.'
+    handle_redirect_notice: If you change this handle, links using the old address will redirect here.
     start_organization_heading: Nova organização
     edit_organization_heading: Editar configurações da organização
     group_name_placeholder: Qual é o nome do seu grupo?
@@ -1406,6 +1406,8 @@ pt_BR:
     members_can_start_discussions_help_v2: Permitir que os membros iniciem novas discussões dentro do grupo.
     members_can_edit_discussions_v2: Os membros podem gerenciar discussões e comentários.
     members_can_edit_discussions_help_v2: Permitir que os membros editem, movam, fixem, marquem ou fechem qualquer discussão ou comentário no grupo.
+    group_handle_hint_new: O URL e o e-mail do seu grupo serão %{host}/%{handle} e %{handle}{'@'}%{host}
+    handle_changed_hint: Seu endereço de URL e e-mail anteriores serão redirecionados para seu novo endereço.
   group_export_modal:
     title: Exportar data do grupo
     body: |

--- a/config/locales/client.pt_BR.yml
+++ b/config/locales/client.pt_BR.yml
@@ -1315,6 +1315,7 @@ pt_BR:
     organization_name: Nome da organização
     handle: Sigla da organização
     group_handle_placeholder: 'Usado no URL do seu grupo: %{host}/%{handle}'
+    handle_redirect_notice: 'If you change this handle, links using the old address will redirect here.'
     start_organization_heading: Nova organização
     edit_organization_heading: Editar configurações da organização
     group_name_placeholder: Qual é o nome do seu grupo?

--- a/config/locales/client.pt_BR.yml
+++ b/config/locales/client.pt_BR.yml
@@ -1315,7 +1315,6 @@ pt_BR:
     organization_name: Nome da organização
     handle: Sigla da organização
     group_handle_placeholder: 'Usado no URL do seu grupo: %{host}/%{handle}'
-    handle_redirect_notice: If you change this handle, links using the old address will redirect here.
     start_organization_heading: Nova organização
     edit_organization_heading: Editar configurações da organização
     group_name_placeholder: Qual é o nome do seu grupo?

--- a/config/locales/client.ro.yml
+++ b/config/locales/client.ro.yml
@@ -1288,7 +1288,6 @@ ro:
     organization_name: Numele Organizatiei
     handle: Mâner
     group_handle_placeholder: 'Folosit în adresa URL a grupului dvs.: %{host}/%{handle}'
-    handle_redirect_notice: If you change this handle, links using the old address will redirect here.
     start_organization_heading: Noua organizare
     edit_organization_heading: Editați setările organizației
     group_name_placeholder: Cum se va numi grupul tău?

--- a/config/locales/client.ro.yml
+++ b/config/locales/client.ro.yml
@@ -1288,6 +1288,7 @@ ro:
     organization_name: Numele Organizatiei
     handle: Mâner
     group_handle_placeholder: 'Folosit în adresa URL a grupului dvs.: %{host}/%{handle}'
+    handle_redirect_notice: 'If you change this handle, links using the old address will redirect here.'
     start_organization_heading: Noua organizare
     edit_organization_heading: Editați setările organizației
     group_name_placeholder: Cum se va numi grupul tău?

--- a/config/locales/client.ro.yml
+++ b/config/locales/client.ro.yml
@@ -1288,7 +1288,7 @@ ro:
     organization_name: Numele Organizatiei
     handle: Mâner
     group_handle_placeholder: 'Folosit în adresa URL a grupului dvs.: %{host}/%{handle}'
-    handle_redirect_notice: 'If you change this handle, links using the old address will redirect here.'
+    handle_redirect_notice: If you change this handle, links using the old address will redirect here.
     start_organization_heading: Noua organizare
     edit_organization_heading: Editați setările organizației
     group_name_placeholder: Cum se va numi grupul tău?
@@ -1379,6 +1379,8 @@ ro:
     members_can_start_discussions_help_v2: Permiteți membrilor să înceapă discuții noi în cadrul grupului
     members_can_edit_discussions_v2: Membrii pot gestiona discuțiile și comentariile
     members_can_edit_discussions_help_v2: Permiteți membrilor să editeze, să mute, să fixeze, să eticheteze sau să închidă orice discuție sau comentariu din grup
+    group_handle_hint_new: Adresa URL și adresa de e-mail a grupului dvs. vor fi %{host}/%{handle} și %{handle}{'@'}%{host}
+    handle_changed_hint: Adresa URL și adresa de e-mail anterioare vor redirecționa către noua adresă.
   group_export_modal:
     title: Exportați datele grupului
     body: <p>Puteți descărca oricând o copie a datelor grupului dvs. <a href="https://help.loomio.org/en/user_manual/groups/data_export/">Află mai multe.</a></p><p> Este nevoie de câteva minute pentru a finaliza, în funcție de dimensiunea grupului dvs. Când este gata, veți primi un e-mail cu un link pentru a descărca fișierul.</p>

--- a/config/locales/client.ru.yml
+++ b/config/locales/client.ru.yml
@@ -1288,6 +1288,7 @@ ru:
     organization_name: Название организации
     handle: Ручка
     group_handle_placeholder: 'Используется в URL-адресе вашей группы: %{host}/%{handle}.'
+    handle_redirect_notice: 'If you change this handle, links using the old address will redirect here.'
     start_organization_heading: Новая организация
     edit_organization_heading: Изменить настройки организации
     group_name_placeholder: Как называется ваша группа?

--- a/config/locales/client.ru.yml
+++ b/config/locales/client.ru.yml
@@ -1288,7 +1288,6 @@ ru:
     organization_name: Название организации
     handle: Ручка
     group_handle_placeholder: 'Используется в URL-адресе вашей группы: %{host}/%{handle}.'
-    handle_redirect_notice: If you change this handle, links using the old address will redirect here.
     start_organization_heading: Новая организация
     edit_organization_heading: Изменить настройки организации
     group_name_placeholder: Как называется ваша группа?

--- a/config/locales/client.ru.yml
+++ b/config/locales/client.ru.yml
@@ -1288,7 +1288,7 @@ ru:
     organization_name: Название организации
     handle: Ручка
     group_handle_placeholder: 'Используется в URL-адресе вашей группы: %{host}/%{handle}.'
-    handle_redirect_notice: 'If you change this handle, links using the old address will redirect here.'
+    handle_redirect_notice: If you change this handle, links using the old address will redirect here.
     start_organization_heading: Новая организация
     edit_organization_heading: Изменить настройки организации
     group_name_placeholder: Как называется ваша группа?
@@ -1379,6 +1379,8 @@ ru:
     members_can_start_discussions_help_v2: Разрешите участникам начинать новые дискуссии внутри группы.
     members_can_edit_discussions_v2: Участники могут управлять обсуждениями и комментариями.
     members_can_edit_discussions_help_v2: Разрешите участникам редактировать, перемещать, закреплять, помечать тегами или закрывать любые обсуждения или комментарии в группе.
+    group_handle_hint_new: 'URL вашей группы и адрес электронной почты будут выглядеть так: %{host}/%{handle} и %{handle}{''@''}%{host}'
+    handle_changed_hint: Ваш прежний URL-адрес и адрес электронной почты будут перенаправлены на ваш новый адрес.
   group_export_modal:
     title: Экспортировать данные группы
     body: <p>Вы можете загрузить копию данных вашей группы в любое время. <a href="https://help.loomio.org/en/user_manual/groups/data_export/">Узнать больше.</a></p><p> Это займет несколько минут, в зависимости от размера вашей группы. Когда он будет готов, вы получите электронное письмо со ссылкой для загрузки файла.</p>

--- a/config/locales/client.sl.yml
+++ b/config/locales/client.sl.yml
@@ -1288,6 +1288,7 @@ sl:
     organization_name: Ime organizacije
     handle: Ročaj
     group_handle_placeholder: 'Uporabljeno v URL-ju vaše skupine: %{host}/%{handle}'
+    handle_redirect_notice: 'If you change this handle, links using the old address will redirect here.'
     start_organization_heading: Nova organizacija
     edit_organization_heading: Uredite nastavitve organizacije
     group_name_placeholder: Kako se imenuje tvoja skupina?

--- a/config/locales/client.sl.yml
+++ b/config/locales/client.sl.yml
@@ -1288,7 +1288,6 @@ sl:
     organization_name: Ime organizacije
     handle: Ročaj
     group_handle_placeholder: 'Uporabljeno v URL-ju vaše skupine: %{host}/%{handle}'
-    handle_redirect_notice: If you change this handle, links using the old address will redirect here.
     start_organization_heading: Nova organizacija
     edit_organization_heading: Uredite nastavitve organizacije
     group_name_placeholder: Kako se imenuje tvoja skupina?

--- a/config/locales/client.sl.yml
+++ b/config/locales/client.sl.yml
@@ -1288,7 +1288,7 @@ sl:
     organization_name: Ime organizacije
     handle: Ročaj
     group_handle_placeholder: 'Uporabljeno v URL-ju vaše skupine: %{host}/%{handle}'
-    handle_redirect_notice: 'If you change this handle, links using the old address will redirect here.'
+    handle_redirect_notice: If you change this handle, links using the old address will redirect here.
     start_organization_heading: Nova organizacija
     edit_organization_heading: Uredite nastavitve organizacije
     group_name_placeholder: Kako se imenuje tvoja skupina?
@@ -1379,6 +1379,8 @@ sl:
     members_can_start_discussions_help_v2: Dovoli članom, da začnejo nove razprave znotraj skupine
     members_can_edit_discussions_v2: Člani lahko upravljajo razprave in komentarje
     members_can_edit_discussions_help_v2: Dovoli članom urejanje, premikanje, pripenjanje, označevanje ali zapiranje katere koli razprave ali komentarja v skupini
+    group_handle_hint_new: URL in e-poštni naslov vaše skupine bosta %{host}/%{handle} in %{handle}{'@'}%{host}
+    handle_changed_hint: Vaš prejšnji URL in e-poštni naslov bosta preusmerila na vaš novi naslov.
   group_export_modal:
     title: Izvoz podatkov skupine
     body: <p>Kopijo podatkov svoje skupine lahko prenesete kadar koli. <a href="https://help.loomio.org/en/user_manual/groups/data_export/">Izvedi več.</a></p><p> Izpolnitev traja nekaj minut, odvisno od velikosti vaše skupine. Ko bo pripravljena, boste prejeli e-poštno sporočilo s povezavo za prenos datoteke.</p>

--- a/config/locales/client.sv.yml
+++ b/config/locales/client.sv.yml
@@ -1288,6 +1288,7 @@ sv:
     organization_name: Organisations namn
     handle: Hantera
     group_handle_placeholder: 'Används i din grupp-URL: %{host}/%{handle}'
+    handle_redirect_notice: 'If you change this handle, links using the old address will redirect here.'
     start_organization_heading: Ny organisation
     edit_organization_heading: Redigera organisationsinställningar
     group_name_placeholder: Vad heter din grupp?

--- a/config/locales/client.sv.yml
+++ b/config/locales/client.sv.yml
@@ -1288,7 +1288,6 @@ sv:
     organization_name: Organisations namn
     handle: Hantera
     group_handle_placeholder: 'Används i din grupp-URL: %{host}/%{handle}'
-    handle_redirect_notice: If you change this handle, links using the old address will redirect here.
     start_organization_heading: Ny organisation
     edit_organization_heading: Redigera organisationsinställningar
     group_name_placeholder: Vad heter din grupp?

--- a/config/locales/client.sv.yml
+++ b/config/locales/client.sv.yml
@@ -1288,7 +1288,7 @@ sv:
     organization_name: Organisations namn
     handle: Hantera
     group_handle_placeholder: 'Används i din grupp-URL: %{host}/%{handle}'
-    handle_redirect_notice: 'If you change this handle, links using the old address will redirect here.'
+    handle_redirect_notice: If you change this handle, links using the old address will redirect here.
     start_organization_heading: Ny organisation
     edit_organization_heading: Redigera organisationsinställningar
     group_name_placeholder: Vad heter din grupp?
@@ -1379,6 +1379,8 @@ sv:
     members_can_start_discussions_help_v2: Tillåt medlemmar att starta nya diskussioner inom gruppen
     members_can_edit_discussions_v2: Medlemmar kan hantera diskussioner och kommentarer
     members_can_edit_discussions_help_v2: Tillåt medlemmar att redigera, flytta, fästa, tagga eller stänga diskussioner eller kommentarer i gruppen
+    group_handle_hint_new: Din grupp-URL och e-postadress kommer att vara %{host}/%{handle} och %{handle}{'@'}%{host}
+    handle_changed_hint: Din tidigare URL och e-postadress kommer att omdirigera till din nya adress.
   group_export_modal:
     title: Exportera gruppdata
     body: <p>Du kan ladda ner en kopia av din grupps data när som helst. <a href="https://help.loomio.org/en/user_manual/groups/data_export/">Få reda på mer.</a></p><p> Det tar några minuter att slutföra, beroende på storleken på din grupp. När den är klar får du ett e-postmeddelande med en länk för att ladda ner filen.</p>

--- a/config/locales/client.tr.yml
+++ b/config/locales/client.tr.yml
@@ -1288,7 +1288,6 @@ tr:
     organization_name: Kuruluş Adı
     handle: Halletmek
     group_handle_placeholder: 'Grup URL''nizde kullanılır: %{host}/%{handle}'
-    handle_redirect_notice: If you change this handle, links using the old address will redirect here.
     start_organization_heading: Yeni organizasyon
     edit_organization_heading: Kuruluş ayarlarını düzenleyin
     group_name_placeholder: Grup isminizin adı nedir?

--- a/config/locales/client.tr.yml
+++ b/config/locales/client.tr.yml
@@ -1288,7 +1288,7 @@ tr:
     organization_name: Kuruluş Adı
     handle: Halletmek
     group_handle_placeholder: 'Grup URL''nizde kullanılır: %{host}/%{handle}'
-    handle_redirect_notice: 'If you change this handle, links using the old address will redirect here.'
+    handle_redirect_notice: If you change this handle, links using the old address will redirect here.
     start_organization_heading: Yeni organizasyon
     edit_organization_heading: Kuruluş ayarlarını düzenleyin
     group_name_placeholder: Grup isminizin adı nedir?
@@ -1379,6 +1379,8 @@ tr:
     members_can_start_discussions_help_v2: Üyelerin grup içinde yeni tartışmalar başlatmasına izin verin.
     members_can_edit_discussions_v2: Üyeler tartışmaları ve yorumları yönetebilirler.
     members_can_edit_discussions_help_v2: Gruptaki üyelerin herhangi bir tartışmayı veya yorumu düzenlemesine, taşımasına, sabitlemesine, etiketlemesine veya kapatmasına izin verin.
+    group_handle_hint_new: Grup URL'niz ve e-posta adresiniz %{host}/%{handle} ve %{handle}{'@'}%{host} olacaktır.
+    handle_changed_hint: Önceki URL'niz ve e-posta adresiniz yeni adresinize yönlendirilecektir.
   group_export_modal:
     title: Grup verilerini dışa aktar
     body: <p>Grubunuzun verilerinin bir kopyasını istediğiniz zaman indirebilirsiniz. <a href="https://help.loomio.org/en/user_manual/groups/data_export/">Daha fazlasını bul.</a></p><p> Grubunuzun büyüklüğüne bağlı olarak tamamlanması birkaç dakika sürer. Hazır olduğunda dosyayı indirme bağlantısını içeren bir e-posta alacaksınız.</p>

--- a/config/locales/client.tr.yml
+++ b/config/locales/client.tr.yml
@@ -1288,6 +1288,7 @@ tr:
     organization_name: Kuruluş Adı
     handle: Halletmek
     group_handle_placeholder: 'Grup URL''nizde kullanılır: %{host}/%{handle}'
+    handle_redirect_notice: 'If you change this handle, links using the old address will redirect here.'
     start_organization_heading: Yeni organizasyon
     edit_organization_heading: Kuruluş ayarlarını düzenleyin
     group_name_placeholder: Grup isminizin adı nedir?

--- a/config/locales/client.uk.yml
+++ b/config/locales/client.uk.yml
@@ -1297,7 +1297,7 @@ uk:
     organization_name: Назва організації
     handle: Регулювання
     group_handle_placeholder: 'Використовується в URL-адресі вашої групи: %{host}/%{handle}'
-    handle_redirect_notice: 'If you change this handle, links using the old address will redirect here.'
+    handle_redirect_notice: If you change this handle, links using the old address will redirect here.
     start_organization_heading: Нова організація
     edit_organization_heading: Редагувати налаштування організації
     group_name_placeholder: Яка назва у вашої групи?
@@ -1388,6 +1388,8 @@ uk:
     members_can_start_discussions_help_v2: Дозволити учасникам розпочинати нові обговорення в групі
     members_can_edit_discussions_v2: Учасники можуть керувати обговореннями та коментарями
     members_can_edit_discussions_help_v2: Дозволити учасникам редагувати, переміщувати, закріплювати, позначати тегами або закривати будь-яке обговорення чи коментар у групі
+    group_handle_hint_new: URL-адреса та електронна адреса вашої групи будуть %{host}/%{handle} та %{handle}{'@'}%{host}
+    handle_changed_hint: Ваша попередня URL-адреса та адреса електронної пошти перенаправлятимуть на вашу нову адресу.
   group_export_modal:
     title: Експортувати дані групи
     body: |

--- a/config/locales/client.uk.yml
+++ b/config/locales/client.uk.yml
@@ -1297,7 +1297,6 @@ uk:
     organization_name: Назва організації
     handle: Регулювання
     group_handle_placeholder: 'Використовується в URL-адресі вашої групи: %{host}/%{handle}'
-    handle_redirect_notice: If you change this handle, links using the old address will redirect here.
     start_organization_heading: Нова організація
     edit_organization_heading: Редагувати налаштування організації
     group_name_placeholder: Яка назва у вашої групи?

--- a/config/locales/client.uk.yml
+++ b/config/locales/client.uk.yml
@@ -1297,6 +1297,7 @@ uk:
     organization_name: Назва організації
     handle: Регулювання
     group_handle_placeholder: 'Використовується в URL-адресі вашої групи: %{host}/%{handle}'
+    handle_redirect_notice: 'If you change this handle, links using the old address will redirect here.'
     start_organization_heading: Нова організація
     edit_organization_heading: Редагувати налаштування організації
     group_name_placeholder: Яка назва у вашої групи?

--- a/config/locales/client.zh_CN.yml
+++ b/config/locales/client.zh_CN.yml
@@ -1354,7 +1354,6 @@ zh_CN:
     organization_name: 组织名称
     handle: 处理
     group_handle_placeholder: 您的群组网址和邮箱地址：%{host}/%{handle}, %{handle}{'@'}%{host}
-    handle_redirect_notice: If you change this handle, links using the old address will redirect here.
     start_organization_heading: 新组织
     edit_organization_heading: 编辑组织设置
     group_name_placeholder: 你们子群组叫什么名字？

--- a/config/locales/client.zh_CN.yml
+++ b/config/locales/client.zh_CN.yml
@@ -1354,7 +1354,7 @@ zh_CN:
     organization_name: 组织名称
     handle: 处理
     group_handle_placeholder: 您的群组网址和邮箱地址：%{host}/%{handle}, %{handle}{'@'}%{host}
-    handle_redirect_notice: 'If you change this handle, links using the old address will redirect here.'
+    handle_redirect_notice: If you change this handle, links using the old address will redirect here.
     start_organization_heading: 新组织
     edit_organization_heading: 编辑组织设置
     group_name_placeholder: 你们子群组叫什么名字？
@@ -1440,6 +1440,8 @@ zh_CN:
     members_can_start_discussions_help_v2: 允许成员在群组内发起新的讨论。
     members_can_edit_discussions_v2: 成员可以管理讨论和评论
     members_can_edit_discussions_help_v2: 允许成员编辑、移动、置顶、标记或关闭群组中的任何讨论或评论。
+    group_handle_hint_new: 您的群组网址和电子邮件地址将分别为 %{host}/%{handle} 和 %{handle}{'@'}%{host}
+    handle_changed_hint: 您之前的网址和电子邮件地址将重定向到您的新地址。
   group_export_modal:
     title: 导出组数据
     body: <p>您可以随时下载您所在子群组的数据副本。<a href="https://help.loomio.org/en/user_manual/groups/data_export/">了解更多信息。</a></p><p>根据子群组人数，完成此操作大约需要几分钟。完成后，您将收到一封包含文件下载链接的电子邮件。</p>

--- a/config/locales/client.zh_CN.yml
+++ b/config/locales/client.zh_CN.yml
@@ -1354,6 +1354,7 @@ zh_CN:
     organization_name: 组织名称
     handle: 处理
     group_handle_placeholder: 您的群组网址和邮箱地址：%{host}/%{handle}, %{handle}{'@'}%{host}
+    handle_redirect_notice: 'If you change this handle, links using the old address will redirect here.'
     start_organization_heading: 新组织
     edit_organization_heading: 编辑组织设置
     group_name_placeholder: 你们子群组叫什么名字？

--- a/config/locales/client.zh_TW.yml
+++ b/config/locales/client.zh_TW.yml
@@ -1373,7 +1373,6 @@ zh_TW:
     default_request_to_join_prompt: 感謝您對我們小組的興趣。請自我介紹並解釋為什麼您要求加入。
     upgrade_for_subgroups: '請<a class="text-decoration-underline" style="color: inherit" href="/upgrade" target="_blank">升級您的訂閱</a>以建立子群組'
     group_handle_placeholder: 您的群組網址與電子郵件：%{host}/%{handle}、%{handle}{'@'}%{host}
-    handle_redirect_notice: If you change this handle, links using the old address will redirect here.
     share_this_url_with_people_who_want_to_join: 與想要加入的人分享此 URL
     aria_label: 小組形式
     list_in_the_groups_directory: 是否已列入群組目錄？

--- a/config/locales/client.zh_TW.yml
+++ b/config/locales/client.zh_TW.yml
@@ -1373,7 +1373,7 @@ zh_TW:
     default_request_to_join_prompt: 感謝您對我們小組的興趣。請自我介紹並解釋為什麼您要求加入。
     upgrade_for_subgroups: '請<a class="text-decoration-underline" style="color: inherit" href="/upgrade" target="_blank">升級您的訂閱</a>以建立子群組'
     group_handle_placeholder: 您的群組網址與電子郵件：%{host}/%{handle}、%{handle}{'@'}%{host}
-    handle_redirect_notice: 'If you change this handle, links using the old address will redirect here.'
+    handle_redirect_notice: If you change this handle, links using the old address will redirect here.
     share_this_url_with_people_who_want_to_join: 與想要加入的人分享此 URL
     aria_label: 小組形式
     list_in_the_groups_directory: 是否已列入群組目錄？
@@ -1388,6 +1388,8 @@ zh_TW:
     members_can_start_discussions_help_v2: 允許成員在群組內發起新的討論。
     members_can_edit_discussions_v2: 會員可以管理討論和評論
     members_can_edit_discussions_help_v2: 允許成員編輯、移動、置頂、標記或關閉群組中的任何討論或評論。
+    group_handle_hint_new: 您的群組網址和電子郵件位址將分別為 %{host}/%{handle} 和 %{handle}{'@'}%{host}
+    handle_changed_hint: 您先前的網址和電子郵件地址將會重新導向到您的新地址。
   group_export_modal:
     title: 匯出群組資料
     body: |

--- a/config/locales/client.zh_TW.yml
+++ b/config/locales/client.zh_TW.yml
@@ -1373,6 +1373,7 @@ zh_TW:
     default_request_to_join_prompt: 感謝您對我們小組的興趣。請自我介紹並解釋為什麼您要求加入。
     upgrade_for_subgroups: '請<a class="text-decoration-underline" style="color: inherit" href="/upgrade" target="_blank">升級您的訂閱</a>以建立子群組'
     group_handle_placeholder: 您的群組網址與電子郵件：%{host}/%{handle}、%{handle}{'@'}%{host}
+    handle_redirect_notice: 'If you change this handle, links using the old address will redirect here.'
     share_this_url_with_people_who_want_to_join: 與想要加入的人分享此 URL
     aria_label: 小組形式
     list_in_the_groups_directory: 是否已列入群組目錄？

--- a/config/locales/server.ca.yml
+++ b/config/locales/server.ca.yml
@@ -153,7 +153,7 @@ ca:
     error:
       handle_must_begin_with_parent_handle: Ha de començar per %{parent_handle}-
       no_public_trials: Si us plau, actualitzeu la versió de prova per canviar la configuració de privadesa del grup
-      handle_must_be_url_friendly: Feu servir només lletres minúscules (az), números (0-9) i guions (-)
+      handle_must_be_url_friendly: Feu servir només lletres minúscules (a-z), números (0-9) i guions (-)
     stats:
       group_stats: Estadístiques del grup
       org_stats: Estadístiques de l'organització (inclosos subgrups)

--- a/config/locales/server.ca.yml
+++ b/config/locales/server.ca.yml
@@ -153,6 +153,7 @@ ca:
     error:
       handle_must_begin_with_parent_handle: Ha de començar per %{parent_handle}-
       no_public_trials: Si us plau, actualitzeu la versió de prova per canviar la configuració de privadesa del grup
+      handle_must_be_url_friendly: Feu servir només lletres minúscules (az), números (0-9) i guions (-)
     stats:
       group_stats: Estadístiques del grup
       org_stats: Estadístiques de l'organització (inclosos subgrups)

--- a/config/locales/server.da.yml
+++ b/config/locales/server.da.yml
@@ -153,6 +153,7 @@ da:
     error:
       handle_must_begin_with_parent_handle: Skal begynde med %{parent_handle}-
       no_public_trials: Opgrader venligst fra prøveversion for at ændre gruppebeskyttelsesindstillingen
+      handle_must_be_url_friendly: Brug kun små bogstaver (az), tal (0-9) og bindestreger (-)
     stats:
       group_stats: Gruppestatistik
       org_stats: Organisationsstatistik (inklusive undergrupper)

--- a/config/locales/server.da.yml
+++ b/config/locales/server.da.yml
@@ -153,7 +153,7 @@ da:
     error:
       handle_must_begin_with_parent_handle: Skal begynde med %{parent_handle}-
       no_public_trials: Opgrader venligst fra prøveversion for at ændre gruppebeskyttelsesindstillingen
-      handle_must_be_url_friendly: Brug kun små bogstaver (az), tal (0-9) og bindestreger (-)
+      handle_must_be_url_friendly: Brug kun små bogstaver (a-z), tal (0-9) og bindestreger (-)
     stats:
       group_stats: Gruppestatistik
       org_stats: Organisationsstatistik (inklusive undergrupper)

--- a/config/locales/server.de.yml
+++ b/config/locales/server.de.yml
@@ -156,7 +156,7 @@ de:
     error:
       handle_must_begin_with_parent_handle: Muss beginnen mit %{parent_handle}-
       no_public_trials: Bitte führe ein Upgrade von der Testversion durch, um die Datenschutzeinstellung der Gruppe zu ändern
-      handle_must_be_url_friendly: Verwenden Sie nur Kleinbuchstaben (az), Zahlen (0-9) und Bindestriche (-).
+      handle_must_be_url_friendly: Verwenden Sie nur Kleinbuchstaben (a-z), Zahlen (0-9) und Bindestriche (-).
     stats:
       group_stats: Gruppen-Statistik
       org_stats: Organisationsstatistiken (einschließlich Untergruppen)

--- a/config/locales/server.de.yml
+++ b/config/locales/server.de.yml
@@ -156,6 +156,7 @@ de:
     error:
       handle_must_begin_with_parent_handle: Muss beginnen mit %{parent_handle}-
       no_public_trials: Bitte führe ein Upgrade von der Testversion durch, um die Datenschutzeinstellung der Gruppe zu ändern
+      handle_must_be_url_friendly: Verwenden Sie nur Kleinbuchstaben (az), Zahlen (0-9) und Bindestriche (-).
     stats:
       group_stats: Gruppen-Statistik
       org_stats: Organisationsstatistiken (einschließlich Untergruppen)

--- a/config/locales/server.el.yml
+++ b/config/locales/server.el.yml
@@ -153,6 +153,7 @@ el:
     error:
       handle_must_begin_with_parent_handle: Πρέπει να ξεκινά με %{parent_handle}-
       no_public_trials: Κάντε αναβάθμιση από τη δοκιμή για να αλλάξετε τη ρύθμιση απορρήτου της ομάδας
+      handle_must_be_url_friendly: Χρησιμοποιήστε μόνο πεζά γράμματα (az), αριθμούς (0-9) και παύλες (-)
     stats:
       group_stats: Στατιστικά ομάδας
       org_stats: Στατιστικά οργανισμού (συμπεριλαμβανομένων των υποομάδων)

--- a/config/locales/server.el.yml
+++ b/config/locales/server.el.yml
@@ -153,7 +153,7 @@ el:
     error:
       handle_must_begin_with_parent_handle: Πρέπει να ξεκινά με %{parent_handle}-
       no_public_trials: Κάντε αναβάθμιση από τη δοκιμή για να αλλάξετε τη ρύθμιση απορρήτου της ομάδας
-      handle_must_be_url_friendly: Χρησιμοποιήστε μόνο πεζά γράμματα (az), αριθμούς (0-9) και παύλες (-)
+      handle_must_be_url_friendly: Χρησιμοποιήστε μόνο πεζά γράμματα (a-z), αριθμούς (0-9) και παύλες (-)
     stats:
       group_stats: Στατιστικά ομάδας
       org_stats: Στατιστικά οργανισμού (συμπεριλαμβανομένων των υποομάδων)

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -420,6 +420,7 @@ en:
   group:
     error:
       handle_must_begin_with_parent_handle: Must begin with %{parent_handle}-
+      handle_must_be_url_friendly: Use only lowercase letters (a-z), numbers (0-9) and hyphens (-)
       no_public_trials: Please upgrade from trial to change the group privacy setting
     stats:
       group_stats: Group stats

--- a/config/locales/server.es.yml
+++ b/config/locales/server.es.yml
@@ -152,7 +152,7 @@ es:
     error:
       handle_must_begin_with_parent_handle: Debe comenzar con %{parent_handle}-
       no_public_trials: Por favor actualizar desde el periodo de prueba para cambiar los ajustes de privacidad del grupo
-      handle_must_be_url_friendly: Utilice únicamente letras minúsculas (az), números (0-9) y guiones (-).
+      handle_must_be_url_friendly: Utilice únicamente letras minúsculas (a-z), números (0-9) y guiones (-).
     stats:
       group_stats: Estadísticas de grupo
       org_stats: Estadísticas de la organización (incluyendo subgrupos)

--- a/config/locales/server.es.yml
+++ b/config/locales/server.es.yml
@@ -152,6 +152,7 @@ es:
     error:
       handle_must_begin_with_parent_handle: Debe comenzar con %{parent_handle}-
       no_public_trials: Por favor actualizar desde el periodo de prueba para cambiar los ajustes de privacidad del grupo
+      handle_must_be_url_friendly: Utilice únicamente letras minúsculas (az), números (0-9) y guiones (-).
     stats:
       group_stats: Estadísticas de grupo
       org_stats: Estadísticas de la organización (incluyendo subgrupos)

--- a/config/locales/server.fi.yml
+++ b/config/locales/server.fi.yml
@@ -153,6 +153,7 @@ fi:
     error:
       handle_must_begin_with_parent_handle: Alkaa %{parent_handle}-
       no_public_trials: Päivitä kokeiluversiosta muuttaaksesi ryhmän tietosuoja-asetusta
+      handle_must_be_url_friendly: Käytä vain pieniä kirjaimia (az), numeroita (0–9) ja yhdysmerkkejä (-)
     stats:
       group_stats: Ryhmätilastot
       org_stats: Organisaatiotilastot (mukaan lukien alaryhmät)

--- a/config/locales/server.fi.yml
+++ b/config/locales/server.fi.yml
@@ -153,7 +153,7 @@ fi:
     error:
       handle_must_begin_with_parent_handle: Alkaa %{parent_handle}-
       no_public_trials: Päivitä kokeiluversiosta muuttaaksesi ryhmän tietosuoja-asetusta
-      handle_must_be_url_friendly: Käytä vain pieniä kirjaimia (az), numeroita (0–9) ja yhdysmerkkejä (-)
+      handle_must_be_url_friendly: Käytä vain pieniä kirjaimia (a-z), numeroita (0–9) ja yhdysmerkkejä (-)
     stats:
       group_stats: Ryhmätilastot
       org_stats: Organisaatiotilastot (mukaan lukien alaryhmät)

--- a/config/locales/server.fr.yml
+++ b/config/locales/server.fr.yml
@@ -156,6 +156,7 @@ fr:
     error:
       handle_must_begin_with_parent_handle: Doit commencer par %{parent_handle}
       no_public_trials: Veuillez quitter la version d'essai pour modifier les paramètres de vie privée du groupe
+      handle_must_be_url_friendly: Utilisez uniquement des lettres minuscules (az), des chiffres (0-9) et des traits d'union (-).
     stats:
       group_stats: Statistiques du groupe
       org_stats: Statistiques de l'organisation (y compris les sous-groupes)

--- a/config/locales/server.fr.yml
+++ b/config/locales/server.fr.yml
@@ -156,7 +156,7 @@ fr:
     error:
       handle_must_begin_with_parent_handle: Doit commencer par %{parent_handle}
       no_public_trials: Veuillez quitter la version d'essai pour modifier les paramètres de vie privée du groupe
-      handle_must_be_url_friendly: Utilisez uniquement des lettres minuscules (az), des chiffres (0-9) et des traits d'union (-).
+      handle_must_be_url_friendly: Utilisez uniquement des lettres minuscules (a-z), des chiffres (0-9) et des traits d'union (-).
     stats:
       group_stats: Statistiques du groupe
       org_stats: Statistiques de l'organisation (y compris les sous-groupes)

--- a/config/locales/server.he.yml
+++ b/config/locales/server.he.yml
@@ -153,6 +153,7 @@ he:
     error:
       handle_must_begin_with_parent_handle: חייב להתחיל ב-%{parent_handle}-
       no_public_trials: שדרג מניסיון כדי לשנות את הגדרת הפרטיות של הקבוצה
+      handle_must_be_url_friendly: השתמשו רק באותיות קטנות (az), מספרים (0-9) ומקפים (-)
     stats:
       group_stats: נתונים סטטיסטיים של הקבוצה
       org_stats: נתונים סטטיסטיים של ארגון (כולל תת-קבוצות)

--- a/config/locales/server.he.yml
+++ b/config/locales/server.he.yml
@@ -153,7 +153,7 @@ he:
     error:
       handle_must_begin_with_parent_handle: חייב להתחיל ב-%{parent_handle}-
       no_public_trials: שדרג מניסיון כדי לשנות את הגדרת הפרטיות של הקבוצה
-      handle_must_be_url_friendly: השתמשו רק באותיות קטנות (az), מספרים (0-9) ומקפים (-)
+      handle_must_be_url_friendly: השתמשו רק באותיות קטנות (a-z), מספרים (0-9) ומקפים (-)
     stats:
       group_stats: נתונים סטטיסטיים של הקבוצה
       org_stats: נתונים סטטיסטיים של ארגון (כולל תת-קבוצות)

--- a/config/locales/server.hr.yml
+++ b/config/locales/server.hr.yml
@@ -153,6 +153,7 @@ hr:
     error:
       handle_must_begin_with_parent_handle: Mora započeti s %{parent_handle}-
       no_public_trials: Nadogradite s probnog razdoblja da biste promijenili postavku privatnosti grupe
+      handle_must_be_url_friendly: Koristite samo mala slova (az), brojeve (0-9) i crtice (-)
     stats:
       group_stats: Grupna statistika
       org_stats: Statistika organizacije (uključujući podgrupe)

--- a/config/locales/server.hr.yml
+++ b/config/locales/server.hr.yml
@@ -153,7 +153,7 @@ hr:
     error:
       handle_must_begin_with_parent_handle: Mora započeti s %{parent_handle}-
       no_public_trials: Nadogradite s probnog razdoblja da biste promijenili postavku privatnosti grupe
-      handle_must_be_url_friendly: Koristite samo mala slova (az), brojeve (0-9) i crtice (-)
+      handle_must_be_url_friendly: Koristite samo mala slova (a-z), brojeve (0-9) i crtice (-)
     stats:
       group_stats: Grupna statistika
       org_stats: Statistika organizacije (uključujući podgrupe)

--- a/config/locales/server.hu.yml
+++ b/config/locales/server.hu.yml
@@ -153,7 +153,7 @@ hu:
     error:
       handle_must_begin_with_parent_handle: 'A következővel kell kezdődnie: %{parent_handle}-'
       no_public_trials: Kérjük, frissítsen a próbaverzióról a csoport adatvédelmi beállításának módosításához
-      handle_must_be_url_friendly: Csak kisbetűket (az), számokat (0-9) és kötőjeleket (-) használjon.
+      handle_must_be_url_friendly: Csak kisbetűket (a-z), számokat (0-9) és kötőjeleket (-) használjon.
     stats:
       group_stats: Csoport statisztika
       org_stats: Szervezeti statisztikák (beleértve az alcsoportokat)

--- a/config/locales/server.hu.yml
+++ b/config/locales/server.hu.yml
@@ -153,6 +153,7 @@ hu:
     error:
       handle_must_begin_with_parent_handle: 'A következővel kell kezdődnie: %{parent_handle}-'
       no_public_trials: Kérjük, frissítsen a próbaverzióról a csoport adatvédelmi beállításának módosításához
+      handle_must_be_url_friendly: Csak kisbetűket (az), számokat (0-9) és kötőjeleket (-) használjon.
     stats:
       group_stats: Csoport statisztika
       org_stats: Szervezeti statisztikák (beleértve az alcsoportokat)

--- a/config/locales/server.it.yml
+++ b/config/locales/server.it.yml
@@ -157,6 +157,7 @@ it:
     error:
       handle_must_begin_with_parent_handle: Deve iniziare con%{parent_handle}-
       no_public_trials: Esegui l'upgrade dalla versione di prova per modificare l'impostazione sulla privacy del gruppo
+      handle_must_be_url_friendly: Utilizzare solo lettere minuscole (az), numeri (0-9) e trattini (-)
     stats:
       group_stats: Statistiche di gruppo
       org_stats: Statistiche dell'organizzazione (inclusi i sottogruppi)

--- a/config/locales/server.it.yml
+++ b/config/locales/server.it.yml
@@ -157,7 +157,7 @@ it:
     error:
       handle_must_begin_with_parent_handle: Deve iniziare con%{parent_handle}-
       no_public_trials: Esegui l'upgrade dalla versione di prova per modificare l'impostazione sulla privacy del gruppo
-      handle_must_be_url_friendly: Utilizzare solo lettere minuscole (az), numeri (0-9) e trattini (-)
+      handle_must_be_url_friendly: Utilizzare solo lettere minuscole (a-z), numeri (0-9) e trattini (-)
     stats:
       group_stats: Statistiche di gruppo
       org_stats: Statistiche dell'organizzazione (inclusi i sottogruppi)

--- a/config/locales/server.ja.yml
+++ b/config/locales/server.ja.yml
@@ -148,6 +148,7 @@ ja:
     error:
       handle_must_begin_with_parent_handle: "%{parent_handle} で始める必要があります -"
       no_public_trials: グループのプライバシー設定を変更するには、試用版からアップグレードしてください
+      handle_must_be_url_friendly: 小文字（az）、数字（0～9）、ハイフン（-）のみを使用してください。
     stats:
       group_stats: グループ統計
       org_stats: 組織統計 (サブグループを含む)

--- a/config/locales/server.ja.yml
+++ b/config/locales/server.ja.yml
@@ -148,7 +148,7 @@ ja:
     error:
       handle_must_begin_with_parent_handle: "%{parent_handle} で始める必要があります -"
       no_public_trials: グループのプライバシー設定を変更するには、試用版からアップグレードしてください
-      handle_must_be_url_friendly: 小文字（az）、数字（0～9）、ハイフン（-）のみを使用してください。
+      handle_must_be_url_friendly: 小文字（a-z）、数字（0～9）、ハイフン（-）のみを使用してください。
     stats:
       group_stats: グループ統計
       org_stats: 組織統計 (サブグループを含む)

--- a/config/locales/server.nl_NL.yml
+++ b/config/locales/server.nl_NL.yml
@@ -157,7 +157,7 @@ nl_NL:
     error:
       handle_must_begin_with_parent_handle: Moet beginnen met %{parent_handle}-
       no_public_trials: Upgrade van de proefversie om de privacyinstelling van de groep te wijzigen
-      handle_must_be_url_friendly: Gebruik alleen kleine letters (az), cijfers (0-9) en koppeltekens (-).
+      handle_must_be_url_friendly: Gebruik alleen kleine letters (a-z), cijfers (0-9) en koppeltekens (-).
     stats:
       group_stats: Groep statistieken
       org_stats: Organisatie statistieken (inclusief subgroepen)

--- a/config/locales/server.nl_NL.yml
+++ b/config/locales/server.nl_NL.yml
@@ -157,6 +157,7 @@ nl_NL:
     error:
       handle_must_begin_with_parent_handle: Moet beginnen met %{parent_handle}-
       no_public_trials: Upgrade van de proefversie om de privacyinstelling van de groep te wijzigen
+      handle_must_be_url_friendly: Gebruik alleen kleine letters (az), cijfers (0-9) en koppeltekens (-).
     stats:
       group_stats: Groep statistieken
       org_stats: Organisatie statistieken (inclusief subgroepen)

--- a/config/locales/server.pl.yml
+++ b/config/locales/server.pl.yml
@@ -157,6 +157,7 @@ pl:
     error:
       handle_must_begin_with_parent_handle: Musi zaczynać się od %{parent_handle}-
       no_public_trials: Zaktualizuj wersję próbną, aby zmienić ustawienia prywatności grupy
+      handle_must_be_url_friendly: Używaj wyłącznie małych liter (az), cyfr (0-9) i myślników (-)
     stats:
       group_stats: Statystyki grupy
       org_stats: Statystyki organizacji (w tym podgrup)

--- a/config/locales/server.pl.yml
+++ b/config/locales/server.pl.yml
@@ -157,7 +157,7 @@ pl:
     error:
       handle_must_begin_with_parent_handle: Musi zaczynać się od %{parent_handle}-
       no_public_trials: Zaktualizuj wersję próbną, aby zmienić ustawienia prywatności grupy
-      handle_must_be_url_friendly: Używaj wyłącznie małych liter (az), cyfr (0-9) i myślników (-)
+      handle_must_be_url_friendly: Używaj wyłącznie małych liter (a-z), cyfr (0-9) i myślników (-)
     stats:
       group_stats: Statystyki grupy
       org_stats: Statystyki organizacji (w tym podgrup)

--- a/config/locales/server.pt_BR.yml
+++ b/config/locales/server.pt_BR.yml
@@ -156,7 +156,7 @@ pt_BR:
     error:
       handle_must_begin_with_parent_handle: Deve começar com %{parent_handle}-
       no_public_trials: Atualize do teste para mudar a configuração de privacidade do grupo
-      handle_must_be_url_friendly: Use apenas letras minúsculas (az), números (0-9) e hífens (-)
+      handle_must_be_url_friendly: Use apenas letras minúsculas (a-z), números (0-9) e hífens (-)
     stats:
       group_stats: Estatísticas do grupo
       org_stats: Estatísticas da organização (incluindo subgrupos)

--- a/config/locales/server.pt_BR.yml
+++ b/config/locales/server.pt_BR.yml
@@ -156,6 +156,7 @@ pt_BR:
     error:
       handle_must_begin_with_parent_handle: Deve começar com %{parent_handle}-
       no_public_trials: Atualize do teste para mudar a configuração de privacidade do grupo
+      handle_must_be_url_friendly: Use apenas letras minúsculas (az), números (0-9) e hífens (-)
     stats:
       group_stats: Estatísticas do grupo
       org_stats: Estatísticas da organização (incluindo subgrupos)

--- a/config/locales/server.ro.yml
+++ b/config/locales/server.ro.yml
@@ -153,7 +153,7 @@ ro:
     error:
       handle_must_begin_with_parent_handle: Trebuie să înceapă cu %{parent_handle}-
       no_public_trials: Vă rugăm să faceți upgrade de la versiunea de încercare pentru a modifica setarea de confidențialitate a grupului
-      handle_must_be_url_friendly: Folosiți doar litere mici (az), cifre (0-9) și cratime (-)
+      handle_must_be_url_friendly: Folosiți doar litere mici (a-z), cifre (0-9) și cratime (-)
     stats:
       group_stats: Statistici de grup
       org_stats: Statistici ale organizației (inclusiv subgrupuri)

--- a/config/locales/server.ro.yml
+++ b/config/locales/server.ro.yml
@@ -153,6 +153,7 @@ ro:
     error:
       handle_must_begin_with_parent_handle: Trebuie să înceapă cu %{parent_handle}-
       no_public_trials: Vă rugăm să faceți upgrade de la versiunea de încercare pentru a modifica setarea de confidențialitate a grupului
+      handle_must_be_url_friendly: Folosiți doar litere mici (az), cifre (0-9) și cratime (-)
     stats:
       group_stats: Statistici de grup
       org_stats: Statistici ale organizației (inclusiv subgrupuri)

--- a/config/locales/server.ru.yml
+++ b/config/locales/server.ru.yml
@@ -153,7 +153,7 @@ ru:
     error:
       handle_must_begin_with_parent_handle: Должен начинаться с %{parent_handle}-
       no_public_trials: Пожалуйста, обновите пробную версию, чтобы изменить настройки конфиденциальности группы.
-      handle_must_be_url_friendly: Используйте только строчные буквы (az), цифры (0-9) и дефисы (-).
+      handle_must_be_url_friendly: Используйте только строчные буквы (a-z), цифры (0-9) и дефисы (-).
     stats:
       group_stats: Статистика группы
       org_stats: Статистика организации (включая подгруппы)

--- a/config/locales/server.ru.yml
+++ b/config/locales/server.ru.yml
@@ -153,6 +153,7 @@ ru:
     error:
       handle_must_begin_with_parent_handle: Должен начинаться с %{parent_handle}-
       no_public_trials: Пожалуйста, обновите пробную версию, чтобы изменить настройки конфиденциальности группы.
+      handle_must_be_url_friendly: Используйте только строчные буквы (az), цифры (0-9) и дефисы (-).
     stats:
       group_stats: Статистика группы
       org_stats: Статистика организации (включая подгруппы)

--- a/config/locales/server.sl.yml
+++ b/config/locales/server.sl.yml
@@ -153,6 +153,7 @@ sl:
     error:
       handle_must_begin_with_parent_handle: Začeti se mora z %{parent_handle}-
       no_public_trials: Če želite spremeniti nastavitev zasebnosti skupine, nadgradite preskusno različico
+      handle_must_be_url_friendly: Uporabljajte samo male črke (az), številke (0–9) in vezaje (-)
     stats:
       group_stats: Statistika skupine
       org_stats: Statistika organizacije (vključno s podskupinami)

--- a/config/locales/server.sl.yml
+++ b/config/locales/server.sl.yml
@@ -153,7 +153,7 @@ sl:
     error:
       handle_must_begin_with_parent_handle: Začeti se mora z %{parent_handle}-
       no_public_trials: Če želite spremeniti nastavitev zasebnosti skupine, nadgradite preskusno različico
-      handle_must_be_url_friendly: Uporabljajte samo male črke (az), številke (0–9) in vezaje (-)
+      handle_must_be_url_friendly: Uporabljajte samo male črke (a-z), številke (0–9) in vezaje (-)
     stats:
       group_stats: Statistika skupine
       org_stats: Statistika organizacije (vključno s podskupinami)

--- a/config/locales/server.sv.yml
+++ b/config/locales/server.sv.yml
@@ -153,7 +153,7 @@ sv:
     error:
       handle_must_begin_with_parent_handle: Måste börja med %{parent_handle}-
       no_public_trials: Vänligen uppgradera från testversion för att ändra gruppens sekretessinställning
-      handle_must_be_url_friendly: Använd endast gemener (az), siffror (0-9) och bindestreck (-)
+      handle_must_be_url_friendly: Använd endast gemener (a-z), siffror (0-9) och bindestreck (-)
     stats:
       group_stats: Gruppstatistik
       org_stats: Organisationsstatistik (inklusive undergrupper)

--- a/config/locales/server.sv.yml
+++ b/config/locales/server.sv.yml
@@ -153,6 +153,7 @@ sv:
     error:
       handle_must_begin_with_parent_handle: Måste börja med %{parent_handle}-
       no_public_trials: Vänligen uppgradera från testversion för att ändra gruppens sekretessinställning
+      handle_must_be_url_friendly: Använd endast gemener (az), siffror (0-9) och bindestreck (-)
     stats:
       group_stats: Gruppstatistik
       org_stats: Organisationsstatistik (inklusive undergrupper)

--- a/config/locales/server.tr.yml
+++ b/config/locales/server.tr.yml
@@ -153,6 +153,7 @@ tr:
     error:
       handle_must_begin_with_parent_handle: "%{parent_handle}- ile başlamalıdır"
       no_public_trials: Grup gizlilik ayarını değiştirmek için lütfen deneme sürümünden yükseltme yapın
+      handle_must_be_url_friendly: Yalnızca küçük harfler (az), rakamlar (0-9) ve kısa çizgiler (-) kullanın.
     stats:
       group_stats: Grup istatistikleri
       org_stats: Organizasyon istatistikleri (alt gruplar dahil)

--- a/config/locales/server.tr.yml
+++ b/config/locales/server.tr.yml
@@ -153,7 +153,7 @@ tr:
     error:
       handle_must_begin_with_parent_handle: "%{parent_handle}- ile başlamalıdır"
       no_public_trials: Grup gizlilik ayarını değiştirmek için lütfen deneme sürümünden yükseltme yapın
-      handle_must_be_url_friendly: Yalnızca küçük harfler (az), rakamlar (0-9) ve kısa çizgiler (-) kullanın.
+      handle_must_be_url_friendly: Yalnızca küçük harfler (a-z), rakamlar (0-9) ve kısa çizgiler (-) kullanın.
     stats:
       group_stats: Grup istatistikleri
       org_stats: Organizasyon istatistikleri (alt gruplar dahil)

--- a/config/locales/server.uk.yml
+++ b/config/locales/server.uk.yml
@@ -153,7 +153,7 @@ uk:
     error:
       handle_must_begin_with_parent_handle: Має починатись з %{parent_handle}-
       no_public_trials: Перейдіть із пробної версії, щоб змінити налаштування конфіденційності групи
-      handle_must_be_url_friendly: Використовуйте лише малі літери (az), цифри (0-9) та дефіси (-)
+      handle_must_be_url_friendly: Використовуйте лише малі літери (a-z), цифри (0-9) та дефіси (-)
     stats:
       group_stats: Статистика групи
       org_stats: Статистика організації (включаючи підгрупи)

--- a/config/locales/server.uk.yml
+++ b/config/locales/server.uk.yml
@@ -153,6 +153,7 @@ uk:
     error:
       handle_must_begin_with_parent_handle: Має починатись з %{parent_handle}-
       no_public_trials: Перейдіть із пробної версії, щоб змінити налаштування конфіденційності групи
+      handle_must_be_url_friendly: Використовуйте лише малі літери (az), цифри (0-9) та дефіси (-)
     stats:
       group_stats: Статистика групи
       org_stats: Статистика організації (включаючи підгрупи)

--- a/config/locales/server.zh_CN.yml
+++ b/config/locales/server.zh_CN.yml
@@ -420,6 +420,7 @@ zh_CN:
     error:
       handle_must_begin_with_parent_handle: 必须以 %{parent_handle}- 开头
       no_public_trials: 请从试用版升级以更改群组隐私设置
+      handle_must_be_url_friendly: 仅使用小写字母（a）、数字（0-9）和连字符（-）。
     stats:
       group_stats: 小组统计数据
       org_stats: 组织统计数据（包括子组）

--- a/config/locales/server.zh_CN.yml
+++ b/config/locales/server.zh_CN.yml
@@ -420,7 +420,7 @@ zh_CN:
     error:
       handle_must_begin_with_parent_handle: 必须以 %{parent_handle}- 开头
       no_public_trials: 请从试用版升级以更改群组隐私设置
-      handle_must_be_url_friendly: 仅使用小写字母（a）、数字（0-9）和连字符（-）。
+      handle_must_be_url_friendly: 仅使用小写字母（a-z）、数字（0-9）和连字符（-）。
     stats:
       group_stats: 小组统计数据
       org_stats: 组织统计数据（包括子组）

--- a/config/locales/server.zh_TW.yml
+++ b/config/locales/server.zh_TW.yml
@@ -156,6 +156,7 @@ zh_TW:
     error:
       handle_must_begin_with_parent_handle: 必須以 %{parent_handle} 開始。
       no_public_trials: 請從試用版升級以變更群組隱私設定
+      handle_must_be_url_friendly: 僅使用小寫字母（a）、數字（0-9）和連字號（-）。
     stats:
       group_stats: 群組統計
       org_stats: 組織統計（包含子群組）

--- a/config/locales/server.zh_TW.yml
+++ b/config/locales/server.zh_TW.yml
@@ -156,7 +156,7 @@ zh_TW:
     error:
       handle_must_begin_with_parent_handle: 必須以 %{parent_handle} 開始。
       no_public_trials: 請從試用版升級以變更群組隱私設定
-      handle_must_be_url_friendly: 僅使用小寫字母（a）、數字（0-9）和連字號（-）。
+      handle_must_be_url_friendly: 僅使用小寫字母（a-z）、數字（0-9）和連字號（-）。
     stats:
       group_stats: 群組統計
       org_stats: 組織統計（包含子群組）

--- a/config/locales/translation_corrections.md
+++ b/config/locales/translation_corrections.md
@@ -85,6 +85,7 @@ languages in the Nov 2025 pass.
 | client.*.yml   | `notifications.email_subject.poll_created` | Dropped `%{poll_type}` and used generic "Vote" labels | Restored `%{poll_type}: %{title}` | Email subject needs the dynamic poll type, not a hard-coded generic label |
 | client.zh_CN.yml | Multiple HTML/interpolation keys | Full-width percent signs or translated placeholder words like `％{标题}` / literal `作者` | Restored placeholders such as `%{title}`, `%{author}`, `%{username}` | Placeholder names and `%{...}` syntax must never be translated or converted to full-width characters |
 | client.*.yml   | `strand_nav.return`, `thread_arrangement_form.items`, `thread_arrangement_form.thread_settings`, `poll_common_settings.*`, `poll_common_details_meta.*` | UI labels translated in wrong senses like "Return"→yield, "items"→goods/articles, "thread"→subprocess/screw-thread, "opened"→inaugurated | Corrected to navigation, discussion-thread, poll-setting, and poll-time meanings | Short UI labels need surrounding UI context; Google often picks a plausible but wrong dictionary sense |
+| server.*.yml   | `group.error.handle_must_be_url_friendly` | Character range `(a-z)` collapsed to `(az)` or `(a)` | Preserve `(a-z)` | ASCII character ranges are literal validation guidance, not prose to translate |
 
 ## 2026-05-21 — lock_thread_modal body changed to explanation
 

--- a/db/migrate/20260612000000_create_group_handle_redirects.rb
+++ b/db/migrate/20260612000000_create_group_handle_redirects.rb
@@ -1,0 +1,12 @@
+class CreateGroupHandleRedirects < ActiveRecord::Migration[8.0]
+  def change
+    create_table :group_handle_redirects do |t|
+      t.references :group, null: false, foreign_key: true
+      t.citext :handle, null: false
+      t.timestamps
+    end
+
+    add_index :group_handle_redirects, :handle, unique: true
+    add_index :group_handle_redirects, [:group_id, :handle], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_06_11_000000) do
+ActiveRecord::Schema[8.0].define(version: 2026_06_12_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "hstore"
@@ -327,6 +327,16 @@ ActiveRecord::Schema[8.0].define(version: 2026_06_11_000000) do
   create_table "forward_email_rules", force: :cascade do |t|
     t.citext "handle", null: false
     t.string "email"
+  end
+
+  create_table "group_handle_redirects", force: :cascade do |t|
+    t.bigint "group_id", null: false
+    t.citext "handle", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["group_id", "handle"], name: "index_group_handle_redirects_on_group_id_and_handle", unique: true
+    t.index ["group_id"], name: "index_group_handle_redirects_on_group_id"
+    t.index ["handle"], name: "index_group_handle_redirects_on_handle", unique: true
   end
 
   create_table "group_identities", id: :serial, force: :cascade do |t|
@@ -1104,6 +1114,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_06_11_000000) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "discussions", "topics", deferrable: :deferred
+  add_foreign_key "group_handle_redirects", "groups"
   add_foreign_key "polls", "topics", deferrable: :deferred
   add_foreign_key "sessions", "users"
 end

--- a/test/controllers/groups_controller_test.rb
+++ b/test/controllers/groups_controller_test.rb
@@ -4,7 +4,7 @@ class GroupsControllerTest < ActionController::TestCase
   setup do
     hex = SecureRandom.hex(4)
     @user = User.create!(name: "grpuser#{hex}", email: "grpuser#{hex}@example.com", username: "grpuser#{hex}", email_verified: true)
-    @group = Group.new(name: "grpctrl#{hex}", group_privacy: 'closed')
+    @group = Group.new(name: "grpctrl#{hex}", handle: "grpctrl#{hex}", group_privacy: 'closed')
     @group.creator = @user
     @group.save!
     ActionMailer::Base.deliveries.clear
@@ -117,5 +117,60 @@ class GroupsControllerTest < ActionController::TestCase
 
     get :export, params: { key: @group.key }, format: :csv
     assert_response 302
+  end
+
+  # Handle redirects
+  test "show renders group by current handle" do
+    @group.update!(handle: "current-handle-#{SecureRandom.hex(4)}")
+    sign_in @user
+    @group.add_member!(@user)
+    get :show, params: { id: @group.handle }
+    assert_response 200
+    assert_equal @group, assigns(:group)
+  end
+
+  test "show redirects retired handle to current handle" do
+    @group.add_admin!(@user)
+    old_handle = @group.handle
+    new_handle = "new-handle-#{SecureRandom.hex(4)}"
+    GroupService.update_handle(group: @group, handle: new_handle, actor: @user)
+
+    sign_in @user
+    @group.add_member!(@user)
+    get :show, params: { id: old_handle }
+    assert_response 301
+    assert_redirected_to group_handle_path(new_handle)
+  end
+
+  test "show redirect preserves query parameters" do
+    @group.add_admin!(@user)
+    old_handle = @group.handle
+    new_handle = "new-handle-qs-#{SecureRandom.hex(4)}"
+    GroupService.update_handle(group: @group, handle: new_handle, actor: @user)
+
+    sign_in @user
+    @group.add_member!(@user)
+    get :show, params: { id: old_handle, foo: 'bar' }
+    assert_response 301
+    assert_redirected_to group_handle_path(new_handle, foo: 'bar')
+  end
+
+  test "old handle redirect returns 403 for secret group if unauthorized" do
+    @group.add_admin!(@user)
+    old_handle = @group.handle
+    new_handle = "new-handle-secret-#{SecureRandom.hex(4)}"
+    @group.update!(group_privacy: 'secret')
+    GroupService.update_handle(group: @group, handle: new_handle, actor: @user)
+
+    # user is not a member of the secret group
+    alien = User.create!(name: "alienghr#{SecureRandom.hex(4)}", email: "alienghr#{SecureRandom.hex(4)}@example.com", username: "alienghr#{SecureRandom.hex(4)}", email_verified: true)
+    sign_in alien
+    get :show, params: { id: old_handle }
+    assert_response 403
+  end
+
+  test "show returns 404 for unknown handle" do
+    get :show, params: { id: "nonexistent-handle-#{SecureRandom.hex(4)}" }
+    assert_response 404
   end
 end

--- a/test/models/group_handle_redirect_test.rb
+++ b/test/models/group_handle_redirect_test.rb
@@ -107,4 +107,69 @@ class GroupHandleRedirectTest < ActiveSupport::TestCase
       @group.destroy
     end
   end
+
+  test "updating parent handle updates direct subgroup handles" do
+    hex = SecureRandom.hex(4)
+    subgroup = Group.create!(
+      name: "Sub #{hex}",
+      parent: @group,
+      handle: "#{@group.handle}-sub#{hex}",
+      group_privacy: 'closed'
+    )
+
+    old_sub_handle = subgroup.handle
+    new_parent_handle = "ghr-parent-new-#{hex}"
+
+    GroupService.update_handle(group: @group, handle: new_parent_handle, actor: @user)
+
+    subgroup.reload
+    assert_equal "#{new_parent_handle}-sub#{hex}", subgroup.handle
+    assert GroupHandleRedirect.exists?(handle: old_sub_handle, group_id: subgroup.id)
+  end
+
+  test "updating parent handle updates nested subgroup handles recursively" do
+    hex = SecureRandom.hex(4)
+    subgroup = Group.create!(
+      name: "Sub #{hex}",
+      parent: @group,
+      handle: "#{@group.handle}-sub#{hex}",
+      group_privacy: 'closed'
+    )
+    subsubgroup = Group.create!(
+      name: "SubSub #{hex}",
+      parent: subgroup,
+      handle: "#{subgroup.handle}-subsub#{hex}",
+      group_privacy: 'closed'
+    )
+
+    old_subsub_handle = subsubgroup.handle
+    new_parent_handle = "ghr-nested-new-#{hex}"
+
+    GroupService.update_handle(group: @group, handle: new_parent_handle, actor: @user)
+
+    subsubgroup.reload
+    expected = "#{new_parent_handle}-sub#{hex}-subsub#{hex}"
+    assert_equal expected, subsubgroup.handle
+    assert GroupHandleRedirect.exists?(handle: old_subsub_handle, group_id: subsubgroup.id)
+  end
+
+  test "updating parent handle creates redirects for all old subgroup handles" do
+    hex = SecureRandom.hex(4)
+    subgroup = Group.create!(
+      name: "Sub #{hex}",
+      parent: @group,
+      handle: "#{@group.handle}-sub#{hex}",
+      group_privacy: 'closed'
+    )
+
+    old_sub_handle = subgroup.handle
+    new_parent_handle = "ghr-redirects-#{hex}"
+
+    assert_difference 'GroupHandleRedirect.count', 2 do
+      # 1 for parent + 1 for subgroup
+      GroupService.update_handle(group: @group, handle: new_parent_handle, actor: @user)
+    end
+
+    assert GroupHandleRedirect.exists?(handle: old_sub_handle, group_id: subgroup.id)
+  end
 end

--- a/test/models/group_handle_redirect_test.rb
+++ b/test/models/group_handle_redirect_test.rb
@@ -1,0 +1,110 @@
+require 'test_helper'
+
+class GroupHandleRedirectTest < ActiveSupport::TestCase
+  setup do
+    hex = SecureRandom.hex(4)
+    @user = User.create!(name: "ghruser#{hex}", email: "ghruser#{hex}@example.com", username: "ghruser#{hex}", email_verified: true)
+    @group = Group.create!(name: "GHR Group #{hex}", handle: "ghrgroup-#{hex}", group_privacy: 'secret')
+    @group.add_admin!(@user)
+    @other_group = Group.create!(name: "GHR Other #{hex}", handle: "ghrother-#{hex}", group_privacy: 'secret')
+    @other_group.add_admin!(@user)
+  end
+
+  test "changing a group handle creates a retired handle" do
+    old_handle = @group.handle
+
+    assert_difference 'GroupHandleRedirect.count', 1 do
+      GroupService.update_handle(group: @group, handle: "ghr-new-handle-#{SecureRandom.hex(4)}", actor: @user)
+    end
+
+    assert_equal old_handle, GroupHandleRedirect.last.handle
+    assert_equal @group.id, GroupHandleRedirect.last.group_id
+  end
+
+  test "changing handle twice keeps both old handles but limit is 3" do
+    first_handle = @group.handle
+
+    GroupService.update_handle(group: @group, handle: "ghr-second-#{SecureRandom.hex(4)}", actor: @user)
+    second_handle = @group.reload.handle
+
+    GroupService.update_handle(group: @group, handle: "ghr-third-#{SecureRandom.hex(4)}", actor: @user)
+
+    assert GroupHandleRedirect.exists?(handle: first_handle, group_id: @group.id)
+    assert GroupHandleRedirect.exists?(handle: second_handle, group_id: @group.id)
+    assert_equal 2, @group.handle_redirects.count
+  end
+
+  test "limits redirects to most recent 3" do
+    first_handle = @group.handle
+
+    GroupService.update_handle(group: @group, handle: "ghr-a-#{SecureRandom.hex(4)}", actor: @user)
+    GroupService.update_handle(group: @group, handle: "ghr-b-#{SecureRandom.hex(4)}", actor: @user)
+    GroupService.update_handle(group: @group, handle: "ghr-c-#{SecureRandom.hex(4)}", actor: @user)
+    GroupService.update_handle(group: @group, handle: "ghr-d-#{SecureRandom.hex(4)}", actor: @user)
+
+    # first_handle (oldest) should have been trimmed
+    refute GroupHandleRedirect.exists?(handle: first_handle, group_id: @group.id)
+    assert_equal 3, @group.handle_redirects.count
+  end
+
+  test "cannot set a group handle to another group's retired handle" do
+    old_handle = @other_group.handle
+    GroupService.update_handle(group: @other_group, handle: "ghr-other-new-#{SecureRandom.hex(4)}", actor: @user)
+
+    # old_handle is now retired by other_group
+    @group.handle = old_handle
+    refute @group.valid?
+    assert_includes @group.errors[:handle], 'has already been taken'
+  end
+
+  test "cannot set a group handle to another group's current handle" do
+    @group.handle = @other_group.handle
+    refute @group.valid?
+    assert_includes @group.errors[:handle], 'has already been taken'
+  end
+
+  test "cannot create duplicate retired handles for the same group" do
+    old_handle = @group.handle
+    GroupService.update_handle(group: @group, handle: "ghr-dup-new-#{SecureRandom.hex(4)}", actor: @user)
+
+    redirect = GroupHandleRedirect.new(group: @group, handle: old_handle)
+    refute redirect.valid?
+  end
+
+  test "cannot create a redirect with the group's current handle" do
+    redirect = GroupHandleRedirect.new(group: @group, handle: @group.handle)
+    refute redirect.valid?
+    assert_includes redirect.errors[:handle], 'has already been taken'
+  end
+
+  test "cannot create a redirect with another group's current handle" do
+    redirect = GroupHandleRedirect.new(group: @group, handle: @other_group.handle)
+    refute redirect.valid?
+    assert_includes redirect.errors[:handle], 'has already been taken'
+  end
+
+  test "parameterizes the handle before saving" do
+    old_handle = @group.handle
+    GroupService.update_handle(group: @group, handle: "ghr-param-new-#{SecureRandom.hex(4)}", actor: @user)
+
+    redirect = GroupHandleRedirect.create!(group: @group, handle: "  Has Spaces and CAPS  ")
+    assert_equal "has-spaces-and-caps", redirect.handle
+  end
+
+  test "handle suggestions avoid retired handles" do
+    old_handle = @group.handle
+    GroupService.update_handle(group: @group, handle: "ghr-suggest-new-#{SecureRandom.hex(4)}", actor: @user)
+
+    suggestion = GroupService.suggest_handle(name: old_handle, parent_handle: nil)
+    refute_equal old_handle, suggestion
+  end
+
+  test "belongs_to group is destroyed with group" do
+    old_handle = @group.handle
+    GroupService.update_handle(group: @group, handle: "ghr-cascade-new-#{SecureRandom.hex(4)}", actor: @user)
+
+    assert_difference 'GroupHandleRedirect.count', -1 do
+      @group.destroy
+    end
+  end
+end

--- a/test/services/received_email_service_test.rb
+++ b/test/services/received_email_service_test.rb
@@ -159,6 +159,74 @@ class ReceivedEmailServiceTest < ActiveSupport::TestCase
     ENV['REPLY_HOSTNAME'] = original_reply
   end
 
+  # -- Handle redirect routing --
+
+  test "routes email to group via retired handle" do
+    original_reply = ENV['REPLY_HOSTNAME']
+    ENV['REPLY_HOSTNAME'] = 'test.host'
+
+    user = User.create!(name: 'RedirectEmailUser', email: "redirectemail#{SecureRandom.hex(4)}@example.com",
+                        email_verified: true, username: "redirectemail#{SecureRandom.hex(4)}")
+    old_handle = "oldhandle#{SecureRandom.hex(4)}"
+    new_handle = "newhandle#{SecureRandom.hex(4)}"
+    group = Group.create!(name: 'Redirect Group', handle: old_handle)
+    group.add_admin!(user)
+    group.add_member!(user)
+    GroupService.update_handle(group: group, handle: new_handle, actor: user)
+
+    from = "\"#{user.name}\" <#{user.email}>"
+    to = "#{old_handle}@#{ENV['REPLY_HOSTNAME']}"
+
+    email = ReceivedEmail.create!(
+      headers: { 'From' => from, 'To' => to, 'Subject' => 'Thread via retired handle' },
+      body_text: "Thread body"
+    )
+
+    assert_difference 'Discussion.count', 1 do
+      ReceivedEmailService.route(email)
+    end
+
+    discussion = Discussion.order(:id).last
+    assert_equal group.id, discussion.group_id
+    assert email.reload.released
+  ensure
+    ENV['REPLY_HOSTNAME'] = original_reply
+  end
+
+  test "routes personal email-to-group via retired handle" do
+    original_reply = ENV['REPLY_HOSTNAME']
+    ENV['REPLY_HOSTNAME'] = 'test.host'
+
+    user = User.create!(name: 'PersRedirectUser', email: "persredirect#{SecureRandom.hex(4)}@example.com",
+                        email_verified: true, username: "persredirect#{SecureRandom.hex(4)}")
+    old_handle = "persold#{SecureRandom.hex(4)}"
+    new_handle = "persnew#{SecureRandom.hex(4)}"
+    group = Group.create!(name: 'PersRedirect Group', handle: old_handle)
+    group.add_admin!(user)
+    group.add_member!(user)
+    GroupService.update_handle(group: group, handle: new_handle, actor: user)
+
+    from = "\"#{user.name}\" <#{user.email}>"
+    to = "#{old_handle}+u=#{user.id}&k=#{user.email_api_key}@#{ENV['REPLY_HOSTNAME']}"
+
+    email = ReceivedEmail.create!(
+      headers: { 'From' => from, 'To' => to, 'Subject' => 'Personal thread via retired handle' },
+      body_text: "Personal thread body"
+    )
+
+    if AppConfig.app_features[:thread_from_mail]
+      assert_difference 'Discussion.count', 1 do
+        ReceivedEmailService.route(email)
+      end
+
+      discussion = Discussion.order(:id).last
+      assert_equal group.id, discussion.group_id
+      assert email.reload.released
+    end
+  ensure
+    ENV['REPLY_HOSTNAME'] = original_reply
+  end
+
   # -- Bounce handling --
 
   test "bounce email increments bounces_count" do

--- a/vue/src/components/group/form.vue
+++ b/vue/src/components/group/form.vue
@@ -242,12 +242,11 @@ v-form(ref="form" @submit.prevent="submit")
           div(v-if="!group.parentId || (group.parentId && group.parent().handle)")
             v-text-field.group-form__handle#group-handle(
               v-model='group.handle'
-              :hint="$t('group_form.group_handle_placeholder', {host: hostname, handle: group.handle})"
+              :hint="realGroup && realGroup.handle && group.handle !== realGroup.handle ? $t('group_form.handle_changed_hint') : $t('group_form.group_handle_hint_new', {host: hostname, handle: group.handle})"
               :rules='validate("handle")'
               maxlength='100'
               :label="$t('group_form.handle')"
             )
-            .text-caption.text-medium-emphasis.mb-2(v-if="realGroup && realGroup.handle && group.handle !== realGroup.handle" v-t="'group_form.handle_redirect_notice'")
           v-spacer
 
           input.d-none.change-picture-form__file-input(type="file" ref="coverPhotoInput" @change='uploadCoverPhoto' accept="image/png, image/jpeg, image/webp")

--- a/vue/src/components/group/form.vue
+++ b/vue/src/components/group/form.vue
@@ -247,6 +247,7 @@ v-form(ref="form" @submit.prevent="submit")
               maxlength='100'
               :label="$t('group_form.handle')"
             )
+            .text-caption.text-medium-emphasis.mb-2(v-if="realGroup && realGroup.handle && group.handle !== realGroup.handle" v-t="'group_form.handle_redirect_notice'")
           v-spacer
 
           input.d-none.change-picture-form__file-input(type="file" ref="coverPhotoInput" @change='uploadCoverPhoto' accept="image/png, image/jpeg, image/webp")

--- a/vue/src/components/group/new_form.vue
+++ b/vue/src/components/group/new_form.vue
@@ -188,7 +188,7 @@ v-card.group-form(:title="group.parentId ? $t('group_form.start_subgroup_heading
     validation-errors(:subject="group", field="name")
 
     div(v-if="!group.parentId || (group.parentId && group.parent().handle)")
-      v-text-field.group-form__handle#group-handle(:loading="loadingHandle" v-model='group.handle' :hint="$t('group_form.group_handle_placeholder', {host: hostname, handle: group.handle})" maxlength='100' :label="$t('group_form.handle')")
+      v-text-field.group-form__handle#group-handle(:loading="loadingHandle" v-model='group.handle' :hint="$t('group_form.group_handle_hint_new', {host: hostname, handle: group.handle})" maxlength='100' :label="$t('group_form.handle')")
       validation-errors(:subject="group", field="handle")
 
     v-select.group-form__category-select(v-if='!group.parentId' v-model="group.category" :items="categoryItems" :label="$t('group_survey.describe_other')")


### PR DESCRIPTION
## Summary

Adds support for group handle redirects, so that when a group changes its handle, old links and email addresses keep working.

### Data model
- New `group_handle_redirects` table stores retired handles (citext, unique)
- `Group` has `has_many :handle_redirects`
- Validations prevent reusing another group's retired handle

### Handle-change behavior
- `GroupService.update_handle` — creates redirect on explicit handle change (admin action)
- `GroupService.update` — detects handle changes during normal group form saves
- `GroupService.move` — creates redirect when handle changes during parent move
- All paths limit redirects to the most recent 3 per group
- `GroupService.suggest_handle` avoids both current and retired handles

### Web redirects
- `GET /old-handle` → 301 redirect to `/current-handle` (query params preserved)
- `403` for unauthorized access to secret/private groups via retired handle

### Email routing
- `ReceivedEmailService.group_from_route_path` resolves both current and retired handles
- Email to `old-handle@reply-host` reaches the correct group
- Personal email-to-group with retired handle works (`+u=...&k=...`)

### UI
- Vue group form shows redirect notice when handle is modified on an existing group
- Admin handle action shows flash with old → new handle info

### Files changed
| File | Change |
|---|---|
| `db/migrate/20260612000000_create_group_handle_redirects.rb` | New table |
| `app/models/group_handle_redirect.rb` | New model |
| `app/models/group.rb` | Association + validation |
| `app/services/group_service.rb` | `update_handle`, `trim_handle_redirects`, handle-aware `update`/`move`/`suggest_handle` |
| `app/controllers/groups_controller.rb` | Redirect logic in `show` |
| `app/services/received_email_service.rb` | `group_from_route_path` helper |
| `app/admin/groups.rb` | Flash notice on handle change |
| `vue/src/components/group/form.vue` | Redirect notice for persisted groups |
| `config/locales/*.yml` | New `group_form.handle_redirect_notice` key |
| `test/**/*` | Model, controller, and service tests (52 tests, all passing) |