### PR TITLE
Security audit fixes

### DIFF
--- a/app/controllers/api/v1/announcements_controller.rb
+++ b/app/controllers/api/v1/announcements_controller.rb
@@ -2,9 +2,13 @@ class Api::V1::AnnouncementsController < Api::V1::RestfulController
   def audience
     current_user.ability.authorize! :show, target_model
 
+    # Anonymous polls must never disclose who voted. 'voters' maps to
+    # Poll#unmasked_voters (which does NOT self-mask, since it is also used for
+    # internal notification targeting), and 'non_voters' reveals voters by
+    # complement — so all voter-derived audiences are refused for anon polls.
     if target_model.respond_to?(:anonymous) &&
        target_model.anonymous &&
-       ['decided_voters', 'undecided_voters'].include?(params[:recipient_audience])
+       ['voters', 'decided_voters', 'undecided_voters', 'non_voters'].include?(params[:recipient_audience])
       raise CanCan::AccessDenied
     end
 

--- a/app/controllers/api/v1/events_controller.rb
+++ b/app/controllers/api/v1/events_controller.rb
@@ -27,7 +27,7 @@ class Api::V1::EventsController < Api::V1::RestfulController
 
   def comment
     load_and_authorize_topic
-    self.resource = Event.find_by!(kind: "new_comment", eventable_type: "Comment", eventable_id: params[:comment_id])
+    self.resource = Event.where(topic_id: @topic.id).find_by!(kind: "new_comment", eventable_type: "Comment", eventable_id: params[:comment_id])
     respond_with_resource
   end
 

--- a/app/controllers/api/v1/profile_controller.rb
+++ b/app/controllers/api/v1/profile_controller.rb
@@ -1,5 +1,25 @@
 class Api::V1::ProfileController < Api::V1::RestfulController
+  # A "restricted" current_user is one authenticated ONLY by an unsubscribe_token
+  # (a permanent bearer token embedded in every notification email), not by a
+  # real session. Such a request may manage email/notification preferences, but
+  # must NEVER reach account-destructive or credential-bearing actions, nor edit
+  # identity fields (name/email/password/username/avatar) via update_profile.
+  RESTRICTED_USER_FORBIDDEN_ACTIONS = %w[
+    email_api_key reset_email_api_key deactivate destroy
+    send_merge_verification_email remind upload_avatar
+  ].freeze
+
+  # The only user fields update_profile may change for a restricted user.
+  RESTRICTED_USER_UPDATABLE_FIELDS = %i[
+    email_when_mentioned email_when_proposal_closing_soon
+    email_new_discussions_and_proposals email_on_participation
+    email_newsletter email_catch_up_day default_membership_volume
+    selected_locale autodetect_time_zone time_zone date_time_pref
+    email_new_discussions_and_proposals_group_ids
+  ].freeze
+
   before_action :require_current_user, except: [:email_status]
+  before_action :forbid_restricted_user_actions
 
   def index
     ids = UserQuery.invitable_user_ids(model: nil, actor: current_user, user_ids: params[:xids].split('x').map(&:to_i).compact)
@@ -146,7 +166,22 @@ class Api::V1::ProfileController < Api::V1::RestfulController
   end
 
   def current_user_params
-    { user: current_user, actor: current_user, params: permitted_params.user }
+    { user: current_user, actor: current_user, params: profile_update_params }
+  end
+
+  def profile_update_params
+    return permitted_params.user unless current_user.restricted
+
+    # Restricted (unsubscribe-token) users may only update notification prefs —
+    # strip identity/credential fields so the token cannot be used to change
+    # name, email, password, username, or avatar.
+    permitted_params.user.slice(*RESTRICTED_USER_UPDATABLE_FIELDS.map(&:to_s))
+  end
+
+  def forbid_restricted_user_actions
+    return unless RESTRICTED_USER_FORBIDDEN_ACTIONS.include?(action_name) && current_user.restricted
+
+    raise CanCan::AccessDenied.new("unsubscribe-token users may not perform #{action_name}")
   end
 
   def resource_class

--- a/app/controllers/api/v1/sessions_controller.rb
+++ b/app/controllers/api/v1/sessions_controller.rb
@@ -88,10 +88,16 @@ class Api::V1::SessionsController < ApplicationController
   def login_token_user
     LoginToken.transaction do
       token = LoginToken.unused.lock.find_by(code: resource_params.require(:code))
-      next unless login_token_matches?(token)
-
-      token.update!(used: true)
-      token.user
+      if login_token_matches?(token)
+        token.update!(used: true)
+        token.user
+      else
+        # This path only runs once the request has cleared turnstile_ok?, so a
+        # wrong code here is a genuine login attempt worth counting against the
+        # token's MAX_FAILED_CODE_ATTEMPTS budget.
+        record_failed_login_code_attempt
+        nil
+      end
     end
   end
 
@@ -99,16 +105,17 @@ class Api::V1::SessionsController < ApplicationController
     resource_params[:email].present? && token&.useable? && token.user.email == resource_params[:email]
   end
 
+  # Used only to decide whether a fresh turnstile is required. A matching code
+  # means the user already solved a CAPTCHA to receive it, so skip turnstile.
+  # A mismatch must NOT mutate token state here (that would let an
+  # unauthenticated, CAPTCHA-less request burn a victim's remaining attempts) —
+  # it simply falls through to the turnstile check. Failed-attempt accounting
+  # happens later, in login_token_user, behind the turnstile gate.
   def usable_login_token_for_code
     return unless resource_params[:code].present?
 
     token = LoginToken.unused.find_by(code: resource_params[:code])
-    if login_token_matches?(token)
-      token
-    else
-      record_failed_login_code_attempt
-      nil
-    end
+    token if login_token_matches?(token)
   end
 
   def record_failed_login_code_attempt

--- a/app/controllers/api/v1/stances_controller.rb
+++ b/app/controllers/api/v1/stances_controller.rb
@@ -80,6 +80,10 @@ class Api::V1::StancesController < Api::V1::RestfulController
 
   def users
     instantiate_collection do |collection|
+      # Anonymous polls must not expose who participated — mirror the masking
+      # applied by polls#voters and stances#index.
+      next User.none if @poll.anonymous?
+
       if query = params[:query]
         collection = collection.
           joins('LEFT OUTER JOIN users on stances.participant_id = users.id').

--- a/app/controllers/api/v1/stances_controller.rb
+++ b/app/controllers/api/v1/stances_controller.rb
@@ -70,7 +70,14 @@ class Api::V1::StancesController < Api::V1::RestfulController
       end
 
       if @poll.anonymous?
-        collection.order(:id)
+        # Anonymous stances must NOT be returned in creation order: stance ids
+        # are assigned in member order, so ordering by id (or created_at) lets a
+        # viewer align each row's position with the member list and read its
+        # option_scores to reconstruct who voted for what. Order by a stable,
+        # app-secret-keyed hash instead — deterministic (so pagination is
+        # consistent) but uncorrelated with creation/member order.
+        salt = Stance.connection.quote(Rails.application.secret_key_base)
+        collection.order(Arel.sql("md5(stances.id::text || #{salt})"))
       else
         collection.order('cast_at DESC NULLS LAST, created_at DESC')
       end

--- a/app/controllers/direct_uploads_controller.rb
+++ b/app/controllers/direct_uploads_controller.rb
@@ -7,6 +7,7 @@ class DirectUploadsController < ActiveStorage::DirectUploadsController
 
   protect_from_forgery with: :exception
   skip_before_action :verify_authenticity_token
+  before_action :require_logged_in_user, only: :create
   before_action :enforce_upload_size_limit, only: :create
   before_action :enforce_content_type, only: :create
 
@@ -22,6 +23,13 @@ class DirectUploadsController < ActiveStorage::DirectUploadsController
   ].freeze
 
   private
+
+  # Only signed-in users may mint presigned upload URLs / blobs — otherwise
+  # anonymous callers can create orphan blobs and public loomio-domain
+  # download URLs for arbitrary content.
+  def require_logged_in_user
+    head :unauthorized unless current_user.is_logged_in?
+  end
 
   def enforce_content_type
     content_type = params.dig(:blob, :content_type).to_s.downcase

--- a/app/extras/clients/matrix.rb
+++ b/app/extras/clients/matrix.rb
@@ -25,20 +25,23 @@ class Clients::Matrix
   # invite. For rooms already joined this is a no-op on the server side.
   # Returns the canonical room ID.
   def join_room(room_id_or_alias)
-    response = HTTParty.post(
+    # @server is user-controlled; go through the SSRF-guarded, IP-pinned client
+    # so a rebinding/redirect can't reach internal services or cloud metadata.
+    response = LinkPreviewService.pinned_request(:post,
       "#{@server}/_matrix/client/v3/join/#{CGI.escape(room_id_or_alias)}",
       headers: auth_headers.merge("Content-Type" => "application/json"),
       body: "{}",
       timeout: REQUEST_TIMEOUT_SECONDS
     )
-    response.parsed_response["room_id"] || room_id_or_alias
+    parsed = (JSON.parse(response.body) rescue {}) if response
+    (parsed.is_a?(Hash) && parsed["room_id"]) || room_id_or_alias
   end
 
   private
 
   def send_message(room_id, content)
     txn_id = SecureRandom.hex(16)
-    HTTParty.put(
+    LinkPreviewService.pinned_request(:put,
       "#{@server}/_matrix/client/v3/rooms/#{CGI.escape(room_id)}/send/m.room.message/#{txn_id}",
       headers: auth_headers.merge("Content-Type" => "application/json"),
       body: content.to_json,

--- a/app/models/identity.rb
+++ b/app/models/identity.rb
@@ -15,10 +15,14 @@ class Identity < ApplicationRecord
 
   def assign_logo!
     return unless user && logo
-    user.uploaded_avatar.attach(
-      io: URI.open(URI.parse(logo)),
-      filename: File.basename(logo)
-    )
+
+    # `logo` comes from the external SSO/OAuth provider's userinfo response, so
+    # it is attacker-influenceable — fetch it through the SSRF-guarded opener
+    # rather than a raw URI.open that would follow it to internal/metadata IPs.
+    io = LinkPreviewService.safe_open(logo)
+    return unless io
+
+    user.uploaded_avatar.attach(io: io, filename: File.basename(logo))
     user.update(avatar_kind: :uploaded)
   rescue StandardError => e
     Rails.logger.warn("assign_logo! failed for identity #{id}: #{e.message}")

--- a/app/models/received_email.rb
+++ b/app/models/received_email.rb
@@ -9,6 +9,23 @@ class ReceivedEmail < ApplicationRecord
     headers.find { |key, value| key.downcase == name.to_s.downcase }&.last
   end
 
+  # The inbound relay (SES/Postfix) evaluates SPF/DKIM/DMARC and stamps
+  # Authentication-Results before forwarding to us. Returns true only when we
+  # can positively determine the From: domain FAILED authentication — used to
+  # refuse auto-authoring content for a spoofed sender on the group-handle
+  # route (which otherwise trusts the From: header alone). Absent/unparseable
+  # results return false: we can't prove a failure, and requiring a positive
+  # pass would break relays that don't stamp the header. Domains with no DMARC
+  # remain inherently spoofable — this stops the practical case where an
+  # attacker forges a DMARC-protected member's address.
+  def sender_authentication_failed?
+    results = String(header('authentication-results')).downcase
+    return false if results.blank?
+    return true if results.include?('dmarc=fail')
+
+    results.include?('dkim=fail') && results.include?('spf=fail')
+  end
+
   def recipient_emails
     String(header('to')).scan(AppConfig::EMAIL_REGEX).uniq
   end

--- a/app/serializers/stance_serializer.rb
+++ b/app/serializers/stance_serializer.rb
@@ -75,6 +75,28 @@ class StanceSerializer < ApplicationSerializer
     object.participant_id
   end
 
+  # For anonymous polls the raw stance id (a creation-ordered primary key) is an
+  # identity oracle: sorted, it recovers the member order, and combined with
+  # option_scores it reconstructs the ballot. Expose an unguessable, app-secret-
+  # keyed pseudonymous id instead — except for the viewer's OWN stance, which
+  # keeps its real id so they can still update/redact it.
+  def id
+    return object.id unless poll.anonymous?
+    return object.id if object.participant_id == scope[:current_user_id]
+    anonymous_id
+  end
+
+  def inviter_id
+    return nil if poll.anonymous?
+    object.inviter_id
+  end
+
+  private
+
+  def anonymous_id
+    OpenSSL::HMAC.hexdigest('SHA256', Rails.application.secret_key_base, "#{object.poll_id}:#{object.id}")[0, 20]
+  end
+
   def include_reason?
     include_results? && !object.redacted_at
   end
@@ -93,5 +115,12 @@ class StanceSerializer < ApplicationSerializer
 
   def include_link_previews?
     include_reason?
+  end
+
+  # ReactionSerializer exposes reactable_id (the real stance id), which would
+  # re-introduce the identity oracle the anonymous_id is meant to remove — so
+  # don't serialize per-stance reactions for anonymous polls.
+  def include_reactions?
+    !poll.anonymous?
   end
 end

--- a/app/serializers/version_serializer.rb
+++ b/app/serializers/version_serializer.rb
@@ -16,6 +16,18 @@ class VersionSerializer < ApplicationSerializer
     object.whodunnit.to_i
   end
 
+  # Anonymous polls must not reveal who cast a stance. PaperTrail records the
+  # voter id in `whodunnit` and the (possibly redacted) reason text in
+  # `object_changes`, neither of which StanceSerializer exposes for anonymous
+  # polls — so suppress them here too.
+  def include_whodunnit?
+    !hide_anonymous_stance_identity?
+  end
+
+  def include_object_changes?
+    !hide_anonymous_stance_data?
+  end
+
   def discussion
     object.item
   end
@@ -50,5 +62,21 @@ class VersionSerializer < ApplicationSerializer
 
   def include_stance?
     object.item_type == 'Stance'
+  end
+
+  private
+
+  def stance_item
+    object.item if object.item_type == 'Stance'
+  end
+
+  def hide_anonymous_stance_identity?
+    stance = stance_item
+    stance.present? && stance.poll&.anonymous?
+  end
+
+  def hide_anonymous_stance_data?
+    stance = stance_item
+    stance.present? && (stance.poll&.anonymous? || stance.redacted_at.present?)
   end
 end

--- a/app/services/chatbot_service.rb
+++ b/app/services/chatbot_service.rb
@@ -59,9 +59,9 @@ class ChatbotService
         if chatbot.kind == "webhook"
           serializer = "Webhook::#{chatbot.webhook_kind.classify}::EventSerializer".constantize
           payload = serializer.new(event, root: false, scope: {template_name: template_name, recipient: recipient}).as_json
-          req = Clients::Webhook.new.post(chatbot.server, params: payload)
-          if req.response.code != 200
-            Sentry.capture_message("chatbot id #{chatbot.id} post event id #{event.id} failed: code: #{req.response.code} body: #{req.response.body}")
+          response = deliver_webhook(chatbot.server, payload)
+          if response.nil? || response.code.to_i != 200
+            Sentry.capture_message("chatbot id #{chatbot.id} post event id #{event.id} failed: code: #{response&.code} body: #{response&.body}")
           end
         else
           component = matrix_component(template_name, event: event, poll: poll, recipient: recipient)
@@ -116,11 +116,7 @@ class ChatbotService
 
     case params[:kind]
     when 'slack_webhook'
-      Clients::Webhook.new.post(
-        params[:server],
-        params: {text: I18n.t('chatbot.connection_test_successful')},
-        options: {timeout: REQUEST_TIMEOUT_SECONDS}
-      )
+      deliver_webhook(params[:server], {text: I18n.t('chatbot.connection_test_successful')})
     else
       matrix_client = Clients::Matrix.new(server: params[:server], access_token: params[:access_token])
       message = I18n.t('chatbot.connection_test_successful', group: params[:group_name])
@@ -130,5 +126,16 @@ class ChatbotService
 
   def self.validate_public_server!(server)
     raise CanCan::AccessDenied unless LinkPreviewService.safe_to_fetch?(server)
+  end
+
+  # Deliver a webhook payload through the SSRF-guarded, IP-pinned client. The
+  # chatbot.server URL is user-controlled and only validated at save time, so
+  # every send must re-resolve-and-pin to defeat DNS rebinding / redirects.
+  # Returns a Net::HTTPResponse or nil.
+  def self.deliver_webhook(url, payload)
+    LinkPreviewService.pinned_request(:post, url,
+      headers: { 'Content-Type' => 'application/json; charset=utf-8' },
+      body: payload.to_json,
+      timeout: REQUEST_TIMEOUT_SECONDS)
   end
 end

--- a/app/services/link_preview_service.rb
+++ b/app/services/link_preview_service.rb
@@ -1,5 +1,7 @@
 require 'ipaddr'
 require 'resolv'
+require 'net/http'
+require 'stringio'
 
 module LinkPreviewService
   MAX_REDIRECTS = 3
@@ -29,14 +31,15 @@ module LinkPreviewService
   ].freeze
 
   def self.fetch(url, redirect_depth: 0)
-    return nil unless safe_to_fetch?(url)
-    response = HTTParty.get(url, follow_redirects: false, timeout: REQUEST_TIMEOUT_SECONDS)
-    if [301, 302, 303, 307, 308].include?(response.code) && response.headers['location']
+    response = pinned_get(url)
+    return nil unless response
+
+    if [301, 302, 303, 307, 308].include?(response.code.to_i) && response['location']
       return nil if redirect_depth >= MAX_REDIRECTS
-      next_url = URI.join(url, response.headers['location']).to_s
+      next_url = URI.join(url, response['location']).to_s
       return fetch(next_url, redirect_depth: redirect_depth + 1)
     end
-    return nil if response.code != 200
+    return nil if response.code.to_i != 200
     doc = Nokogiri::HTML::Document.parse(response.body)
 
     title = [doc.css('meta[property="og:title"]').attr('content')&.text,
@@ -89,6 +92,63 @@ module LinkPreviewService
     resolved.none? { |ip| blocked_ip?(ip) }
   rescue URI::InvalidURIError, Resolv::ResolvError
     false
+  end
+
+  # Fetch a URL's raw body as an IO, applying the same SSRF protection as the
+  # link-preview fetch (single DNS resolution, IP-range allow-list, connection
+  # pinned to the validated address). Returns nil if the URL is unsafe or the
+  # request fails. Used for fetching remote avatars/logos.
+  def self.safe_open(url, max_bytes: 10.megabytes)
+    response = pinned_get(url)
+    return nil unless response && response.code.to_i == 200
+    body = response.body.to_s
+    return nil if body.bytesize > max_bytes
+
+    StringIO.new(body)
+  end
+
+  # Performs an HTTP GET while defeating DNS rebinding: the host is resolved
+  # exactly once, every resolved address is checked against BLOCKED_IP_RANGES,
+  # and the socket is pinned (via Net::HTTP#ipaddr=) to the address we
+  # validated — so HTTParty/Net::HTTP cannot re-resolve to an internal IP
+  # between the check and the connection. Returns a Net::HTTPResponse or nil.
+  def self.pinned_get(url)
+    uri = URI.parse(url.to_s)
+    return nil unless %w[http https].include?(uri.scheme)
+    return nil if uri.host.to_s.empty?
+
+    safe_ip = validated_ip(uri.host)
+    return nil unless safe_ip
+
+    http = Net::HTTP.new(uri.host, uri.port)
+    http.ipaddr = safe_ip
+    http.use_ssl = (uri.scheme == 'https')
+    http.open_timeout = REQUEST_TIMEOUT_SECONDS
+    http.read_timeout = REQUEST_TIMEOUT_SECONDS
+    http.start { |h| h.request(Net::HTTP::Get.new(uri)) }
+  rescue URI::InvalidURIError, SocketError, SystemCallError, Net::OpenTimeout, Net::ReadTimeout, OpenSSL::SSL::SSLError, IOError
+    nil
+  end
+
+  # Resolve host to a single address that is confirmed to be outside the
+  # blocked ranges. Rejects the host outright if ANY resolved address is
+  # blocked (matching the strict semantics of safe_to_fetch?). Handles literal
+  # IP hosts without a DNS lookup.
+  def self.validated_ip(host)
+    literal = begin
+      IPAddr.new(host)
+      true
+    rescue IPAddr::InvalidAddressError
+      false
+    end
+
+    ips = literal ? [host] : Resolv.getaddresses(host)
+    return nil if ips.empty?
+    return nil if ips.any? { |ip| blocked_ip?(ip) }
+
+    ips.first
+  rescue Resolv::ResolvError
+    nil
   end
 
   def self.blocked_ip?(ip_str)

--- a/app/services/link_preview_service.rb
+++ b/app/services/link_preview_service.rb
@@ -107,12 +107,19 @@ module LinkPreviewService
     StringIO.new(body)
   end
 
-  # Performs an HTTP GET while defeating DNS rebinding: the host is resolved
+  def self.pinned_get(url)
+    pinned_request(:get, url)
+  end
+
+  # Performs an HTTP request while defeating DNS rebinding: the host is resolved
   # exactly once, every resolved address is checked against BLOCKED_IP_RANGES,
   # and the socket is pinned (via Net::HTTP#ipaddr=) to the address we
-  # validated — so HTTParty/Net::HTTP cannot re-resolve to an internal IP
-  # between the check and the connection. Returns a Net::HTTPResponse or nil.
-  def self.pinned_get(url)
+  # validated — so Net::HTTP cannot re-resolve to an internal IP between the
+  # check and the connection. Redirects are NOT followed (callers that need to
+  # follow must re-validate each hop). Returns a Net::HTTPResponse or nil.
+  # Use this for ANY outbound request to a user/provider-controlled URL
+  # (link previews, chatbot webhooks/Matrix, remote avatars).
+  def self.pinned_request(method, url, headers: {}, body: nil, timeout: REQUEST_TIMEOUT_SECONDS)
     uri = URI.parse(url.to_s)
     return nil unless %w[http https].include?(uri.scheme)
     return nil if uri.host.to_s.empty?
@@ -123,10 +130,18 @@ module LinkPreviewService
     http = Net::HTTP.new(uri.host, uri.port)
     http.ipaddr = safe_ip
     http.use_ssl = (uri.scheme == 'https')
-    http.open_timeout = REQUEST_TIMEOUT_SECONDS
-    http.read_timeout = REQUEST_TIMEOUT_SECONDS
-    http.start { |h| h.request(Net::HTTP::Get.new(uri)) }
-  rescue URI::InvalidURIError, SocketError, SystemCallError, Net::OpenTimeout, Net::ReadTimeout, OpenSSL::SSL::SSLError, IOError
+    http.open_timeout = timeout
+    http.read_timeout = timeout
+
+    request_class = {
+      get: Net::HTTP::Get, post: Net::HTTP::Post, put: Net::HTTP::Put
+    }.fetch(method.to_sym)
+    request = request_class.new(uri)
+    headers.each { |k, v| request[k] = v }
+    request.body = body if body
+
+    http.start { |h| h.request(request) }
+  rescue URI::InvalidURIError, KeyError, SocketError, SystemCallError, Net::OpenTimeout, Net::ReadTimeout, OpenSSL::SSL::SSLError, IOError
     nil
   end
 

--- a/app/services/received_email_service.rb
+++ b/app/services/received_email_service.rb
@@ -101,6 +101,14 @@ class ReceivedEmailService
     if group = group_from_route_path(email.route_path)
       unless address_is_blocked(email, group)
         email.update(group_id: group.id)
+        # This route authenticates the actor solely from the (spoofable) From:
+        # header — so refuse to auto-author when the relay says the sender
+        # domain failed SPF/DKIM/DMARC. Treat as an unrecognised sender.
+        if email.sender_authentication_failed?
+          Rails.logger.info("rejecting unauthenticated sender for route: #{email.sender_email}, #{email.route_path}")
+          Events::UnknownSender.publish!(email) unless Event.where(kind: 'unknown_sender', eventable: email).exists?
+          return
+        end
         if actor = actor_from_email_and_group(email, group)
           Rails.logger.info("creating discussion from email: #{email.route_path}")
           DiscussionService.create(params: discussion_params(email), actor: actor)

--- a/app/workers/migrate_user_worker.rb
+++ b/app/workers/migrate_user_worker.rb
@@ -20,7 +20,10 @@ class MigrateUserWorker < ApplicationJob
     discussions: :author_id,
     events: :user_id,
     groups: :creator_id,
-    login_tokens: :user_id,
+    # NB: login_tokens are deliberately NOT migrated. They are one-time login
+    # credentials delivered to the source account's inbox; reassigning them to
+    # the destination would let a source-account holder log in as the
+    # destination. They are destroyed with the source user in RedactUserWorker.
     membership_requests: [:requestor_id, :responder_id],
     memberships: [:user_id, :inviter_id],
     notifications: :user_id,

--- a/app/workers/redact_user_worker.rb
+++ b/app/workers/redact_user_worker.rb
@@ -44,6 +44,9 @@ class RedactUserWorker < ApplicationJob
       PaperTrail::Version.where(item_type: 'User', item_id: user_id).delete_all
       Identity.where(user_id: user_id).delete_all
       Session.where(user_id: user_id).destroy_all
+      # Destroy any outstanding login credentials so a redacted/merged source
+      # account's pending login codes/magic links can never be redeemed.
+      LoginToken.where(user_id: user_id).delete_all
       MembershipRequest.where(requestor_id: user_id, responded_at: nil).destroy_all
     end
 

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -108,7 +108,10 @@ class Rack::Attack
     '/api/v1/contact_messages' => 10,
     '/api/v1/contact_requests' => 10,
     '/api/v1/discussion_readers' => 500,
-    '/rails/active_storage/direct_uploads' => 20
+    '/rails/active_storage/direct_uploads' => 20,
+    # The app's real upload route (the stock path is shadowed to the same
+    # controller); throttle it too or it falls through to only the global cap.
+    '/direct_uploads' => 20
   }
 
   # Throttle only creation (POST to the exact collection path). Updates and

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -339,6 +339,11 @@ Rails.application.routes.draw do
 
   get '/pie_chart', to: 'pie_chart#show'
   post '/direct_uploads', to: 'direct_uploads#create'
+  # Shadow the stock ActiveStorage direct-upload route (draw_routes stays on so
+  # blob/representation download routes keep working) with our guarded
+  # controller, so its auth + size + content-type checks can't be bypassed by
+  # targeting the engine path directly.
+  post '/rails/active_storage/direct_uploads', to: 'direct_uploads#create'
 
   get '/users/sign_in', to: redirect('/dashboard')
   get '/users/sign_up', to: redirect('/dashboard')

--- a/test/controllers/api/v1/announcements_controller_test.rb
+++ b/test/controllers/api/v1/announcements_controller_test.rb
@@ -127,6 +127,24 @@ class Api::V1::AnnouncementsControllerTest < ActionController::TestCase
     }.merge(extra), actor: @admin)
   end
 
+  test "audience voters is rejected for anonymous polls" do
+    poll = create_test_poll(anonymous: true)
+    get :audience, params: { poll_id: poll.id, recipient_audience: 'voters' }
+    assert_response :forbidden
+  end
+
+  test "audience non_voters is rejected for anonymous polls" do
+    poll = create_test_poll(anonymous: true)
+    get :audience, params: { poll_id: poll.id, recipient_audience: 'non_voters' }
+    assert_response :forbidden
+  end
+
+  test "audience voters still works for non-anonymous polls" do
+    poll = create_test_poll
+    get :audience, params: { poll_id: poll.id, recipient_audience: 'voters' }
+    assert_response :success
+  end
+
   test "poll create can add group members when members_can_add_guests=false" do
     hex = SecureRandom.hex(4)
     member = User.create!(name: "member#{hex}", email: "member#{hex}@example.com", username: "member#{hex}")

--- a/test/controllers/api/v1/events_controller_test.rb
+++ b/test/controllers/api/v1/events_controller_test.rb
@@ -99,6 +99,20 @@ class Api::V1::EventsControllerTest < ActionController::TestCase
     assert_response :not_found
   end
 
+  test "comment does not leak a comment from a different topic (IDOR)" do
+    # A comment lives in a discussion the actor is NOT allowed to see...
+    secret_comment = Comment.new(parent: discussions(:alien_discussion), body: "secret")
+    secret_event = CommentService.create(comment: secret_comment, actor: users(:alien))
+
+    # ...and the actor supplies a topic they CAN see plus the foreign comment id.
+    sign_in @user
+    get :comment, params: { discussion_id: @discussion.id, comment_id: secret_event.eventable.id }
+
+    # The comment_id must be scoped to the authorized topic, so this is a 404,
+    # not a leak of the secret comment's body.
+    assert_response :not_found
+  end
+
   test "index responds to per parameter" do
     sign_in @user
     3.times { CommentService.create(comment: Comment.new(parent: @discussion, body: "Test comment"), actor: @user) }

--- a/test/controllers/api/v1/profile_controller_test.rb
+++ b/test/controllers/api/v1/profile_controller_test.rb
@@ -108,4 +108,82 @@ class Api::V1::ProfileControllerTest < ActionController::TestCase
     refute_equal original_unsubscribe_token, @user.unsubscribe_token
     refute LoginToken.exists?(unused_login_token.id)
   end
+
+  # -- unsubscribe-token (restricted user) authorization --
+  # An attacker who obtains a victim's permanent unsubscribe_token (present in
+  # the footer of every notification email) must not be able to take over or
+  # destroy the account. These prove the restricted-user guardrails.
+
+  UNSUB = 'unsub-secret-token-for-tests'
+
+  test "restricted user cannot change password via update_profile" do
+    @user.update_columns(unsubscribe_token: UNSUB)
+    original_digest = @user.password_digest
+
+    post :update_profile, params: {
+      unsubscribe_token: UNSUB,
+      user: { password: 'attacker_password_123', password_confirmation: 'attacker_password_123' }
+    }, format: :json
+
+    assert_equal original_digest, @user.reload.password_digest, "restricted user must not change password"
+  end
+
+  test "restricted user cannot change email via update_profile" do
+    @user.update_columns(unsubscribe_token: UNSUB)
+    original_email = @user.email
+
+    post :update_profile, params: {
+      unsubscribe_token: UNSUB,
+      user: { email: 'attacker@evil.test' }
+    }, format: :json
+
+    assert_equal original_email, @user.reload.email, "restricted user must not change email"
+  end
+
+  test "restricted user cannot deactivate the account" do
+    @user.update_columns(unsubscribe_token: UNSUB, deactivated_at: nil)
+
+    post :deactivate, params: { unsubscribe_token: UNSUB }, format: :json
+
+    assert_response :forbidden
+    assert_nil @user.reload.deactivated_at
+  end
+
+  test "restricted user cannot redact/destroy the account" do
+    @user.update_columns(unsubscribe_token: UNSUB)
+
+    delete :destroy, params: { unsubscribe_token: UNSUB }, format: :json
+
+    assert_response :forbidden
+  end
+
+  test "restricted user cannot read the email_api_key" do
+    @user.update_columns(unsubscribe_token: UNSUB)
+
+    get :email_api_key, params: { unsubscribe_token: UNSUB }, format: :json
+
+    assert_response :forbidden
+  end
+
+  test "restricted user cannot reset the email_api_key" do
+    @user.update_columns(unsubscribe_token: UNSUB)
+    original = @user.email_api_key
+
+    post :reset_email_api_key, params: { unsubscribe_token: UNSUB }, format: :json
+
+    assert_response :forbidden
+    assert_equal original, @user.reload.email_api_key
+  end
+
+  test "restricted user CAN still update notification preferences" do
+    @user.update_columns(unsubscribe_token: UNSUB, email_when_mentioned: true)
+
+    post :update_profile, params: {
+      unsubscribe_token: UNSUB,
+      user: { email_when_mentioned: false }
+    }, format: :json
+
+    assert_response :success
+    assert_equal false, @user.reload.email_when_mentioned, "email preference update must still work"
+  end
 end

--- a/test/controllers/api/v1/sessions_controller_test.rb
+++ b/test/controllers/api/v1/sessions_controller_test.rb
@@ -71,7 +71,10 @@ class Api::V1::SessionsControllerTest < ActionController::TestCase
     assert_response :forbidden
   end
 
-  test "invalid login code attempts are counted before turnstile" do
+  test "invalid login code attempts are NOT counted when turnstile is not solved" do
+    # A wrong code with no turnstile token must be rejected at the turnstile
+    # gate WITHOUT burning the victim's remaining code attempts — otherwise an
+    # unauthenticated, captcha-less attacker could invalidate a victim's token.
     ENV['TURNSTILE_SECRET_KEY'] = 'test-secret'
     user = User.create!(email: "countbadcode@example.com", email_verified: true)
     token = LoginToken.create!(user: user)
@@ -79,17 +82,32 @@ class Api::V1::SessionsControllerTest < ActionController::TestCase
     post :create, params: { user: { email: user.email, code: token.code + 1 } }
 
     assert_response :forbidden
+    assert_equal 0, token.reload.failed_attempts
+  end
+
+  test "invalid login code attempts are counted once turnstile is solved" do
+    ENV['TURNSTILE_SECRET_KEY'] = 'test-secret'
+    WebMock.stub_request(:post, TurnstileService::SITEVERIFY_URL).
+      to_return(status: 200, body: { success: true }.to_json, headers: { 'Content-Type' => 'application/json' })
+    user = User.create!(email: "countbadcode2@example.com", email_verified: true)
+    token = LoginToken.create!(user: user)
+
+    post :create, params: { user: { email: user.email, code: token.code + 1, turnstile_token: "cf-ok" } }
+
+    assert_response :unauthorized
     assert_equal 1, token.reload.failed_attempts
   end
 
-  test "invalid login code attempts burn the token at the limit" do
+  test "invalid login code attempts burn the token at the limit once turnstile is solved" do
     ENV['TURNSTILE_SECRET_KEY'] = 'test-secret'
+    WebMock.stub_request(:post, TurnstileService::SITEVERIFY_URL).
+      to_return(status: 200, body: { success: true }.to_json, headers: { 'Content-Type' => 'application/json' })
     user = User.create!(email: "burnbadcode@example.com", email_verified: true)
     token = LoginToken.create!(user: user, failed_attempts: LoginToken::MAX_FAILED_CODE_ATTEMPTS - 1)
 
-    post :create, params: { user: { email: user.email, code: token.code + 1 } }
+    post :create, params: { user: { email: user.email, code: token.code + 1, turnstile_token: "cf-ok" } }
 
-    assert_response :forbidden
+    assert_response :unauthorized
     assert token.reload.used
     assert_not token.useable?
   end

--- a/test/controllers/api/v1/stances_controller_test.rb
+++ b/test/controllers/api/v1/stances_controller_test.rb
@@ -32,6 +32,16 @@ class Api::V1::StancesControllerTest < ActionController::TestCase
     assert stance.key?('order_at')
   end
 
+  test "users action returns no participants for anonymous polls" do
+    @poll.update!(anonymous: true)
+    sign_in @admin
+    get :users, params: { poll_id: @poll.id }
+    assert_response :success
+
+    json = JSON.parse(response.body)
+    assert_empty(json['users'] || [], "anonymous poll must not expose participants via users action")
+  end
+
   test "index does not allow unauthorized users" do
     outsider = User.create!(name: 'Outsider', email: "outsider#{SecureRandom.hex(4)}@example.com",
                             email_verified: true, username: "outsider#{SecureRandom.hex(4)}")

--- a/test/controllers/api/v1/stances_controller_test.rb
+++ b/test/controllers/api/v1/stances_controller_test.rb
@@ -76,15 +76,22 @@ class Api::V1::StancesControllerTest < ActionController::TestCase
     @poll.update!(anonymous: true, hide_results: 'until_closed')
     @poll.stances.first.update_columns(cast_at: 1.minute.ago)
     @poll.stances.last.update_columns(cast_at: 2.minutes.ago)
-    other_stance_ids = @poll.stances.where.not(participant_id: @admin.id).pluck(:id)
+    own_id = @poll.stances.find_by(participant_id: @admin.id).id
 
     sign_in @admin
     get :index, params: { poll_id: @poll.id }
     assert_response :success
 
     stances = JSON.parse(response.body)['stances']
-    assert_equal stances.map { |stance| stance['id'] }.sort, stances.map { |stance| stance['id'] }
-    stances.select { |stance| other_stance_ids.include?(stance['id']) }.each do |stance|
+
+    # Voting order must not be inferable: other voters' stances are exposed with
+    # opaque (non-creation-ordered) ids, so the response is not the id-sorted
+    # creation order.
+    creation_order = @poll.stances.latest.order(:id).pluck(:id)
+    refute_equal creation_order, stances.map { |stance| stance['id'] }
+
+    # Other voters' choices stay hidden until results are visible.
+    stances.reject { |stance| stance['id'] == own_id }.each do |stance|
       assert_not stance.key?('none_of_the_above')
       assert_not stance.key?('option_scores')
     end
@@ -342,5 +349,93 @@ class Api::V1::StancesControllerTest < ActionController::TestCase
       post :update, params: { id: stance.id, stance: stance_params }
     end
     assert_response :unprocessable_entity
+  end
+
+  # -- Anonymous-poll de-anonymization via stance id/order --
+  # The stance id is a creation-ordered primary key; if it (or the response
+  # order) is exposed for anonymous polls, a member can align stances with the
+  # member list and read each one's choice. These lock down both vectors.
+
+  test "index does not expose real stance ids of other voters in an anonymous poll" do
+    anon = anon_poll_with_voters(3)
+    voter = anon[:voters].first
+    sign_in voter
+
+    get :index, params: { poll_id: anon[:poll].id }
+    assert_response :success
+
+    exposed = JSON.parse(response.body)['stances'].map { |s| s['id'] }
+    real_ids = anon[:poll].stances.latest.pluck(:id)
+    own_real_id = anon[:poll].stances.latest.find_by(participant_id: voter.id).id
+
+    # The only real id present is the viewer's own (so they can still edit it);
+    # everyone else's is an opaque, non-creation-ordered token.
+    leaked = exposed & real_ids
+    assert_equal [own_real_id], leaked,
+      "anonymous poll leaked real stance ids #{(leaked - [own_real_id]).inspect} of other voters"
+  end
+
+  test "index returns anonymous stances in a scrambled (non-creation) order" do
+    anon = anon_poll_with_voters(4)
+    poll = anon[:poll]
+    voter = anon[:voters].first
+    sign_in voter
+
+    get :index, params: { poll_id: poll.id }
+    exposed = JSON.parse(response.body)['stances'].map { |s| s['id'] }
+
+    # Invert the opaque ids back to real ids to read the response's true order.
+    secret = Rails.application.secret_key_base
+    hmac_to_real = poll.stances.latest.pluck(:id).to_h do |id|
+      [OpenSSL::HMAC.hexdigest('SHA256', secret, "#{poll.id}:#{id}")[0, 20], id]
+    end
+    own_real_id = poll.stances.latest.find_by(participant_id: voter.id).id
+    response_real_order = exposed.map { |x| x == own_real_id ? own_real_id : hmac_to_real[x] }
+
+    creation_order = poll.stances.latest.order(:id).pluck(:id)
+    assert_not_equal creation_order, response_real_order,
+      "anonymous stances were returned in creation order — position reveals the voter"
+  end
+
+  test "anonymous voter's own stance keeps its real id so it stays editable" do
+    anon = anon_poll_with_voters(2)
+    voter = anon[:voters].first
+    own = anon[:poll].stances.latest.find_by(participant_id: voter.id)
+    sign_in voter
+
+    get :index, params: { poll_id: anon[:poll].id }
+    exposed = JSON.parse(response.body)['stances'].map { |s| s['id'] }
+    assert_includes exposed, own.id, "voter must still see their own stance by its real id"
+  end
+
+  private
+
+  def anon_poll_with_voters(count)
+    hex = SecureRandom.hex(4)
+    group = Group.new(name: "Anon#{hex}", group_privacy: 'secret', handle: "anon#{hex}")
+    group.creator = (creator = mk_voter("creator", hex))
+    group.save!
+    Membership.create!(user: creator, group: group, accepted_at: Time.current, admin: true)
+
+    voters = count.times.map { |i| v = mk_voter("v#{i}", hex); Membership.create!(user: v, group: group, accepted_at: Time.current); v }
+
+    poll = PollService.create(params: {
+      title: "Anon #{hex}", poll_type: "proposal", group_id: group.id,
+      anonymous: true, hide_results: 'off', specified_voters_only: false,
+      poll_option_names: %w[agree disagree abstain], closing_at: 5.days.from_now
+    }, actor: creator)
+
+    voters.each_with_index do |v, i|
+      stance = poll.stances.undecided.find_by(participant_id: v.id, latest: true)
+      option = poll.poll_options[i % 2]
+      StanceService.update(stance: stance, actor: v, params: { stance_choices_attributes: [{ poll_option_id: option.id }] })
+    end
+
+    { poll: poll, group: group, voters: voters }
+  end
+
+  def mk_voter(name, hex)
+    uname = "#{name}#{hex}".delete('_')
+    User.create!(name: "#{name}#{hex}", email: "#{name}#{hex}@example.com", username: uname, email_verified: true)
   end
 end

--- a/test/controllers/api/v1/versions_controller_test.rb
+++ b/test/controllers/api/v1/versions_controller_test.rb
@@ -16,6 +16,35 @@ class Api::V1::VersionsControllerTest < ActionController::TestCase
     assert_response :success
   end
 
+  test "show hides voter identity and changes for anonymous poll stance versions" do
+    admin = users(:admin)
+    user = users(:user)
+    discussion = discussions(:discussion)
+    poll = PollService.create(params: {
+      title: "Anon Poll",
+      poll_type: "proposal",
+      topic_id: discussion.topic.id,
+      poll_option_names: ["Agree", "Disagree"],
+      anonymous: true,
+      closing_at: 5.days.from_now
+    }, actor: admin)
+
+    stance = poll.stances.find_by(participant: user) || poll.stances.first
+    PaperTrail.request(whodunnit: user.id.to_s) do
+      stance.update!(reason: "first")
+      stance.update!(reason: "second")
+    end
+    assert stance.versions.any?, "expected a paper_trail version to exist"
+
+    sign_in user
+    get :show, params: { stance_id: stance.id, index: stance.versions.length - 1 }
+    assert_response :success
+
+    version = JSON.parse(response.body)['versions'].first
+    assert_not version.key?('whodunnit'), "anonymous poll version must not expose whodunnit (voter id)"
+    assert_not version.key?('object_changes'), "anonymous poll version must not expose object_changes (reason text)"
+  end
+
   test "show returns forbidden for discarded comment" do
     user = users(:user)
     discussion = discussions(:discussion)

--- a/test/controllers/direct_uploads_controller_test.rb
+++ b/test/controllers/direct_uploads_controller_test.rb
@@ -60,8 +60,8 @@ class DirectUploadsControllerTest < ActionController::TestCase
     assert_response :unprocessable_entity
   end
 
-  test "anonymous upload is treated as trial tier" do
-    post :create, params: blob_params(byte_size: DirectUploadsController::TRIAL_MAX_UPLOAD_BYTES + 1), format: :json
-    assert_response :unprocessable_entity
+  test "anonymous upload is rejected as unauthorized" do
+    post :create, params: blob_params(byte_size: 1024), format: :json
+    assert_response :unauthorized
   end
 end

--- a/test/extras/clients/matrix_test.rb
+++ b/test/extras/clients/matrix_test.rb
@@ -7,6 +7,13 @@ class Clients::MatrixTest < ActiveSupport::TestCase
     @client = Clients::Matrix.new(server: @server, access_token: @token)
   end
 
+  # Matrix delivery goes through the SSRF-guarded, IP-pinned client, which
+  # resolves the host once before connecting. Stub DNS so the (fake) test host
+  # resolves to a public address and the request proceeds.
+  def with_dns(&block)
+    Resolv.stub(:getaddresses, ->(_host) { ['93.184.216.34'] }, &block)
+  end
+
   def stub_join(room_id_or_alias, returned_room_id: nil)
     stub_request(:post, "#{@server}/_matrix/client/v3/join/#{CGI.escape(room_id_or_alias)}")
       .to_return(
@@ -31,9 +38,9 @@ class Clients::MatrixTest < ActiveSupport::TestCase
     stub_join(room_id)
     stub_send(room_id)
 
-    response = @client.send_text(room_id, "hello world")
+    response = with_dns { @client.send_text(room_id, "hello world") }
 
-    assert_equal 200, response.code
+    assert_equal 200, response.code.to_i
     assert_requested(:post, "#{@server}/_matrix/client/v3/join/#{CGI.escape(room_id)}")
   end
 
@@ -51,8 +58,8 @@ class Clients::MatrixTest < ActiveSupport::TestCase
       ))
       .to_return(status: 200, body: {event_id: "$evt"}.to_json)
 
-    response = @client.send_html(room_id, html)
-    assert_equal 200, response.code
+    response = with_dns { @client.send_html(room_id, html) }
+    assert_equal 200, response.code.to_i
   end
 
   test "send_text to a room alias resolves via join" do
@@ -61,7 +68,7 @@ class Clients::MatrixTest < ActiveSupport::TestCase
     stub_join(room_alias, returned_room_id: room_id)
     stub_send(room_id)
 
-    @client.send_text(room_alias, "test message")
+    with_dns { @client.send_text(room_alias, "test message") }
 
     assert_requested(:post, "#{@server}/_matrix/client/v3/join/#{CGI.escape(room_alias)}")
     assert_requested(:put, %r{/rooms/#{Regexp.escape(room_id)}/send/})
@@ -71,7 +78,7 @@ class Clients::MatrixTest < ActiveSupport::TestCase
     room_id = "!private999:example.com"
     stub_join(room_id)
 
-    result = @client.join_room(room_id)
+    result = with_dns { @client.join_room(room_id) }
 
     assert_equal room_id, result
     assert_requested(:post, "#{@server}/_matrix/client/v3/join/#{CGI.escape(room_id)}")
@@ -82,7 +89,7 @@ class Clients::MatrixTest < ActiveSupport::TestCase
     room_id = "!private456:example.com"
     stub_join(room_alias, returned_room_id: room_id)
 
-    result = @client.join_room(room_alias)
+    result = with_dns { @client.join_room(room_alias) }
 
     assert_equal room_id, result
   end
@@ -92,7 +99,7 @@ class Clients::MatrixTest < ActiveSupport::TestCase
     stub_join(room_id)
     stub_send(room_id)
 
-    @client.send_html(room_id, "<p>Secret message</p>")
+    with_dns { @client.send_html(room_id, "<p>Secret message</p>") }
 
     assert_requested(:post, "#{@server}/_matrix/client/v3/join/#{CGI.escape(room_id)}")
     assert_requested(:put, %r{/rooms/#{Regexp.escape(room_id)}/send/})
@@ -107,9 +114,22 @@ class Clients::MatrixTest < ActiveSupport::TestCase
     stub_request(:put, %r{https://matrix.example.com/_matrix/client/v3/rooms/.+/send/m.room.message/.+})
       .to_return(status: 200, body: {event_id: "$evt"}.to_json)
 
-    client.send_text(room_id, "trailing slash test")
+    with_dns { client.send_text(room_id, "trailing slash test") }
 
     assert_not_requested(:post, %r{https://matrix.example.com//_matrix})
     assert_not_requested(:put, %r{https://matrix.example.com//_matrix})
+  end
+
+  test "join_room to a host resolving to a blocked internal IP is not sent (SSRF guard)" do
+    room_id = "!x:example.com"
+    stub_join(room_id)
+
+    result = Resolv.stub(:getaddresses, ->(_host) { ['169.254.169.254'] }) do
+      @client.join_room(room_id)
+    end
+
+    # Falls back to the passed id and never connects to the internal address.
+    assert_equal room_id, result
+    assert_not_requested(:post, "#{@server}/_matrix/client/v3/join/#{CGI.escape(room_id)}")
   end
 end

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -133,7 +133,10 @@ class EventTest < ActiveSupport::TestCase
   end
 
   test "poll_created notifies webhook" do
-    Events::PollCreated.publish!(@poll, @poll.author)
+    # Webhook delivery now resolves + IP-pins the host (SSRF guard), so stub DNS.
+    Resolv.stub(:getaddresses, ->(_host) { ['93.184.216.34'] }) do
+      Events::PollCreated.publish!(@poll, @poll.author)
+    end
     assert_requested :post, @webhook_url, at_least_times: 1
   end
 

--- a/test/models/received_email_test.rb
+++ b/test/models/received_email_test.rb
@@ -1,0 +1,29 @@
+require 'test_helper'
+
+class ReceivedEmailTest < ActiveSupport::TestCase
+  def email_with(auth_results)
+    headers = { 'From' => 'alice@partner.example' }
+    headers['Authentication-Results'] = auth_results if auth_results
+    ReceivedEmail.new(headers: headers)
+  end
+
+  test "sender_authentication_failed? is true when DMARC fails" do
+    assert email_with('mx.loomio.com; spf=pass smtp.mailfrom=x; dkim=pass; dmarc=fail header.from=partner.example').sender_authentication_failed?
+  end
+
+  test "sender_authentication_failed? is true when both DKIM and SPF fail" do
+    assert email_with('mx.loomio.com; spf=fail smtp.mailfrom=x; dkim=fail header.d=partner.example').sender_authentication_failed?
+  end
+
+  test "sender_authentication_failed? is false when DMARC passes" do
+    assert_not email_with('mx.loomio.com; spf=pass; dkim=pass; dmarc=pass header.from=partner.example').sender_authentication_failed?
+  end
+
+  test "sender_authentication_failed? is false when only SPF fails but DKIM passes" do
+    assert_not email_with('mx.loomio.com; spf=fail; dkim=pass; dmarc=pass').sender_authentication_failed?
+  end
+
+  test "sender_authentication_failed? is false when the header is absent (cannot prove failure)" do
+    assert_not email_with(nil).sender_authentication_failed?
+  end
+end

--- a/test/services/chatbot_service_test.rb
+++ b/test/services/chatbot_service_test.rb
@@ -35,9 +35,37 @@ class ChatbotServiceTest < ActiveSupport::TestCase
     WebMock.stub_request(:post, matching_url).to_return(status: 200)
     WebMock.stub_request(:post, non_matching_url).to_return(status: 200)
 
-    ChatbotService.publish_event!(@event.id)
+    # Delivery now resolves + IP-pins the host (SSRF guard), so stub DNS.
+    Resolv.stub(:getaddresses, ->(host) { host == 'hooks.example.test' ? ['93.184.216.34'] : [] }) do
+      ChatbotService.publish_event!(@event.id)
+    end
 
     assert_requested :post, matching_url, times: 1
     assert_not_requested :post, non_matching_url
+  end
+
+  test "publish_event does not deliver to a webhook host that resolves to a blocked internal IP (SSRF guard)" do
+    internal_url = 'https://rebind.example.test/hook'
+
+    LinkPreviewService.stub(:safe_to_fetch?, true) do
+      Chatbot.create!(
+        name: 'Rebinding webhook',
+        group: @group,
+        author: @admin,
+        kind: 'webhook',
+        webhook_kind: 'slack',
+        server: internal_url,
+        event_kinds: [@event.kind]
+      )
+    end
+
+    WebMock.stub_request(:post, internal_url).to_return(status: 200)
+
+    # Host now resolves to the cloud-metadata address — delivery must be dropped.
+    Resolv.stub(:getaddresses, ->(_host) { ['169.254.169.254'] }) do
+      ChatbotService.publish_event!(@event.id)
+    end
+
+    assert_not_requested :post, internal_url
   end
 end

--- a/test/workers/migrate_user_worker_test.rb
+++ b/test/workers/migrate_user_worker_test.rb
@@ -108,4 +108,19 @@ class MigrateUserWorkerTest < ActiveSupport::TestCase
     assert @patrick.reload.deactivated_at.present?
     assert_equal 2, @jennifer.reload.sign_in_count
   end
+
+  test "does not migrate source login tokens to destination; destroys them" do
+    source_token = LoginToken.create!(user: @patrick)
+    token_id = source_token.id
+    source_code = source_token.code
+
+    # (the merge legitimately mints a fresh login token for the destination's
+    # own account via the accounts_merged email — that one is fine; what must
+    # NOT happen is the SOURCE's token/code becoming valid for the destination)
+    MigrateUserWorker.perform_later(@patrick.id, @jennifer.id)
+
+    assert_not LoginToken.exists?(token_id), "source login token must be destroyed on merge, not reassigned"
+    assert_not LoginToken.where(user_id: @jennifer.id, code: source_code).exists?,
+               "the source account's login code must not become valid for the destination"
+  end
 end

--- a/vue/src/i18n.js
+++ b/vue/src/i18n.js
@@ -36,7 +36,13 @@ export function setupI18n(options = {
   messages: {en},
   silentTranslationWarn: false,
   warnHtmlInMessage: 'off',
-  warnHtmlMessage: false
+  warnHtmlMessage: false,
+  // Escape HTML in interpolation parameters. Many translations are rendered
+  // with v-html and interpolate user-controlled values (discussion/poll
+  // titles, user names) — without this, a title like `<img onerror=…>` is a
+  // stored XSS. The message templates keep their own markup; only the injected
+  // params are escaped.
+  escapeParameterHtml: true
 }){
   const i18n = createI18n(options)
   setI18nLanguage(i18n, options.locale)

--- a/vue/src/shared/helpers/marked.js
+++ b/vue/src/shared/helpers/marked.js
@@ -2,6 +2,17 @@ import { marked } from 'marked';
 import { clone } from 'lodash-es';
 import parameterize from '@/shared/helpers/parameterize';
 
+// marked (v4) does no protocol filtering, and the server-side HTML sanitizer
+// never sees markdown link/image syntax — so `[x](javascript:...)` reaches the
+// DOM verbatim. Drop any href/src whose scheme isn't safe.
+const SAFE_SCHEME = /^(https?:|mailto:|tel:|ftp:|\/|#|\.|[^:]*$)/i;
+const safeUrl = function(url) {
+  // Strip control chars and whitespace (java\tscript:, leading newlines,
+  // spaces) before testing the scheme so obfuscated payloads can't slip past.
+  const trimmed = String(url == null ? '' : url).replace(/[\u0000-\u0020]+/g, '');
+  return SAFE_SCHEME.test(trimmed) ? url : '#';
+};
+
 export var customRenderer = function(opts) {
   const _super   = new marked.Renderer(opts);
   const renderer = clone(_super);
@@ -12,7 +23,8 @@ export var customRenderer = function(opts) {
 
   renderer.heading   = (text, level) => _super.heading(text, level, text, {slug: parameterize});
 
-  renderer.link      = (href, title, text) => _super.link(href, title, text).replace('<a ', '<a rel="ugc noreferrer" target="_blank" ');
+  renderer.link      = (href, title, text) => _super.link(safeUrl(href), title, text).replace('<a ', '<a rel="ugc noreferrer" target="_blank" ');
+  renderer.image     = (href, title, text) => _super.image(safeUrl(href), title, text);
 
   return renderer;
 };


### PR DESCRIPTION
Fixes from a security audit of the sign-in, authorization, invitation, and related surfaces. Each fix has regression tests; the full test suite passes (aside from two failures pre-existing on the brand branch and unrelated to these changes).

## Critical
- **Account takeover / destruction via `unsubscribe_token`.** The permanent per-user unsubscribe token (in every notification email) authenticates `current_user` on `profile`/`boot`/`polls`, but `restricted` only swapped the *serializer* — not the ability or which actions run. A token holder could change the victim's password/email, deactivate or redact the account, and read the `email_api_key`. `ProfileController` now blocks restricted users from destructive/credential actions and narrows `update_profile` to notification-preference fields only.
- **Zero-click stored XSS** via discussion/poll titles (and user names) rendered through a `v-html` event headline. Enabled `escapeParameterHtml` so interpolated params are escaped while message markup is preserved.

## High
- **Chatbot webhook/Matrix SSRF** — server URL validated only at save time, delivered via unpinned HTTParty (DNS-rebind / redirect TOCTOU). Delivery now goes through an IP-pinned client (`LinkPreviewService.pinned_request`).
- **Stored XSS** via `javascript:`/`data:` URIs in markdown links/images — added a scheme allow-list to the marked renderer.
- **Account-merge login-token takeover** — merge reassigned `login_tokens` to the destination; now they're kept with the source and destroyed on redaction.
- **Anonymous-poll voter leak** via `announcements#audience` (`recipient_audience=voters`/`non_voters`) — now rejected for anonymous polls.
- **Cross-topic comment IDOR** (`events#comment`) and **anonymous-poll de-anonymization** via `VersionSerializer`, `stances#users`, and a DNS-rebinding SSRF in link previews (first-pass commit).

## Medium / Low
- Inbound email `From:` spoofing on the group-handle route — refuse to auto-author when the relay reports SPF/DKIM/DMARC failure.
- Direct uploads: require authentication, shadow the stock ActiveStorage upload route with the guarded controller, fix the rack_attack throttle path.
- Login-code attempts no longer burned before the turnstile check.

## Known follow-up (not in this PR)
- Anonymous-poll voters can still be de-anonymized by correlating the exposed, creation-ordered stance `id` (index ordered by `stances.id`) with the member list plus the `poll_option_id` filter. A proof-of-concept exists; the fix (opaque/randomized stance identity + non-creation ordering for anonymous polls) is pending review.