### PR TITLE
Speed up permission-filtered search

### DIFF
--- a/app/controllers/api/v1/search_controller.rb
+++ b/app/controllers/api/v1/search_controller.rb
@@ -14,7 +14,18 @@ class Api::V1::SearchController < Api::V1::RestfulController
       rel = PgSearch.multisearch(params[:query]).where("group_id IN (:group_ids) OR discussion_id in (:discussion_ids)", group_ids: group_ids, discussion_ids: guest_discussion_ids)
     end
 
-    rel = rel.where(topic_id: TopicQuery.visible_to(user: current_user).select(:id))
+    visible_topic = TopicQuery
+      .visible_to(
+        user: current_user,
+        topic_id: PgSearch::Document.arel_table[:topic_id]
+      )
+      .select(:id)
+      .limit(1)
+      .offset(0)
+
+    # Keep this as a correlated lookup so PostgreSQL checks visibility only
+    # after using the full-text index to find matching search documents.
+    rel = rel.where(visible_topic.arel.exists)
     rel = rel.where(
       "pg_search_documents.discussion_id IS NULL OR pg_search_documents.discussion_id IN (?)",
       Discussion.kept.select(:id)

--- a/app/queries/topic_query.rb
+++ b/app/queries/topic_query.rb
@@ -13,8 +13,19 @@ class TopicQuery
                       tags: [],
                       or_subgroups: true,
                       only_direct: false,
-                      only_unread: false)
-    visible_scope(chain: chain, user: user, group_ids: group_ids, tags: tags, or_subgroups: or_subgroups, only_direct: only_direct, only_unread: only_unread, public_group_ids: nil)
+                      only_unread: false,
+                      topic_id: nil)
+    visible_scope(
+      chain: chain,
+      user: user,
+      group_ids: group_ids,
+      tags: tags,
+      or_subgroups: or_subgroups,
+      only_direct: only_direct,
+      only_unread: only_unread,
+      public_group_ids: nil,
+      topic_id: topic_id
+    )
   end
 
   def self.relevant_to(chain: start,
@@ -34,7 +45,8 @@ class TopicQuery
                          or_subgroups:,
                          only_direct:,
                          only_unread:,
-                         public_group_ids:)
+                         public_group_ids:,
+                         topic_id: nil)
     group_ids = Array(group_ids).compact.map(&:to_i)
     public_group_ids = Array(public_group_ids).compact.map(&:to_i) if public_group_ids
 
@@ -78,6 +90,7 @@ class TopicQuery
       .where(discarded_at: nil)
 
     arms = [arm1, arm2].map do |arm|
+      arm = arm.where(Topic.arel_table[:id].eq(topic_id)) if topic_id
       arm = arm.where("topics.group_id IN (?)", group_ids) if group_ids.any?
       arm = arm.where("topics.group_id IS NULL")            if only_direct
       arm = arm.where("topics.tags @> ARRAY[?]::varchar[]", tags) if tags.any?

--- a/test/controllers/api/v1/search_controller_test.rb
+++ b/test/controllers/api/v1/search_controller_test.rb
@@ -81,6 +81,73 @@ class Api::V1::SearchControllerTest < ActionController::TestCase
     refute results.any? { |result| result['discussion_key'] == @discussion.key }
   end
 
+  test "does not return records from a discarded topic" do
+    @discussion.topic.update_columns(discarded_at: Time.current)
+    assert PgSearch::Document.where(topic_id: @discussion.topic.id).exists?
+
+    sign_in @user
+    get :index, params: { query: 'findme' }
+
+    results = JSON.parse(response.body)['search_results']
+    refute results.any? { |result| result['discussion_key'] == @discussion.key }
+  end
+
+  test "respects parent member access to private subgroup discussions" do
+    subgroup = groups(:subgroup)
+    subgroup.update_columns(
+      is_visible_to_parent_members: true,
+      parent_members_can_see_discussions: false
+    )
+    discussion = DiscussionService.create(
+      params: {
+        group_id: subgroup.id,
+        title: "findprivatesubgroup",
+        private: true
+      },
+      actor: users(:admin)
+    )
+    discussion.update_pg_search_document
+
+    sign_in users(:member)
+    get :index, params: { query: "findprivatesubgroup" }
+
+    results = JSON.parse(response.body)['search_results']
+    refute results.any? { |result| result['searchable_id'] == discussion.id }
+
+    subgroup.update_columns(parent_members_can_see_discussions: true)
+    get :index, params: { query: "findprivatesubgroup" }
+
+    results = JSON.parse(response.body)['search_results']
+    assert results.any? { |result| result['searchable_id'] == discussion.id }
+  end
+
+  test "returns direct discussions only to guests" do
+    discussion = DiscussionService.build(
+      params: {
+        title: "findguestdiscussion",
+        private: true,
+        description_format: "html"
+      },
+      actor: users(:admin)
+    )
+    discussion.save!(validate: false)
+    discussion.create_missing_created_event!
+    discussion.add_guest!(@user, discussion.author)
+    discussion.update_pg_search_document
+
+    sign_in @user
+    get :index, params: { query: "findguestdiscussion" }
+
+    results = JSON.parse(response.body)['search_results']
+    assert results.any? { |result| result['searchable_id'] == discussion.id }
+
+    sign_in users(:alien)
+    get :index, params: { query: "findguestdiscussion" }
+
+    results = JSON.parse(response.body)['search_results']
+    refute results.any? { |result| result['searchable_id'] == discussion.id }
+  end
+
   test "returns group filtered records" do
     sign_in @user
 


### PR DESCRIPTION
## Summary

- apply topic visibility as a correlated lookup after full-text candidates are found
- constrain both TopicQuery visibility arms by candidate topic ID
- preserve discarded-topic, private subgroup, and direct guest access rules

## Performance

For query Shrimp ordered by authored_at descending as user 1 against 4.95 million search documents:

- previous plan: approximately 361-442 ms after buffer churn
- updated plan: approximately 99-103 ms after buffer churn and 4.6 ms warm
- returned search document unchanged

The previous plan enumerated 25,976 visible topics and repeated the full-text bitmap intersection for each topic. The updated plan uses the full-text index first and checks visibility for the resulting candidates.

## Security review

Search visibility is an access boundary. Controller regression coverage verifies:

- stale discarded discussions remain hidden
- discarded topics remain hidden
- private subgroup discussions follow parent_members_can_see_discussions
- direct discussions are returned only to invited guests

Brakeman reports no security warnings.

## Tests

- bin/rails test test/controllers/api/v1/search_controller_test.rb test/queries/topic_query_test.rb
- 26 runs, 68 assertions, 0 failures, 0 errors