### PR TITLE
Include non-secret subgroups in parent group exports

### DIFF
--- a/app/services/group_service.rb
+++ b/app/services/group_service.rb
@@ -173,8 +173,13 @@ module GroupService
   end
 
   def self.export(group: , actor: )
-    actor.ability.authorize! :show, group
+    actor.ability.authorize! :export, group
     group_ids = actor.groups.where(id: group.all_groups).pluck(:id)
+
+    if group.is_parent? && group.admins.exists?(actor.id)
+      group_ids |= group.subgroups.reject { |subgroup| subgroup.group_privacy == 'secret' }.map(&:id)
+    end
+
     Sentry.metrics.count("group.export")
     GroupExportWorker.perform_later(group_ids, group.name, actor.id)
   end

--- a/test/services/group_service_test.rb
+++ b/test/services/group_service_test.rb
@@ -55,6 +55,33 @@ class GroupServiceTest < ActiveSupport::TestCase
     refute publications.any? { |models, options| models == [subgroup] && options[:group_id] == parent.id }
   end
 
+  test "exports open and closed subgroups for a parent group admin" do
+    parent = create_parent_group(group_privacy: 'secret')
+    closed_subgroup = create_subgroup(parent: parent, group_privacy: 'closed')
+    open_subgroup = create_subgroup(parent: parent, group_privacy: 'open')
+    secret_subgroup = create_subgroup(parent: parent, group_privacy: 'secret')
+    joined_secret_subgroup = create_subgroup(parent: parent, group_privacy: 'secret')
+    joined_secret_subgroup.add_member!(@user, inviter: joined_secret_subgroup.creator)
+
+    group_ids = capture_group_export_ids(parent, @user)
+
+    assert_includes group_ids, parent.id
+    assert_includes group_ids, closed_subgroup.id
+    assert_includes group_ids, open_subgroup.id
+    assert_includes group_ids, joined_secret_subgroup.id
+    refute_includes group_ids, secret_subgroup.id
+  end
+
+  test "only group admins can export a group" do
+    parent = create_parent_group(group_privacy: 'secret')
+    member = users(:member)
+    parent.add_member!(member, inviter: @user)
+
+    assert_raises CanCan::AccessDenied do
+      GroupService.export(group: parent, actor: member)
+    end
+  end
+
   test "does not reparent a group on update" do
     group = Group.create!(
       name: "Managed Group",
@@ -224,6 +251,23 @@ class GroupServiceTest < ActiveSupport::TestCase
       name: "Parent group #{SecureRandom.hex(4)}",
       group_privacy: group_privacy
     ).tap { |group| group.add_admin!(@user) }
+  end
+
+  def create_subgroup(parent:, group_privacy:)
+    Group.create!(
+      name: "Subgroup #{SecureRandom.hex(4)}",
+      parent: parent,
+      group_privacy: group_privacy
+    )
+  end
+
+  def capture_group_export_ids(group, actor)
+    group_ids = nil
+    perform_later = ->(ids, _name, _actor_id) { group_ids = ids }
+    GroupExportWorker.stub(:perform_later, perform_later) do
+      GroupService.export(group: group, actor: actor)
+    end
+    group_ids
   end
 
   def assert_subgroup_published_to_parent(subgroup, parent)


### PR DESCRIPTION
## Summary

- include open and closed subgroups when a parent-group admin exports the parent group
- retain membership requirements for secret subgroups
- enforce export authorization at the GroupService boundary
- add focused export-scope and authorization tests

Closes #12705

## Security review

Parent-group administrators can export open and closed subgroups without first joining them. Secret subgroups are exported only when the exporter is a member, and archived subgroups remain excluded. The expanded access applies only when the exporter is an actual admin member of the parent group.

## Testing

- bin/rails test test/services/group_service_test.rb
- 13 runs, 30 assertions, 0 failures, 0 errors
- Brakeman: 0 security warnings
- Bundler Audit: no vulnerabilities

## Agent use

Implementation, tests, and the initial PR description were prepared with OpenAI Codex. The changes were verified with the focused Rails test suite and repository security checks.