### PR TITLE
Filter reaction batches by visibility

### DIFF
--- a/app/controllers/api/v1/reactions_controller.rb
+++ b/app/controllers/api/v1/reactions_controller.rb
@@ -13,8 +13,7 @@ class Api::V1::ReactionsController < Api::V1::RestfulController
       next unless params.has_key? key
       params[key] = params[key].split('x').map(&:to_i)
     end
-    ReactionQuery.authorize!(user: current_user, params: params)
-    self.collection = ReactionQuery.unsafe_where(params)
+    self.collection = ReactionQuery.visible_where(user: current_user, params: params)
     respond_with_collection
   end
 

--- a/app/queries/reaction_query.rb
+++ b/app/queries/reaction_query.rb
@@ -3,34 +3,61 @@ class ReactionQuery
     Reaction.includes(:user)
   end
 
-  def self.authorize!(user: LoggedOutUser.new, chain: start, params: )
-    comment_topic_ids = []
-    discussion_ids    = []
-    poll_ids          = []
+  def self.visible_where(user: LoggedOutUser.new, params:)
+    ids_requested = {
+      comment_ids:    Array(params[:comment_ids]),
+      discussion_ids: Array(params[:discussion_ids]),
+      outcome_ids:    Array(params[:outcome_ids]),
+      poll_ids:       Array(params[:poll_ids]),
+      stance_ids:     Array(params[:stance_ids])
+    }
 
-    if params[:comment_ids]
-      comment_topic_ids.concat(
-        Comment.joins(:events)
-               .where(comments: { id: params[:comment_ids] })
-               .where.not(events: { topic_id: nil })
-               .pluck('events.topic_id')
-      )
-    end
-    discussion_ids.concat(params[:discussion_ids]) if params[:discussion_ids]
+    comment_topic_ids = Comment.joins(:events)
+                               .where(comments: { id: ids_requested[:comment_ids] })
+                               .where.not(events: { topic_id: nil })
+                               .distinct
+                               .pluck('events.topic_id')
+    topic_ids_visible = TopicQuery.visible_to(user: user)
+                                  .where(id: comment_topic_ids)
+                                  .except(:includes)
+                                  .ids
 
-    poll_ids.concat(Stance.where(id: params[:stance_ids]).pluck(:poll_id)) if params[:stance_ids]
-    poll_ids.concat(Outcome.where(id: params[:outcome_ids]).pluck(:poll_id)) if params[:outcome_ids]
-    poll_ids.concat(params[:poll_ids]) if params[:poll_ids]
+    discussion_ids_visible = TopicQuery.visible_to(user: user)
+                                       .where(
+                                         topicable_type: 'Discussion',
+                                         topicable_id: ids_requested[:discussion_ids]
+                                       )
+                                       .except(:includes)
+                                       .pluck(:topicable_id)
 
-    comment_topic_ids.uniq!
-    discussion_ids.uniq!
-    poll_ids.uniq!
+    poll_ids_requested = ids_requested[:poll_ids]
+    poll_ids_requested += Outcome.where(id: ids_requested[:outcome_ids]).pluck(:poll_id)
+    poll_ids_requested += Stance.where(id: ids_requested[:stance_ids]).pluck(:poll_id)
+    poll_ids_visible = PollQuery.visible_to(user: user)
+                                .where(id: poll_ids_requested.uniq)
+                                .except(:includes)
+                                .ids
+    stance_ids_visible = Stance.joins(:poll)
+                               .where(id: ids_requested[:stance_ids], poll_id: poll_ids_visible)
+                               .where(
+                                 "polls.anonymous = TRUE OR polls.hide_results != :until_closed OR " \
+                                 "polls.closed_at IS NOT NULL OR stances.participant_id = :user_id",
+                                 until_closed: Poll.hide_results[:until_closed],
+                                 user_id: user.id || 0
+                               )
+                               .ids
 
-    if (TopicQuery.visible_to(user: user).where(id: comment_topic_ids).count != comment_topic_ids.length) ||
-       (PollQuery.visible_to(user: user).where(id: poll_ids).count != poll_ids.length) ||
-       (TopicQuery.visible_to(user: user).where(topicable_type: 'Discussion', topicable_id: discussion_ids).count != discussion_ids.length)
-      raise CanCan::AccessDenied.new
-    end
+    unsafe_where(
+      comment_ids: Comment.joins(:events)
+                          .where(comments: { id: ids_requested[:comment_ids] })
+                          .where(events: { topic_id: topic_ids_visible })
+                          .distinct
+                          .ids,
+      discussion_ids: discussion_ids_visible,
+      outcome_ids: Outcome.where(id: ids_requested[:outcome_ids], poll_id: poll_ids_visible).ids,
+      poll_ids: ids_requested[:poll_ids] & poll_ids_visible,
+      stance_ids: stance_ids_visible
+    )
   end
 
   def self.unsafe_where(params)
@@ -48,4 +75,6 @@ class ReactionQuery
        (reactable_type = 'Stance'     AND reactable_id IN (:stance_ids)) OR
        (reactable_type = 'Poll'       AND reactable_id IN (:poll_ids))", ids)
   end
+
+  private_class_method :unsafe_where
 end

--- a/test/controllers/api/v1/reactions_controller_test.rb
+++ b/test/controllers/api/v1/reactions_controller_test.rb
@@ -168,27 +168,125 @@ class Api::V1::ReactionsControllerTest < ActionController::TestCase
     assert_response :forbidden
   end
 
-  test "index denies access correctly" do
-    author = users(:admin)
+  test "index filters inaccessible discussions and comments from a mixed batch" do
+    user = users(:admin)
+    inaccessible_user = users(:alien)
     discussion = discussions(:discussion)
-
-    comment = Comment.new(body: "Test comment", parent: discussion, author: author)
-    CommentService.create(comment: comment, actor: author)
-
-    Reaction.create!(user: author, reactable: comment, reaction: '👍')
-    Reaction.create!(user: author, reactable: discussion, reaction: '👍')
-
-    # Create a user who is NOT a member of the group
-    unauthorized_user = User.create!(
-      name: "Unauthorized User 2",
-      email: "unauthorized2@example.com",
-      username: "unauthorized2",
-      password_digest: "$2a$12$K3E5h0VGlqmXL8HqWw7mIe3qP0XjQSfZ1jK4PqYX7Qq5N9YK6L4/K",
-      email_verified: true
+    inaccessible_discussion = discussions(:alien_discussion)
+    comment = Comment.new(body: "Visible comment", parent: discussion, author: user)
+    inaccessible_comment = Comment.new(
+      body: "Inaccessible comment",
+      parent: inaccessible_discussion,
+      author: inaccessible_user
     )
+    CommentService.create(comment: comment, actor: user)
+    CommentService.create(comment: inaccessible_comment, actor: inaccessible_user)
 
-    sign_in unauthorized_user
-    get :index, params: { comment_ids: comment.id, discussion_ids: discussion.id }
-    assert_response :forbidden
+    reactions_visible = [
+      Reaction.create!(user: user, reactable: comment, reaction: '👍'),
+      Reaction.create!(user: user, reactable: discussion, reaction: '👍')
+    ]
+    Reaction.create!(user: inaccessible_user, reactable: inaccessible_comment, reaction: '👍')
+    Reaction.create!(user: inaccessible_user, reactable: inaccessible_discussion, reaction: '👍')
+
+    sign_in user
+    get :index, params: {
+      comment_ids: [comment.id, inaccessible_comment.id].join('x'),
+      discussion_ids: [discussion.id, inaccessible_discussion.id].join('x')
+    }
+
+    assert_response :success
+    assert_equal reactions_visible.map(&:id).sort, response_reaction_ids
+  end
+
+  test "index filters inaccessible polls outcomes and stances from a mixed batch" do
+    user = users(:admin)
+    inaccessible_user = users(:alien)
+    poll = create_poll(topic: discussions(:discussion).topic, actor: user)
+    inaccessible_poll = create_poll(topic: discussions(:alien_discussion).topic, actor: inaccessible_user)
+    outcome = create_outcome(poll: poll, actor: user)
+    inaccessible_outcome = create_outcome(poll: inaccessible_poll, actor: inaccessible_user)
+    stance = create_stance(poll: poll, actor: user)
+    inaccessible_stance = create_stance(poll: inaccessible_poll, actor: inaccessible_user)
+
+    reactions_visible = [poll, outcome, stance].map do |reactable|
+      Reaction.create!(user: user, reactable: reactable, reaction: '👍')
+    end
+    [inaccessible_poll, inaccessible_outcome, inaccessible_stance].each do |reactable|
+      Reaction.create!(user: inaccessible_user, reactable: reactable, reaction: '👍')
+    end
+
+    sign_in user
+    get :index, params: {
+      poll_ids: [poll.id, inaccessible_poll.id].join('x'),
+      outcome_ids: [outcome.id, inaccessible_outcome.id].join('x'),
+      stance_ids: [stance.id, inaccessible_stance.id].join('x')
+    }
+
+    assert_response :success
+    assert_equal reactions_visible.map(&:id).sort, response_reaction_ids
+  end
+
+  test "index only returns public reactions to signed out users" do
+    user = users(:admin)
+    discussion = discussions(:public_discussion)
+    inaccessible_discussion = discussions(:discussion)
+    reactions_visible = [Reaction.create!(user: user, reactable: discussion, reaction: '👍')]
+    Reaction.create!(user: user, reactable: inaccessible_discussion, reaction: '👍')
+
+    get :index, params: { discussion_ids: [discussion.id, inaccessible_discussion.id].join('x') }
+
+    assert_response :success
+    assert_equal reactions_visible.map(&:id), response_reaction_ids
+  end
+
+  test "index filters other participants' stance reactions while results are hidden" do
+    user = users(:admin)
+    participant = users(:user)
+    poll = create_poll(topic: discussions(:discussion).topic, actor: user)
+    poll.update!(hide_results: 'until_closed')
+    stance = create_stance(poll: poll, actor: user)
+    inaccessible_stance = create_stance(poll: poll, actor: participant)
+    reaction_visible = Reaction.create!(user: user, reactable: stance, reaction: '👍')
+    Reaction.create!(user: participant, reactable: inaccessible_stance, reaction: '👍')
+
+    sign_in user
+    get :index, params: { stance_ids: [stance.id, inaccessible_stance.id].join('x') }
+
+    assert_response :success
+    assert_equal [reaction_visible.id], response_reaction_ids
+  end
+
+  private
+
+  def create_poll(topic:, actor:)
+    PollService.create(params: {
+      title: "Test Poll",
+      poll_type: "proposal",
+      topic_id: topic.id,
+      closing_at: 5.days.from_now,
+      poll_option_names: %w[agree disagree]
+    }, actor: actor)
+  end
+
+  def create_outcome(poll:, actor:)
+    poll.update!(closed_at: 1.day.ago)
+    outcome = Outcome.new(statement: "Test outcome", poll: poll, author: actor)
+    OutcomeService.create(outcome: outcome, actor: actor)
+    outcome
+  end
+
+  def create_stance(poll:, actor:)
+    stance = poll.stances.latest.find_or_initialize_by(participant: actor)
+    stance.assign_attributes(
+      cast_at: Time.current,
+      stance_choices_attributes: [{ poll_option_id: poll.poll_options.first.id }]
+    )
+    stance.save!
+    stance
+  end
+
+  def response_reaction_ids
+    JSON.parse(response.body)['reactions'].pluck('id').sort
   end
 end


### PR DESCRIPTION
## Summary

- filter mixed reaction batches to records visible to the current user instead of rejecting the whole request
- preserve poll-level reactions when poll results are hidden while restricting reactions on other participants' hidden stances
- cover discussions, comments, polls, outcomes, stances, and signed-out access

Fixes LOOMIO-5X

## Security review

Visibility is enforced in the shared server-side query using TopicQuery and PollQuery. Inaccessible records are omitted, and hidden non-anonymous stance reactions remain limited to the current participant until results are visible. Anonymous polls retain their existing non-identifying stance visibility.

## Verification

- bin/rails test test/controllers/api/v1/reactions_controller_test.rb
- 12 runs, 20 assertions, 0 failures, 0 errors
- Brakeman: 0 warnings
- Bundler Audit: no vulnerabilities

AI-assisted by Codex (GPT-5).