### PR TITLE
Add multilingual typo-tolerant search

### DIFF
--- a/app/controllers/api/v1/search_controller.rb
+++ b/app/controllers/api/v1/search_controller.rb
@@ -3,16 +3,27 @@ class Api::V1::SearchController < Api::V1::RestfulController
     guest_discussion_ids = Topic.where(id: current_user.guest_topic_ids, topicable_type: 'Discussion').pluck(:topicable_id)
 
     if group_or_org_id.to_i == 0
-      rel = PgSearch.multisearch(params[:query]).where("group_id is null and discussion_id IN (:discussion_ids)", discussion_ids: guest_discussion_ids)
+      rel = PgSearch::Document.where("group_id is null and discussion_id IN (:discussion_ids)", discussion_ids: guest_discussion_ids)
     end
 
     if group_or_org_id.to_i > 0
-      rel = PgSearch.multisearch(params[:query]).where("group_id IN (:group_ids)", group_ids: group_ids)
+      rel = PgSearch::Document.where("group_id IN (:group_ids)", group_ids: group_ids)
     end
 
     if group_or_org_id.blank?
-      rel = PgSearch.multisearch(params[:query]).where("group_id IN (:group_ids) OR discussion_id in (:discussion_ids)", group_ids: group_ids, discussion_ids: guest_discussion_ids)
+      rel = PgSearch::Document.where("group_id IN (:group_ids) OR discussion_id in (:discussion_ids)", group_ids: group_ids, discussion_ids: guest_discussion_ids)
     end
+
+    if params[:tag]
+      tag_topic_ids = Topic.where(group_id: group_ids).where("tags @> ARRAY[?]::varchar[]", Array(params[:tag])).pluck(:id)
+      rel = rel.where(topic_id: tag_topic_ids)
+    end
+
+    if %w[Discussion Comment Poll Stance Outcome].include?(params[:type])
+      rel = rel.where(searchable_type: params[:type])
+    end
+
+    candidate_rel = rel
 
     visible_topic = TopicQuery
       .visible_to(
@@ -41,24 +52,12 @@ class Api::V1::SearchController < Api::V1::RestfulController
       search_documents[:discussion_id].eq(nil).or(kept_discussion.arel.exists)
     )
 
-    if params[:tag]
-      tag_topic_ids = Topic.where(group_id: group_ids).where("tags @> ARRAY[?]::varchar[]", Array(params[:tag])).pluck(:id)
-      rel = rel.where(topic_id: tag_topic_ids)
-    end
-
-    if %w[Discussion Comment Poll Stance Outcome].include?(params[:type])
-      rel = rel.where(searchable_type: params[:type])
-    end
-
-    if params[:order] == 'authored_at_desc'
-      rel = rel.reorder('authored_at desc')
-    end
-
-    if params[:order] == 'authored_at_asc'
-      rel = rel.reorder('authored_at asc')
-    end
-
-    results = rel.limit(20).with_pg_search_highlight.all
+    results = SearchQuery.new(
+      relation: rel,
+      candidate_relation: candidate_rel,
+      query: params[:query],
+      order: params[:order]
+    ).results
     # results = results.order().offset().limit()
 
     groups = access_by_id(Group.where(id: results.map(&:group_id)))
@@ -72,7 +71,7 @@ class Api::V1::SearchController < Api::V1::RestfulController
     )
 
     stance_events = access_by_id(
-      Event.where("topic_id is not null").where(eventable_type: "Stance", eventable_id: results.filter {|r| r.searchable_type == 'Stance'}.map(&:searchable_id)),
+      Event.where("topic_id is not null").where(eventable_type: "Stance", eventable_id: results.filter { |r| r.searchable_type == 'Stance' }.map(&:searchable_id)),
       :eventable_id
     )
 

--- a/app/services/search_query.rb
+++ b/app/services/search_query.rb
@@ -1,0 +1,179 @@
+class SearchQuery
+  RESULT_LIMIT = 20
+  FUZZY_TERM_LENGTH_MIN = 4
+  FUZZY_TERM_LENGTH_MAX = 64
+  FUZZY_TERMS_MAX = 8
+  FUZZY_ALTERNATIVES_MAX = 3
+  FUZZY_CANDIDATES_MAX = 200
+  FUZZY_SIMILARITY_MIN = 0.25
+  TOKEN_PATTERN = /[\p{L}\p{N}]+(?:['’_-][\p{L}\p{N}]+)*/
+
+  def initialize(relation:, candidate_relation:, query:, order: nil)
+    @relation = relation
+    @candidate_relation = candidate_relation
+    @query = query.to_s
+    @order = order
+  end
+
+  def results
+    exact = exact_relation.limit(RESULT_LIMIT).with_pg_search_highlight.to_a
+    return exact unless fuzzy_search?
+
+    if authored_order?
+      fuzzy = fuzzy_results(limit: RESULT_LIMIT, excluding: exact.map(&:id))
+      sort_by_authored_at(exact + fuzzy).first(RESULT_LIMIT)
+    elsif exact.length < RESULT_LIMIT
+      exact + fuzzy_results(limit: RESULT_LIMIT - exact.length, excluding: exact.map(&:id))
+    else
+      exact
+    end
+  end
+
+  private
+
+  attr_reader :relation, :candidate_relation, :query, :order
+
+  def exact_relation
+    apply_authored_order(PgSearch.multisearch(query).merge(relation))
+  end
+
+  def fuzzy_results(limit:, excluding:)
+    PgSearch::Document.transaction(requires_new: true) do
+      PgSearch::Document.connection.execute(
+        "SET LOCAL pg_trgm.similarity_threshold = '#{FUZZY_SIMILARITY_MIN}'"
+      )
+
+      alternatives = fuzzy_alternatives
+      next [] unless alternatives.values.any? { |words| words.length > 1 }
+
+      fuzzy_relation(alternatives: alternatives, excluding: excluding).limit(limit).to_a
+    end
+  end
+
+  def fuzzy_relation(alternatives:, excluding:)
+    query_groups = terms.map { |term| tsquery_group(alternatives.fetch(term, [ term ])) }
+    combined_query = query_groups.reduce { |left, right| Arel::Nodes::InfixOperation.new('||', left, right) }
+    match_conditions = query_groups
+      .map { |group| Arel::Nodes::InfixOperation.new('@@', documents[:ts_content], group) }
+      .reduce(&:and)
+    rank = query_groups
+      .map { |group| Arel::Nodes::NamedFunction.new('ts_rank', [ documents[:ts_content], group ]) }
+      .reduce { |left, right| Arel::Nodes::Addition.new(left, right) }
+    highlight = Arel::Nodes::NamedFunction.new(
+      'ts_headline',
+      [
+        Arel::Nodes.build_quoted('simple'),
+        documents[:content],
+        combined_query,
+        Arel::Nodes.build_quoted('StartSel = "<b>", StopSel = "</b>"')
+      ]
+    )
+
+    candidates = candidate_relation.where(match_conditions)
+    candidates = candidates.where.not(id: excluding) if excluding.any?
+    candidates = candidates.select(:id)
+    candidates = if authored_order?
+      apply_authored_order(candidates)
+    else
+      candidates.reorder(rank.desc, :id)
+    end
+    candidates = candidates.limit(FUZZY_CANDIDATES_MAX)
+    candidate_ids = candidate_ids_without_anonymous_stances(candidates)
+
+    rel = relation.where(id: candidate_ids)
+    rel = rel.where.not(id: excluding) if excluding.any?
+    rel = rel.select(documents[Arel.star], rank.as('fuzzy_score'), highlight.as('pg_search_highlight'))
+
+    authored_order? ? apply_authored_order(rel) : rel.reorder(Arel.sql('fuzzy_score DESC'), :id)
+  end
+
+  def fuzzy_alternatives
+    fuzzy = correction_candidates.group_by { |candidate| candidate['term'] }
+
+    terms.index_with do |term|
+      [ term, *fuzzy.fetch(term, []).map { |candidate| candidate['word'] } ].uniq
+    end
+  end
+
+  def correction_candidates
+    return [] if fuzzy_terms.empty?
+
+    values = fuzzy_terms.map do |term|
+      "(#{PgSearch::Document.connection.quote(term)})"
+    end.join(', ')
+
+    PgSearch::Document.connection.select_all(<<~SQL.squish).to_a
+      SELECT input.term, candidate.word
+      FROM (VALUES #{values}) AS input(term)
+      CROSS JOIN LATERAL (
+        SELECT word
+        FROM pg_search_words
+        WHERE word % input.term
+          AND abs(length(word) - length(input.term)) <= 2
+        ORDER BY similarity(word, input.term) * (1 + ln(document_count)) DESC
+        LIMIT #{FUZZY_ALTERNATIVES_MAX}
+      ) AS candidate
+    SQL
+  end
+
+  def tsquery_group(words)
+    alternatives = words.map do |word|
+      Arel::Nodes::NamedFunction.new(
+        'plainto_tsquery',
+        [ Arel::Nodes.build_quoted('simple'), Arel::Nodes.build_quoted(word) ]
+      )
+    end
+
+    Arel::Nodes::Grouping.new(
+      alternatives.reduce { |left, right| Arel::Nodes::InfixOperation.new('||', left, right) }
+    )
+  end
+
+  def documents
+    PgSearch::Document.arel_table
+  end
+
+  def candidate_ids_without_anonymous_stances(candidates)
+    rows = candidates.reselect(:id, :searchable_type, :poll_id).to_a
+    stance_poll_ids = rows.filter_map { |row| row.poll_id if row.searchable_type == 'Stance' }
+    anonymous_poll_ids = Poll.where(id: stance_poll_ids, anonymous: true).pluck(:id)
+
+    rows.filter_map do |row|
+      row.id unless row.searchable_type == 'Stance' && anonymous_poll_ids.include?(row.poll_id)
+    end
+  end
+
+  def fuzzy_search?
+    query.present? && !query.match?(/[!"()]/) && fuzzy_terms.any? && terms.length <= FUZZY_TERMS_MAX
+  end
+
+  def terms
+    @terms ||= query.scan(TOKEN_PATTERN).map(&:downcase).uniq
+  end
+
+  def fuzzy_terms
+    @fuzzy_terms ||= terms.select do |term|
+      term.length.between?(FUZZY_TERM_LENGTH_MIN, FUZZY_TERM_LENGTH_MAX)
+    end
+  end
+
+  def authored_order?
+    %w[authored_at_asc authored_at_desc].include?(order)
+  end
+
+  def apply_authored_order(rel)
+    case order
+    when 'authored_at_asc'
+      rel.reorder(authored_at: :asc)
+    when 'authored_at_desc'
+      rel.reorder(authored_at: :desc)
+    else
+      rel
+    end
+  end
+
+  def sort_by_authored_at(documents)
+    direction = order == 'authored_at_asc' ? 1 : -1
+    documents.sort_by { |document| [ direction * document.authored_at.to_f, document.id ] }
+  end
+end

--- a/app/services/search_service.rb
+++ b/app/services/search_service.rb
@@ -8,6 +8,53 @@ class SearchService
     reindex_in_batches("Comment", Comment)
     reindex_in_batches("Stance", Stance)
     reindex_in_batches("Outcome", Outcome)
+    rebuild_words
+  end
+
+  def self.rebuild_words
+    connection = ActiveRecord::Base.connection
+    connection.execute("SELECT pg_advisory_lock(hashtext('loomio_rebuild_search_words'))")
+
+    connection.execute("DROP TABLE IF EXISTS pg_search_words_rebuild")
+    connection.execute <<~SQL
+      CREATE TABLE pg_search_words_rebuild (
+        word text NOT NULL,
+        document_count integer NOT NULL
+      )
+    SQL
+    connection.execute <<~SQL
+        INSERT INTO pg_search_words_rebuild (word, document_count)
+        SELECT word, ndoc
+        FROM ts_stat('SELECT ts_content FROM pg_search_documents')
+        WHERE ndoc >= 3
+          AND length(word) BETWEEN 4 AND 64
+          AND word ~ '^[[:alpha:]][[:alpha:]''’_-]{3,63}$'
+    SQL
+    connection.execute <<~SQL
+      CREATE UNIQUE INDEX index_pg_search_words_rebuild_on_word
+        ON pg_search_words_rebuild (word)
+    SQL
+    connection.execute <<~SQL
+      CREATE INDEX index_pg_search_words_rebuild_on_word_trigram
+        ON pg_search_words_rebuild USING gin (word gin_trgm_ops)
+    SQL
+    connection.execute("ANALYZE pg_search_words_rebuild")
+
+    ActiveRecord::Base.transaction do
+      connection.execute("ALTER TABLE pg_search_words RENAME TO pg_search_words_previous")
+      connection.execute("ALTER TABLE pg_search_words_rebuild RENAME TO pg_search_words")
+      connection.execute("DROP TABLE pg_search_words_previous")
+      connection.execute <<~SQL
+        ALTER INDEX index_pg_search_words_rebuild_on_word
+          RENAME TO index_pg_search_words_on_word
+      SQL
+      connection.execute <<~SQL
+        ALTER INDEX index_pg_search_words_rebuild_on_word_trigram
+          RENAME TO index_pg_search_words_on_word_trigram
+      SQL
+    end
+  ensure
+    connection&.execute("SELECT pg_advisory_unlock(hashtext('loomio_rebuild_search_words'))")
   end
 
   private_class_method def self.reindex_in_batches(type, model)
@@ -18,7 +65,7 @@ class SearchService
     # puts "  #{type}: #{count} records to index (max id: #{max})"
     cursor = max
     while cursor > 0
-      lower = [cursor - BATCH_SIZE, 0].max
+      lower = [ cursor - BATCH_SIZE, 0 ].max
       sql = model.pg_search_insert_statement + " AND #{model.table_name}.id > #{lower} AND #{model.table_name}.id <= #{cursor}"
       rows = ActiveRecord::Base.connection.execute(sql).cmd_tuples
       total += rows
@@ -35,7 +82,7 @@ class SearchService
       Comment.pg_search_insert_statement(author_id: author_id),
       Poll.pg_search_insert_statement(author_id: author_id),
       Stance.pg_search_insert_statement(author_id: author_id),
-      Outcome.pg_search_insert_statement(author_id: author_id),
+      Outcome.pg_search_insert_statement(author_id: author_id)
     ].each do |statement|
       ActiveRecord::Base.connection.execute(statement)
     end
@@ -51,7 +98,7 @@ class SearchService
 
     statements = [
       Discussion.pg_search_insert_statement(id: discussion_id),
-      (Comment.pg_search_insert_statement(topic_id: topic_id) if topic_id),
+      (Comment.pg_search_insert_statement(topic_id: topic_id) if topic_id)
     ]
 
     if topic_id
@@ -73,7 +120,7 @@ class SearchService
     [
       Poll.pg_search_insert_statement(id: poll_id),
       Stance.pg_search_insert_statement(poll_id: poll_id),
-      Outcome.pg_search_insert_statement(poll_id: poll_id),
+      Outcome.pg_search_insert_statement(poll_id: poll_id)
     ].each do |statement|
       ActiveRecord::Base.connection.execute(statement)
     end
@@ -84,5 +131,4 @@ class SearchService
     PgSearch::Document.where(searchable_type: 'Comment', searchable_id: comment_id).delete_all
     ActiveRecord::Base.connection.execute(Comment.pg_search_insert_statement(id: comment_id))
   end
-
 end

--- a/db/migrate/20260813000000_create_pg_search_words.rb
+++ b/db/migrate/20260813000000_create_pg_search_words.rb
@@ -1,0 +1,33 @@
+class CreatePgSearchWords < ActiveRecord::Migration[8.0]
+  def up
+    enable_extension 'pg_trgm' unless extension_enabled?('pg_trgm')
+
+    create_table :pg_search_words, id: false do |t|
+      t.text :word, null: false
+      t.integer :document_count, null: false
+    end
+
+    execute "TRUNCATE pg_search_words"
+    execute <<~SQL
+      INSERT INTO pg_search_words (word, document_count)
+      SELECT word, ndoc
+      FROM ts_stat('SELECT ts_content FROM pg_search_documents')
+      WHERE ndoc >= 3
+        AND length(word) BETWEEN 4 AND 64
+        AND word ~ '^[[:alpha:]][[:alpha:]''’_-]{3,63}$'
+    SQL
+
+    execute <<~SQL
+      CREATE UNIQUE INDEX index_pg_search_words_on_word
+        ON pg_search_words (word)
+    SQL
+    execute <<~SQL
+      CREATE INDEX index_pg_search_words_on_word_trigram
+        ON pg_search_words USING gin (word gin_trgm_ops)
+    SQL
+  end
+
+  def down
+    drop_table :pg_search_words, if_exists: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_08_08_000000) do
+ActiveRecord::Schema[8.0].define(version: 2026_08_13_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "hstore"
@@ -670,6 +670,13 @@ ActiveRecord::Schema[8.0].define(version: 2026_08_08_000000) do
     t.index ["tags"], name: "index_pg_search_documents_on_tags", using: :gin
     t.index ["topic_id"], name: "index_pg_search_documents_on_topic_id"
     t.index ["ts_content"], name: "pg_search_documents_searchable_index", using: :gin
+  end
+
+  create_table "pg_search_words", id: false, force: :cascade do |t|
+    t.text "word", null: false
+    t.integer "document_count", null: false
+    t.index ["word"], name: "index_pg_search_words_on_word", unique: true
+    t.index ["word"], name: "index_pg_search_words_on_word_trigram", opclass: :gin_trgm_ops, using: :gin
   end
 
   create_table "poll_options", id: :serial, force: :cascade do |t|

--- a/docs/user_manual/changelog/2026-08-13_typo_tolerant_search.md
+++ b/docs/user_manual/changelog/2026-08-13_typo_tolerant_search.md
@@ -1,0 +1,5 @@
+# Search tolerates misspelled words
+
+Search now finds likely matches when one or more words are misspelled. Exact and prefix matches remain first, followed by matches found through spelling correction.
+
+Spelling correction works across the languages and writing systems present in Loomio's search index. Group, topic, tag, content type, and direct-discussion permissions continue to apply to corrected searches.

--- a/lib/tasks/search.rake
+++ b/lib/tasks/search.rake
@@ -1,0 +1,6 @@
+namespace :loomio do
+  desc "Rebuild the typo-correction vocabulary from search documents"
+  task rebuild_search_words: :environment do
+    SearchService.rebuild_words
+  end
+end

--- a/test/controllers/api/v1/search_controller_test.rb
+++ b/test/controllers/api/v1/search_controller_test.rb
@@ -17,7 +17,7 @@ class Api::V1::SearchControllerTest < ActionController::TestCase
       topic_id: @discussion.topic.id,
       specified_voters_only: true,
       closing_at: 5.days.from_now,
-      poll_option_names: ["findme"]
+      poll_option_names: [ "findme" ]
     }, actor: @user)
     @poll.update!(closed_at: 1.day.ago)
 
@@ -30,7 +30,20 @@ class Api::V1::SearchControllerTest < ActionController::TestCase
 
     # Rebuild search documents after events are created
     PgSearch::Document.delete_all
-    [Discussion, Comment, Poll, Outcome].each(&:rebuild_pg_search_documents)
+    [ Discussion, Comment, Poll, Outcome ].each(&:rebuild_pg_search_documents)
+    PgSearch::Document.connection.execute <<~SQL
+      INSERT INTO pg_search_words (word, document_count)
+      VALUES
+        ('democracia', 100),
+        ('participativa', 100),
+        ('whakawhanaungatanga', 100),
+        ('демократия', 100),
+        ('findme', 100),
+        ('findguestdiscussion', 100),
+        ('findprivatesubgroup', 100),
+        ('confidential', 100)
+      ON CONFLICT (word) DO UPDATE SET document_count = EXCLUDED.document_count
+    SQL
   end
 
   test "returns visible records for group member" do
@@ -65,9 +78,32 @@ class Api::V1::SearchControllerTest < ActionController::TestCase
     assert_not result.key?('author_name')
     assert_not result.key?('authored_at')
 
-    get :index, params: {query: @user.name}
+    get :index, params: { query: @user.name }
     name_results = JSON.parse(response.body)['search_results']
     assert name_results.any? { |record| record['searchable_type'] == 'Stance' && record['poll_id'] == @poll.id }
+  end
+
+  test "does not fuzzy match anonymous stances by participant name" do
+    @poll.update!(anonymous: true)
+    stance = @poll.stances.build(participant: @user, latest: true)
+    stance.reason = 'anonymous vote reason'
+    stance.cast_at = 2.days.ago
+    stance.stance_choices.build(poll_option: @poll.poll_options.first)
+    stance.save!
+    stance.update_pg_search_document
+
+    name = @user.name.downcase.scan(/[\p{L}\p{N}]{4,}/).first
+    PgSearch::Document.connection.execute <<~SQL
+      INSERT INTO pg_search_words (word, document_count)
+      VALUES (#{PgSearch::Document.connection.quote(name)}, 100)
+      ON CONFLICT (word) DO UPDATE SET document_count = EXCLUDED.document_count
+    SQL
+
+    sign_in @user
+    get :index, params: { query: "#{name}x" }
+
+    results = JSON.parse(response.body)['search_results']
+    refute results.any? { |record| record['searchable_type'] == 'Stance' && record['searchable_id'] == stance.id }
   end
 
   test "does not return stale documents for a legacy discarded discussion" do
@@ -75,7 +111,7 @@ class Api::V1::SearchControllerTest < ActionController::TestCase
     assert PgSearch::Document.where(discussion_id: @discussion.id).exists?
 
     sign_in @user
-    get :index, params: { query: 'findme' }
+    get :index, params: { query: 'findmee' }
 
     results = JSON.parse(response.body)['search_results']
     refute results.any? { |result| result['discussion_key'] == @discussion.key }
@@ -86,7 +122,7 @@ class Api::V1::SearchControllerTest < ActionController::TestCase
     assert PgSearch::Document.where(topic_id: @discussion.topic.id).exists?
 
     sign_in @user
-    get :index, params: { query: 'findme' }
+    get :index, params: { query: 'findmee' }
 
     results = JSON.parse(response.body)['search_results']
     refute results.any? { |result| result['discussion_key'] == @discussion.key }
@@ -109,13 +145,13 @@ class Api::V1::SearchControllerTest < ActionController::TestCase
     discussion.update_pg_search_document
 
     sign_in users(:member)
-    get :index, params: { query: "findprivatesubgroup" }
+    get :index, params: { query: "findprivatesubgrop" }
 
     results = JSON.parse(response.body)['search_results']
     refute results.any? { |result| result['searchable_id'] == discussion.id }
 
     subgroup.update_columns(parent_members_can_see_discussions: true)
-    get :index, params: { query: "findprivatesubgroup" }
+    get :index, params: { query: "findprivatesubgrop" }
 
     results = JSON.parse(response.body)['search_results']
     assert results.any? { |result| result['searchable_id'] == discussion.id }
@@ -146,12 +182,24 @@ class Api::V1::SearchControllerTest < ActionController::TestCase
 
     results = JSON.parse(response.body)['search_results']
     refute results.any? { |result| result['searchable_id'] == discussion.id }
+
+    sign_in @user
+    get :index, params: { query: "findguestdiscusison" }
+
+    results = JSON.parse(response.body)['search_results']
+    assert results.any? { |result| result['searchable_id'] == discussion.id }
+
+    sign_in users(:alien)
+    get :index, params: { query: "findguestdiscusison" }
+
+    results = JSON.parse(response.body)['search_results']
+    refute results.any? { |result| result['searchable_id'] == discussion.id }
   end
 
   test "returns group filtered records" do
     sign_in @user
 
-    get :index, params: { query: "findme", group_id: @group.id }
+    get :index, params: { query: "findmee", group_id: @group.id }
     results = JSON.parse(response.body)['search_results']
 
     assert results.any? { |r| r['searchable_type'] == 'Discussion' && r['searchable_id'] == @discussion.id }
@@ -186,5 +234,113 @@ class Api::V1::SearchControllerTest < ActionController::TestCase
     assert_response :success
     json = JSON.parse(response.body)
     assert_includes json.keys, 'search_results'
+  end
+
+  test "returns a result when multiple search terms are misspelled" do
+    @discussion.update!(title: 'Democracia participativa')
+    @discussion.update_pg_search_document
+
+    sign_in @user
+    get :index, params: { query: 'democracai partciipativa' }
+
+    result = JSON.parse(response.body)['search_results'].find do |record|
+      record['searchable_type'] == 'Discussion' && record['searchable_id'] == @discussion.id
+    end
+    assert_not_nil result
+    assert_includes result['highlight'], '<b>Democracia</b>'
+    assert_includes result['highlight'], '<b>participativa</b>'
+  end
+
+  test "supports fuzzy matching across writing systems" do
+    @discussion.update!(title: 'Whakawhanaungatanga демократия')
+    @discussion.update_pg_search_document
+
+    sign_in @user
+    get :index, params: { query: 'whakawhanaungatnga демократя' }
+
+    results = JSON.parse(response.body)['search_results']
+    assert results.any? { |record| record['searchable_type'] == 'Discussion' && record['searchable_id'] == @discussion.id }
+  end
+
+  test "ranks exact matches before fuzzy matches" do
+    exact_discussion = DiscussionService.create(
+      params: { group_id: @group.id, title: 'findmee discussion', private: true },
+      actor: users(:admin)
+    )
+    exact_discussion.update_pg_search_document
+
+    sign_in @user
+    get :index, params: { query: 'findmee' }
+
+    results = JSON.parse(response.body)['search_results']
+    exact_index = results.index { |record| record['searchable_type'] == 'Discussion' && record['searchable_id'] == exact_discussion.id }
+    fuzzy_index = results.index { |record| record['searchable_type'] == 'Discussion' && record['searchable_id'] == @discussion.id }
+    assert_operator exact_index, :<, fuzzy_index
+  end
+
+  test "applies authored ordering across exact and fuzzy matches" do
+    exact_discussion = DiscussionService.create(
+      params: { group_id: @group.id, title: 'findmee discussion', private: true },
+      actor: users(:admin)
+    )
+    exact_discussion.update_columns(created_at: 1.day.ago)
+    exact_discussion.update_pg_search_document
+
+    fuzzy_discussion = DiscussionService.create(
+      params: { group_id: @group.id, title: 'findme discussion', private: true },
+      actor: users(:admin)
+    )
+    fuzzy_discussion.update_columns(created_at: 1.day.from_now)
+    fuzzy_discussion.update_pg_search_document
+
+    sign_in @user
+    get :index, params: { query: 'findmee', order: 'authored_at_desc' }
+
+    result = JSON.parse(response.body)['search_results'].first
+    assert_equal 'Discussion', result['searchable_type']
+    assert_equal fuzzy_discussion.id, result['searchable_id']
+  end
+
+  test "applies type filters to fuzzy matches" do
+    sign_in @user
+    get :index, params: { query: 'findmee', type: 'Discussion' }
+
+    results = JSON.parse(response.body)['search_results']
+    assert results.any?
+    assert results.all? { |record| record['searchable_type'] == 'Discussion' }
+  end
+
+  test "applies tag filters to fuzzy matches" do
+    @discussion.topic.update!(tags: [ 'planning' ])
+    [ Discussion, Comment, Poll, Outcome ].each(&:rebuild_pg_search_documents)
+
+    sign_in @user
+    get :index, params: { query: 'findmee', tag: 'planning' }
+    matching_results = JSON.parse(response.body)['search_results']
+
+    get :index, params: { query: 'findmee', tag: 'governance' }
+    excluded_results = JSON.parse(response.body)['search_results']
+
+    assert matching_results.any? { |record| record['searchable_id'] == @discussion.id }
+    refute excluded_results.any? { |record| record['searchable_id'] == @discussion.id }
+  end
+
+  test "does not fuzzy match documents outside the user's groups" do
+    alien_discussion = discussions(:alien_discussion)
+    alien_discussion.update!(title: 'Confidential strategy')
+    alien_discussion.update_pg_search_document
+
+    sign_in @user
+    get :index, params: { query: 'confidnetial' }
+
+    results = JSON.parse(response.body)['search_results']
+    refute results.any? { |record| record['searchable_id'] == alien_discussion.id }
+  end
+
+  test "does not use fuzzy matching for negated queries" do
+    sign_in @user
+    get :index, params: { query: 'findmee !poll' }
+
+    assert_empty JSON.parse(response.body)['search_results']
   end
 end

--- a/test/services/search_service_test.rb
+++ b/test/services/search_service_test.rb
@@ -111,4 +111,33 @@ class SearchServiceTest < ActiveSupport::TestCase
 
     assert PgSearch::Document.where(searchable_type: 'Poll', searchable_id: poll.id).exists?
   end
+
+  test "rebuild_words retains established multilingual words" do
+    PgSearch::Document.create!(
+      searchable_type: 'Discussion',
+      searchable_id: 1,
+      content: 'democracia',
+      ts_content: "'democracia':1"
+    )
+    PgSearch::Document.create!(
+      searchable_type: 'Discussion',
+      searchable_id: 2,
+      content: 'democracia',
+      ts_content: "'democracia':1"
+    )
+    PgSearch::Document.create!(
+      searchable_type: 'Discussion',
+      searchable_id: 3,
+      content: 'democracia',
+      ts_content: "'democracia':1"
+    )
+
+    SearchService.rebuild_words
+
+    assert_equal 3, ActiveRecord::Base.connection.select_value(<<~SQL.squish)
+      SELECT document_count
+      FROM pg_search_words
+      WHERE word = 'democracia'
+    SQL
+  end
 end


### PR DESCRIPTION
Adds typo-tolerant search while preserving Loomio’s existing multilingual full-text search, result filters, and authorization rules.

Search continues to run the existing PostgreSQL full-text query first. When that returns fewer than 20 results, Loomio looks for likely spelling corrections and uses them to fill the
remaining result slots. Exact matches therefore remain ahead of fuzzy matches.

The correction vocabulary is generated from the words already present in the Loomio instance’s search index. This avoids depending on a single-language dictionary and supports the
languages and writing systems used by each installation.

## User-visible changes

- Searches can find results when one or more words are misspelled
- Exact matches remain ahead of corrected matches
- Multiple misspelled words are supported
- Existing tag, content type, group, topic, and ordering options continue to work
- Searches containing advanced syntax such as negation, quotes, or parentheses retain their existing exact-search behaviour
- Words shorter than four characters are not corrected

For example, a search for democracai participatoin can find content containing democracia participación when those words are established in the instance’s search corpus.

## Implementation

The fuzzy path uses a separate pg_search_words vocabulary containing:

- Search lexemes found in at least three documents
- Their document frequency
- A unique B-tree index
- A PostgreSQL trigram GIN index

Correction candidates are ranked using trigram similarity combined with document frequency. This helps established words rank above rare misspellings already present in the corpus.

The fuzzy query is deliberately bounded:

- Maximum 8 query terms
- Maximum 3 correction alternatives per term
- Terms must be between 4 and 64 characters
- Minimum trigram similarity of 0.25
- Maximum 200 candidate search documents before full authorization
- Maximum 20 returned results

Each term is converted into an OR group containing the original term and its correction alternatives. The groups are then combined with AND, retaining the expectation that every entered
word should contribute to a match.

All PostgreSQL query expressions are constructed using quoted values or typed Arel nodes.

## Permissions and privacy

Corrected results pass through the same final authorization relation as exact results, including:

- Group membership and subgroup permissions
- Topic visibility
- Direct-discussion guest access
- Discarded topic and discussion filtering
- Tag filtering
- Searchable content-type filtering

Candidate preselection does not grant access to documents. It only limits the records passed to the existing authorization query; results are returned exclusively from the authorized relation.

Fuzzy matching excludes stances belonging to anonymous polls. This prevents misspelled participant-name searches from introducing a new way to associate anonymous stance records with participants. Existing exact-search behaviour is unchanged.

Tests cover:

- Records outside the user’s groups
- Private subgroup discussions
- Direct discussions
- Discarded topics and discussions
- Anonymous poll stances
- Type and tag filters
- Exact-before-fuzzy ranking
- Authored-date ordering

## Multilingual support

The vocabulary is derived from PostgreSQL’s existing ts_content values instead of an English dictionary. Unicode-aware token handling permits alphabetic words from the languages and
writing systems represented in the search index.

Focused tests include Spanish, Māori, and Cyrillic examples.

## Performance testing

Test scopes included:

- A group containing 35,377 searchable documents
- A user with access to 131 groups and approximately 113,850 searchable documents
- Single-word typos
- Multiple misspelled terms
- Cyrillic text
- Mixed short and corrected terms
- The maximum eight-term query
- An adversarial repeated-character query
- Authored-date ordering

Warm timings observed:

Scope                        Query type                 Time
━━━━━━━━━━━━━━━━━━━━━━━━━━━  ━━━━━━━━━━━━━━━━━━━  ━━━━━━━━━━━━
35k-document group           Single typo            68–79 ms
───────────────────────────  ───────────────────  ────────────
35k-document group           Multiple typos         44–84 ms
───────────────────────────  ───────────────────  ────────────
35k-document group           Cyrillic typo           7–13 ms
───────────────────────────  ───────────────────  ────────────
35k-document group           Eight terms          118–165 ms
───────────────────────────  ───────────────────  ────────────
114k authorized documents    Single typo          254–297 ms
───────────────────────────  ───────────────────  ────────────
114k authorized documents    Multiple typos         96–97 ms
───────────────────────────  ───────────────────  ────────────
114k authorized documents    Cyrillic typo          18–20 ms
───────────────────────────  ───────────────────  ────────────
114k authorized documents    Eight terms              119 ms
───────────────────────────  ───────────────────  ────────────
114k authorized documents    Authored ordering    258–326 ms

For comparison, the existing correctly spelled broad query took approximately 465–505 ms warm and 2.7 seconds on a cold-cache sample. Query-plan inspection showed that Loomio’s existing
per-topic authorization checks dominate broad-search latency rather than spelling correction.

A direct trigram index over the complete search-document content was also evaluated and rejected. On the production-sized copy it:

- Required approximately 1.8 GB
- Took around 11.5 minutes to build
- Produced typo queries taking approximately 560–860 ms
- Generated hundreds of thousands to more than one million candidate rows

The pruned vocabulary approach is both smaller and faster.

## Storage and migration impact

On the production-sized database:

- Vocabulary entries: 843,132
- Table heap: approximately 38 MB
- Unique index: approximately 24 MB
- Trigram index: approximately 25 MB
- Total permanent storage: approximately 87 MB
- Initial vocabulary generation and indexing: approximately 2 minutes

The migration enables pg_trgm if it is not already installed, creates the vocabulary table, populates it from the existing search documents, and creates both indexes.

## Vocabulary maintenance

A full search reindex now rebuilds the correction vocabulary automatically.

It can also be refreshed independently with:

bin/rake loomio:rebuild_search_words

The refresh builds and indexes a replacement table alongside the live vocabulary, then swaps it into place atomically. Existing fuzzy searches therefore continue using the previous
vocabulary while a refresh is running.

The replacement temporarily requires approximately another 87 MB during a refresh.

New content is immediately available through exact search. Its words become correction candidates after the next vocabulary rebuild.

## Validation

- 29 focused tests
- 57 assertions

## Deployment notes

No manual step is required beyond running the database migration.