### PR TITLE
Allow adding voters to open anonymous polls

### DIFF
--- a/.github/workflows/minitest.yml
+++ b/.github/workflows/minitest.yml
@@ -30,10 +30,10 @@ jobs:
           --health-retries 5
 
     steps:
-    - name: install libvips
+    - name: install image processing tools
       run: |
         sudo apt-get update
-        sudo apt-get install -y libvips
+        sudo apt-get install -y imagemagick libvips
     - name: git checkout
       uses: actions/checkout@v5
     - name: install ruby

--- a/app/services/poll_service.rb
+++ b/app/services/poll_service.rb
@@ -137,9 +137,7 @@ class PollService
 
     Poll.transaction do
       poll.lock!
-      if poll.detached_anonymous? && poll.anonymous_ballots.exists?
-        raise CanCan::AccessDenied
-      end
+      raise CanCan::AccessDenied if poll.detached_anonymous? && !poll.active?
 
       TopicService.add_users(
         topic:  poll.topic,
@@ -363,7 +361,15 @@ class PollService
     return if group_id.nil?
 
     Poll.active.joins(:topic).where(topics: { group_id: group_id }, specified_voters_only: false).each do |poll|
-      create_anyone_can_vote_stances(poll)
+      if poll.detached_anonymous?
+        Poll.transaction do
+          poll.lock!
+          create_anonymous_poll_voters(poll: poll, actor: poll.author, params: {})
+          poll.update_counts!
+        end
+      else
+        create_anyone_can_vote_stances(poll)
+      end
     end
   end
 

--- a/docs/system/anonymous_voting.md
+++ b/docs/system/anonymous_voting.md
@@ -95,6 +95,7 @@ The application-level guarantee does not protect against:
 - malicious changes to the running application;
 - a voter identifying themselves outside Loomio;
 - statistical inference from a small electorate;
+- aggregate subtraction when a coordinator or other participants know every ballot except one, including when a voter is added after voting starts;
 - inference from a distinctive ballot pattern; or
 - information voluntarily shared by voters.
 
@@ -210,7 +211,7 @@ When voting opens, Loomio must:
 4. make the poll eligible for the hourly automatic-reminder check; and
 5. avoid creating named or undecided stance records.
 
-The implementation must define whether the electorate is frozen when voting opens and whether late invitations are permitted. The selected policy must not create a ballot-to-voter correlation path.
+Coordinators may add eligible voters while the poll is open, including after ballots have been submitted. Group members added to an unrestricted group poll also become eligible while it remains open. Existing electorate records cannot be removed, and late additions must not create a ballot-to-voter correlation path.
 
 ## Ballot submission
 
@@ -671,8 +672,8 @@ The migration is complete only after Release 2 is deployed and the final product
 
 1. Native detached results and ordinary user-facing application exports expose aggregates only, not individual ballots or ballot patterns. The closed-poll JSON group portability archive is the documented operational exception required for restoration. Migrated legacy polls may additionally display a plain-text legacy reason with the choices from that reason's historical vote, without exposing a ballot identifier or metadata.
 2. Poll coordinators may view invitation provenance. They may view named participation status only once at least three people have voted. Result access alone does not grant this permission.
-3. Group polls establish their electorate when the poll is created. Polls restricted to specified voters use an explicitly invited electorate.
-4. Coordinators may add specified voters until the first ballot is submitted. The electorate is frozen after that point.
+3. Group polls establish their initial electorate when the poll is created. Polls restricted to specified voters use an explicitly invited electorate.
+4. Coordinators may add specified voters while voting is open, including after ballots have been submitted. New group members become eligible in unrestricted group polls while voting remains open. Existing electorate records cannot be removed.
 5. `closing_at` may be extended while voting is open. The hourly check uses the current deadline without maintaining queued-job state. A poll receives at most one automatic closing reminder, including after an extension.
 6. The automatic reminder is sent when a poll lasting at least 24 hours enters its final 24 hours. Polls lasting less than 24 hours receive no automatic closing reminder.
 7. There is no minimum electorate size.

--- a/docs/system/anonymous_voting_security_review.md
+++ b/docs/system/anonymous_voting_security_review.md
@@ -17,7 +17,7 @@ This review covers the detached anonymous voting implementation and the migratio
 ## Submission boundary
 
 - The dedicated service authenticates and authorizes the voter, locks the poll and their electorate row, validates choices against the poll, creates the ballot, and marks participation in one transaction.
-- Ballot submission, poll closing, and specified-electorate changes serialize on the same poll-row lock. A vote cannot cross the closing boundary, and a voter cannot be added as the first ballot arrives.
+- Ballot submission, poll closing, and electorate changes serialize on the same poll-row lock. A vote cannot cross the closing boundary, and each voter addition completes atomically before that voter can submit a ballot.
 - A used electorate row cannot submit again. Concurrent requests by the same voter serialize on the same electorate-row lock.
 - The response contains only `recorded: true`.
 - Unsupported fields, including reasons and attachments, are rejected. Ballot request parameters are filtered from application logs.
@@ -76,7 +76,7 @@ Operational rollout, canary conversion, batch auditing, and removal of stance-sp
 
 ## Residual risks
 
-The application-level design does not protect against database, backup, host, process-memory, transaction-log, network-timing, mail-system, or server-log operators. Small electorates, unanimous results, distinctive aggregate patterns, and information voters disclose elsewhere can also permit inference. Hiding named participation status below three votes reduces one disclosure risk but cannot prevent inference from the aggregate result itself. The UI and user documentation must not describe the feature as cryptographically anonymous or protected from infrastructure operators.
+The application-level design does not protect against database, backup, host, process-memory, transaction-log, network-timing, mail-system, or server-log operators. Small electorates, unanimous results, distinctive aggregate patterns, and information voters disclose elsewhere can also permit inference. A coordinator or cooperating participants who know every ballot except one can subtract their ballots from the aggregate result to infer the remaining ballot; adding voters after voting starts can make that composition attack easier to arrange. Hiding named participation status below three votes reduces one disclosure risk but cannot prevent inference from the aggregate result itself. The UI and user documentation must not describe the feature as cryptographically anonymous or protected from infrastructure operators.
 
 ## Validation evidence for manual review
 

--- a/docs/user_manual/changelog/2026-08-13_anonymous_poll_late_voters.md
+++ b/docs/user_manual/changelog/2026-08-13_anonymous_poll_late_voters.md
@@ -1,0 +1,5 @@
+# Add voters to an open anonymous poll
+
+Poll coordinators can add eligible voters to an anonymous poll while voting is open, including after other people have voted. For anonymous group polls open to all group members, people who join the group while voting is open also become eligible.
+
+Existing voters cannot be removed from an anonymous poll. Results remain hidden until the poll closes, and submitted ballots remain stored separately from voter identities.

--- a/test/controllers/api/v1/announcements_controller_test.rb
+++ b/test/controllers/api/v1/announcements_controller_test.rb
@@ -429,6 +429,29 @@ class Api::V1::AnnouncementsControllerTest < ActionController::TestCase
     assert_equal 1, json['stances'].length
   end
 
+  test "poll create can invite a voter after an anonymous ballot is submitted" do
+    poll = create_test_poll(anonymous: true)
+    voter = users(:user)
+    PollService.invite(
+      poll: poll,
+      actor: @admin,
+      params: { recipient_user_ids: [voter.id] }
+    )
+    AnonymousBallotService.create(
+      anonymous_ballot: poll.anonymous_ballots.build(
+        anonymous_ballot_choices_attributes: [{ poll_option_id: poll.poll_options.first.id }]
+      ),
+      actor: voter
+    )
+
+    post :create, params: { poll_id: poll.id, recipient_emails: ['late-voter@example.com'] }
+
+    assert_response :success
+    assert_equal 1, JSON.parse(response.body)['users'].length
+    assert poll.anonymous_poll_voters.joins(:voter).exists?(users: { email: 'late-voter@example.com' })
+    assert_equal 1, poll.reload.undecided_voters_count
+  end
+
   test "poll create reports the invitation rate limit" do
     poll = create_test_poll
     error = ThrottleService::LimitReached.new('Throttled')

--- a/test/services/anonymous_ballot_service_test.rb
+++ b/test/services/anonymous_ballot_service_test.rb
@@ -195,7 +195,7 @@ class AnonymousBallotServiceTest < ActiveSupport::TestCase
     assert_not_includes PollExporter.new(@poll).to_csv, @poll.anonymous_ballots.first.id
   end
 
-  test "specified electorate invitations create no stances and freeze after the first ballot" do
+  test "specified electorate invitations create no stances and remain open after the first ballot" do
     poll = PollService.create(
       params: {
         title: "Specified anonymous poll",
@@ -230,16 +230,21 @@ class AnonymousBallotServiceTest < ActiveSupport::TestCase
       actor: @voter
     )
 
-    assert_raises(CanCan::AccessDenied) do
-      PollService.invite(
-        poll: poll,
-        actor: @admin,
-        params: { recipient_user_ids: [users(:alien).id] }
-      )
-    end
+    late_voter = users(:alien)
+    voters = PollService.invite(
+      poll: poll,
+      actor: @admin,
+      params: { recipient_emails: [late_voter.email] }
+    )
+
+    assert_equal [late_voter.id], voters.pluck(:voter_id)
+    assert_not poll.anonymous_poll_voters.find_by!(voter: late_voter).group_member
+    assert_equal 2, poll.reload.voters_count
+    assert_equal 1, poll.undecided_voters_count
+    assert_equal 1, poll.anonymous_ballots.count
   end
 
-  test "specified electorate freezes when the first ballot arrives at the poll lock boundary" do
+  test "late specified electorate invitations take the shared poll lock" do
     poll = PollService.create(
       params: {
         title: "Specified anonymous poll",
@@ -257,22 +262,50 @@ class AnonymousBallotServiceTest < ActiveSupport::TestCase
       actor: @admin,
       params: { recipient_user_ids: [@voter.id] }
     )
+    AnonymousBallotService.create(
+      anonymous_ballot: poll.anonymous_ballots.build(
+        anonymous_ballot_choices_attributes: [{ poll_option_id: poll.poll_options.first.id }]
+      ),
+      actor: @voter
+    )
     locked = false
-    ballots = poll.anonymous_ballots
 
     poll.stub(:lock!, -> {
       locked = true
       poll
     }) do
-      ballots.stub(:exists?, -> { locked }) do
-        assert_raises(CanCan::AccessDenied) do
-          PollService.invite(
-            poll: poll,
-            actor: @admin,
-            params: { recipient_user_ids: [users(:alien).id] }
-          )
-        end
-      end
+      PollService.invite(
+        poll: poll,
+        actor: @admin,
+        params: { recipient_emails: [users(:alien).email] }
+      )
+    end
+
+    assert locked
+    assert poll.anonymous_poll_voters.exists?(voter_id: users(:alien).id)
+  end
+
+  test "specified electorate invitations are rejected after an anonymous poll closes" do
+    poll = PollService.create(
+      params: {
+        title: "Specified anonymous poll",
+        poll_type: "proposal",
+        closing_at: 3.days.from_now,
+        group_id: @group.id,
+        anonymous: true,
+        specified_voters_only: true,
+        poll_option_names: ["Agree", "Disagree"]
+      },
+      actor: @admin
+    )
+    PollService.close(poll: poll, actor: @admin)
+
+    assert_raises(CanCan::AccessDenied) do
+      PollService.invite(
+        poll: poll,
+        actor: @admin,
+        params: { recipient_emails: [users(:alien).email] }
+      )
     end
 
     refute poll.anonymous_poll_voters.exists?(voter_id: users(:alien).id)

--- a/test/services/poll_service_test.rb
+++ b/test/services/poll_service_test.rb
@@ -414,6 +414,26 @@ class PollServiceTest < ActiveSupport::TestCase
     assert_equal count + 1, poll.voters.count
   end
 
+  test "adds new group members to active anonymous polls after voting starts" do
+    poll = create_poll(specified_voters_only: false, anonymous: true)
+    AnonymousBallotService.create(
+      anonymous_ballot: poll.anonymous_ballots.build(
+        anonymous_ballot_choices_attributes: [{ poll_option_id: poll.poll_options.first.id, score: 1 }]
+      ),
+      actor: @user
+    )
+    voters_count = poll.reload.voters_count
+    undecided_voters_count = poll.undecided_voters_count
+
+    new_member = create_unique_user("newanonymousmember")
+    Membership.create!(user: new_member, group: @group, accepted_at: Time.current)
+    PollService.group_members_added(@group.id)
+
+    assert poll.anonymous_poll_voters.exists?(voter: new_member, ballot_submitted: false)
+    assert_equal voters_count + 1, poll.reload.voters_count
+    assert_equal undecided_voters_count + 1, poll.undecided_voters_count
+  end
+
   test "does not add bot users to polls" do
     poll = create_poll(specified_voters_only: false)
     PollService.group_members_added(@group.id)


### PR DESCRIPTION
## Summary

- allow coordinators to add voters to anonymous polls after ballots have been submitted
- add new group members to active unrestricted anonymous polls automatically
- reject electorate changes after an anonymous poll closes
- update the user changelog, system design, and security review

## Security review

Detached ballots remain separate from voter identities: ballots contain no voter ID or submission timestamp, and electorate records contain no ballot ID.

Late additions make a known-ballot aggregate subtraction attack easier to arrange when a coordinator or cooperating voters know every other ballot. This is an accepted product limitation and is now documented explicitly. The review also found and fixed a closed-poll integrity edge case by checking that detached anonymous polls are active while holding the poll lock.

## Tests

- bin/rails test test/services/anonymous_ballot_service_test.rb test/services/poll_service_test.rb test/controllers/api/v1/announcements_controller_test.rb
- 138 runs, 359 assertions, 0 failures, 0 errors
- pre-push Brakeman: 0 warnings
- pre-push Bundler Audit: no vulnerabilities