### PR TITLE
Normalize mutation service result contracts

### DIFF
--- a/app/controllers/admin/subscriptions_controller.rb
+++ b/app/controllers/admin/subscriptions_controller.rb
@@ -18,17 +18,19 @@ class Admin::SubscriptionsController < Admin::BaseController
 
   def update
     if @subscription.update(subscription_params)
-      redirect_to admin_subscription_path(@subscription), notice: "Subscription updated"
+      if params[:refresh_from_chargify].present?
+        refresh_from_chargify
+        redirect_to admin_subscription_path(@subscription), notice: "Subscription updated and refreshed from Chargify"
+      else
+        redirect_to admin_subscription_path(@subscription), notice: "Subscription updated"
+      end
     else
       render Views::Admin::Subscriptions::Edit.new(subscription: @subscription), status: :unprocessable_entity
     end
   end
 
   def refresh
-    subscription_service.update(
-      subscription: @subscription,
-      params: subscription_service.chargify_get(@subscription.chargify_subscription_id)
-    )
+    refresh_from_chargify
     redirect_to admin_subscription_path(@subscription), notice: "Subscription refreshed"
   end
 
@@ -65,5 +67,12 @@ class Admin::SubscriptionsController < Admin::BaseController
 
   def subscription_service
     SubscriptionService
+  end
+
+  def refresh_from_chargify
+    subscription_service.update(
+      subscription: @subscription,
+      params: subscription_service.chargify_get(@subscription.chargify_subscription_id)
+    )
   end
 end

--- a/app/controllers/api/b2/comments_controller.rb
+++ b/app/controllers/api/b2/comments_controller.rb
@@ -6,20 +6,14 @@ class Api::B2::CommentsController < Api::B2::BaseController
       resource.parent_id = params[:discussion_id]
     end
     raise CanCan::AccessDenied unless resource.parent_id.present?
-    if CommentService.create(comment: resource, actor: current_user)
-      respond_with_resource
-    else
-      respond_with_errors
-    end
+    self.resource = CommentService.create(comment: resource, actor: current_user)
+    respond_with_resource
   end
 
   def update
     load_resource
-    if CommentService.update(comment: resource, params: resource_params, actor: current_user)
-      respond_with_resource
-    else
-      respond_with_errors
-    end
+    self.resource = CommentService.update(comment: resource, params: resource_params, actor: current_user)
+    respond_with_resource
   end
 
   def destroy

--- a/app/controllers/api/b2/discussions_controller.rb
+++ b/app/controllers/api/b2/discussions_controller.rb
@@ -11,11 +11,8 @@ class Api::B2::DiscussionsController < Api::B2::BaseController
 
   def update
     load_resource
-    if DiscussionService.update(discussion: resource, params: resource_params, actor: current_user)
-      respond_with_resource
-    else
-      respond_with_errors
-    end
+    self.resource = DiscussionService.update(discussion: resource, params: resource_params, actor: current_user)
+    respond_with_resource
   end
 
   def destroy

--- a/app/controllers/api/b2/polls_controller.rb
+++ b/app/controllers/api/b2/polls_controller.rb
@@ -6,17 +6,14 @@ class Api::B2::PollsController < Api::B2::BaseController
 
   def create
     self.resource = PollService.create(params: resource_params, actor: current_user)
-    PollService.invite(poll: resource, actor: current_user, params: params)
+    PollService.invite(poll: resource, actor: current_user, params: params) if resource.errors.empty?
     respond_with_resource
   end
 
   def update
     load_resource
-    if PollService.update(poll: resource, params: resource_params, actor: current_user)
-      respond_with_resource
-    else
-      respond_with_errors
-    end
+    self.resource = PollService.update(poll: resource, params: resource_params, actor: current_user)
+    respond_with_resource
   end
 
   def destroy

--- a/app/controllers/api/v1/comments_controller.rb
+++ b/app/controllers/api/v1/comments_controller.rb
@@ -1,13 +1,13 @@
 class Api::V1::CommentsController < Api::V1::RestfulController
   def discard
     load_resource
-    capture_topic_item(service.discard(comment: resource, actor: current_user))
+    service.discard(comment: resource, actor: current_user) { |topic_item| @topic_item = topic_item }
     respond_with_resource(scope: default_scope.merge(exclude_types: %w[discussion group user]))
   end
 
   def undiscard
     load_resource
-    capture_topic_item(service.undiscard(comment: resource, actor: current_user))
+    service.undiscard(comment: resource, actor: current_user) { |topic_item| @topic_item = topic_item }
     respond_with_resource(scope: {exclude_types: %w[discussion group user]})
   end
 

--- a/app/controllers/api/v1/outcomes_controller.rb
+++ b/app/controllers/api/v1/outcomes_controller.rb
@@ -1,6 +1,7 @@
 class Api::V1::OutcomesController < Api::V1::RestfulController
   def create_action
-    capture_topic_item(service.create(**{resource_symbol => resource, actor: current_user, params: resource_params}))
+    outcome = service.create(**{resource_symbol => resource, actor: current_user, params: resource_params}) { |topic_item| @topic_item = topic_item }
+    self.resource = outcome
   end
 
   def exclude_types

--- a/app/controllers/api/v1/polls_controller.rb
+++ b/app/controllers/api/v1/polls_controller.rb
@@ -83,18 +83,18 @@ class Api::V1::PollsController < Api::V1::RestfulController
   end
 
   def close
-    capture_topic_item(service.close(poll: load_resource, actor: current_user))
+    service.close(poll: load_resource, actor: current_user) { |topic_item| @topic_item = topic_item }
     respond_with_resource
   end
 
   def reopen
-    capture_topic_item(service.reopen(poll: load_resource, params: resource_params, actor: current_user))
+    service.reopen(poll: load_resource, params: resource_params, actor: current_user) { |topic_item| @topic_item = topic_item }
     respond_with_resource
   end
 
   def discard
     load_resource
-    capture_topic_item(service.discard(poll: resource, actor: current_user))
+    service.discard(poll: resource, actor: current_user) { |topic_item| @topic_item = topic_item }
     respond_with_resource
   end
 

--- a/app/controllers/api/v1/snorlax_base.rb
+++ b/app/controllers/api/v1/snorlax_base.rb
@@ -42,12 +42,18 @@ class Api::V1::SnorlaxBase < ActionController::Base
     self.resource = resource_class.find(params[:id])
   end
 
+  # Mutation services return their domain model, including an invalid model on
+  # validation failure. Authorization and persistence failures still raise.
+  # Operations that add a timeline entry may also yield the persisted topic item
+  # after their transaction commits.
   def create_action
-    capture_topic_item(service.create(**{resource_symbol => resource, actor: current_user}))
+    model = service.create(**{resource_symbol => resource, actor: current_user}) { |topic_item| @topic_item = topic_item }
+    self.resource = model
   end
 
   def update_action
-    capture_topic_item(service.update(**{resource_symbol => resource, params: resource_params, actor: current_user}))
+    model = service.update(**{resource_symbol => resource, params: resource_params, actor: current_user}) { |topic_item| @topic_item = topic_item }
+    self.resource = model
   end
 
   def destroy_action
@@ -153,10 +159,6 @@ class Api::V1::SnorlaxBase < ActionController::Base
 
   def collection=(value)
     instance_variable_set :"@#{resource_name.pluralize}", value
-  end
-
-  def capture_topic_item(result)
-    @topic_item = result if result.is_a?(TopicItem)
   end
 
   def instantiate_resource

--- a/app/controllers/dev/scenarios/discussion.rb
+++ b/app/controllers/dev/scenarios/discussion.rb
@@ -62,7 +62,8 @@ module Dev::Scenarios::Discussion
     create_another_discussion
     sign_in patrick
     CommentService.create(comment: Comment.new(parent: create_discussion, body: "This is totally on topic!"), actor: jennifer)
-    topic_item = CommentService.create(comment: Comment.new(parent: create_discussion, body: "This is totally **off** topic!"), actor: jennifer)
+    topic_item = nil
+    CommentService.create(comment: Comment.new(parent: create_discussion, body: "This is totally **off** topic!"), actor: jennifer) { |created_topic_item| topic_item = created_topic_item }
     CommentService.create(comment: Comment.new(parent: topic_item.itemable, body: "This is a reply to the off-topic thing!"), actor: emilio)
     CommentService.create(comment: Comment.new(parent: create_discussion, body: "This is also off-topic"), actor: emilio)
     CommentService.create(comment: Comment.new(parent: create_discussion, body: "This is totally back on topic!"), actor: patrick)
@@ -89,7 +90,8 @@ module Dev::Scenarios::Discussion
   def setup_thread_catch_up
     jennifer.update(email_catch_up_day: 7)
     CommentService.create(comment: Comment.new(parent: create_discussion, body: "first comment"), actor: patrick)
-    topic_item = CommentService.create(comment: Comment.new(parent: create_discussion, body: "removed comment"), actor: patrick)
+    topic_item = nil
+    CommentService.create(comment: Comment.new(parent: create_discussion, body: "removed comment"), actor: patrick) { |created_topic_item| topic_item = created_topic_item }
     CommentService.discard(comment: topic_item.itemable, actor: topic_item.user)
     DiscussionService.update(discussion: create_discussion,
                              params: {recipient_message: 'this is an edit message'},

--- a/app/helpers/dev/ninties_movies_helper.rb
+++ b/app/helpers/dev/ninties_movies_helper.rb
@@ -308,7 +308,8 @@ module Dev::NintiesMoviesHelper
     #'reaction_created'
     patrick_comment = Comment.new(parent: create_discussion, body: 'I\'m rather likeable')
     reaction = Reaction.new(reactable: patrick_comment, reaction: "❤️")
-    new_comment_event = CommentService.create(comment: patrick_comment, actor: patrick)
+    new_comment_event = nil
+    CommentService.create(comment: patrick_comment, actor: patrick) { |created_topic_item| new_comment_event = created_topic_item }
     ReactionService.update(reaction: reaction, params: {reaction: '🙂'}, actor: jennifer)
     create_another_group.add_member! jennifer
 

--- a/app/helpers/dev/scenarios_helper.rb
+++ b/app/helpers/dev/scenarios_helper.rb
@@ -129,7 +129,8 @@ module Dev::ScenariosHelper
     TopicReader.find_or_create_by!(topic: topic, user: scenario[:poll].author).set_volume!('loud') if topic
 
     stance = Stance.find_by(poll: scenario[:poll], participant: voter, latest: true)
-    topic_item = StanceService.update(stance: stance, actor: voter, params: cast_stance_params(scenario[:poll]))
+    topic_item = nil
+    StanceService.update(stance: stance, actor: voter, params: cast_stance_params(scenario[:poll])) { |created_topic_item| topic_item = created_topic_item }
     scenario[:stance] = topic_item.itemable
     scenario[:actor] = topic_item.itemable.participant
     scenario[:real_actor] = voter

--- a/app/services/anonymous_ballot_service.rb
+++ b/app/services/anonymous_ballot_service.rb
@@ -17,6 +17,6 @@ class AnonymousBallotService
       poll.update_counts!
     end
 
-    true
+    anonymous_ballot
   end
 end

--- a/app/services/bookmark_service.rb
+++ b/app/services/bookmark_service.rb
@@ -5,7 +5,7 @@ class BookmarkService
     bookmark.user = actor
     bookmark.discarded_at = nil # re-bookmarking an item that was removed
 
-    return false unless bookmark.valid?
+    return bookmark unless bookmark.valid?
     bookmark.save!
 
     MessageChannelService.publish_models([bookmark], user_id: actor.id)

--- a/app/services/chatbot_service.rb
+++ b/app/services/chatbot_service.rb
@@ -5,11 +5,12 @@ class ChatbotService
     actor.ability.authorize! :create, chatbot
     unless chatbot.valid?
       Sentry.metrics.count("chatbot.create_failed", attributes: { columns: chatbot.errors.attribute_names.join(',') })
-      return false
+      return chatbot
     end
     chatbot.author = actor
     chatbot.save!
     Sentry.metrics.count("chatbot.create", attributes: { kind: chatbot.kind })
+    chatbot
   end
 
   def self.update(chatbot:, params:, actor:)
@@ -18,10 +19,11 @@ class ChatbotService
     chatbot.assign_attributes(params.except(:group_id))
     unless chatbot.valid?
       Sentry.metrics.count("chatbot.update_failed", attributes: { columns: chatbot.errors.attribute_names.join(',') })
-      return false
+      return chatbot
     end
     chatbot.save!
     Sentry.metrics.count("chatbot.update", attributes: { kind: chatbot.kind })
+    chatbot
   end
 
   def self.destroy(chatbot:, actor:)

--- a/app/services/comment_service.rb
+++ b/app/services/comment_service.rb
@@ -1,9 +1,10 @@
 class CommentService
-  def self.create(comment:, actor:)
+  def self.create(comment:, actor:, &on_topic_item)
     comment.author = actor
     actor.ability.authorize! :create, comment
+    return comment unless comment.valid?
 
-    Comment.transaction do
+    topic_item = Comment.transaction do
       comment.save!
       comment.update_pg_search_document
       Sentry.metrics.count("comment.create", attributes: { parent_type: comment.parent_type })
@@ -17,9 +18,11 @@ class CommentService
       )
       topic_item
     end
+    on_topic_item&.call(topic_item)
+    comment
   end
 
-  def self.discard(comment:, actor:)
+  def self.discard(comment:, actor:, &on_topic_item)
     actor.ability.authorize!(:discard, comment)
     Sentry.metrics.count("comment.discard")
     ActiveRecord::Base.transaction do
@@ -28,17 +31,19 @@ class CommentService
     end
     comment.topic.update_sequence_info!
     ReindexCommentWorker.perform_later(comment.id)
-    comment.created_topic_item
+    on_topic_item&.call(comment.created_topic_item)
+    comment
   end
 
-  def self.undiscard(comment:, actor:)
+  def self.undiscard(comment:, actor:, &on_topic_item)
     actor.ability.authorize!(:undiscard, comment)
     ActiveRecord::Base.transaction do
       comment.update(discarded_at: nil, discarded_by: nil)
       comment.created_topic_item.update(user_id: comment.user_id)
     end
     ReindexCommentWorker.perform_later(comment.id)
-    comment.created_topic_item
+    on_topic_item&.call(comment.created_topic_item)
+    comment
   end
 
   def self.destroy(comment:, actor:)
@@ -60,7 +65,7 @@ class CommentService
     comment.assign_attributes_and_files(params)
     unless comment.valid?
       Sentry.metrics.count("comment.update_failed", attributes: { columns: comment.errors.attribute_names.join(',') })
-      return false
+      return comment
     end
     Comment.transaction do
       comment.save!

--- a/app/services/contact_message_service.rb
+++ b/app/services/contact_message_service.rb
@@ -1,19 +1,18 @@
 class ContactMessageService
   def self.create(contact_message:, actor:)
-    if contact_message.valid?
-      ContactMailer.contact_message(
-        contact_message.name,
-        contact_message.email,
-        contact_message.subject,
-        contact_message.message,
-        {
-          site: ENV['CANONICAL_HOST'],
-          form_type: 'Support',
-          user_id: actor.id
-        }.compact
-      ).deliver_later
-    else
-      raise "failed to send a contact message. name: #{contact_message.name}, #{contact_message.email}, #{contact_message.subject}, #{contact_message.errors.to_s}"
-    end
+    return contact_message unless contact_message.valid?
+
+    ContactMailer.contact_message(
+      contact_message.name,
+      contact_message.email,
+      contact_message.subject,
+      contact_message.message,
+      {
+        site: ENV['CANONICAL_HOST'],
+        form_type: 'Support',
+        user_id: actor.id
+      }.compact
+    ).deliver_later
+    contact_message
   end
 end

--- a/app/services/discussion_service.rb
+++ b/app/services/discussion_service.rb
@@ -20,12 +20,13 @@ class DiscussionService
     discussion
   end
 
-  def self.create(params:, actor:)
+  def self.create(params:, actor:, &on_topic_item)
     discussion = build(params: params, actor: actor)
+    actor.ability.authorize!(:create, discussion)
+    TagService.authorize_create_tag_names!(discussion.group, discussion.topic.tags, actor)
+    return discussion unless TopicService.validate_topicable(discussion)
 
-    Discussion.transaction do
-      actor.ability.authorize!(:create, discussion)
-      TagService.authorize_create_tag_names!(discussion.group, discussion.topic.tags, actor)
+    topic_item = Discussion.transaction do
       discussion.save!
       discussion.topic.save!
       discussion.topic.update_sequence_info!
@@ -78,12 +79,14 @@ class DiscussionService
         actor: actor,
         already_notified_user_ids: users.pluck(:id)
       )
+      topic_item
     end
     EventBus.broadcast('discussion_create', discussion, actor)
+    on_topic_item&.call(topic_item)
     discussion
   end
 
-  def self.update(discussion:, actor:, params:)
+  def self.update(discussion:, actor:, params:, &on_topic_item)
     actor.ability.authorize! :update, discussion
 
     UserInviter.authorize!(user_ids: params[:recipient_user_ids],
@@ -98,7 +101,7 @@ class DiscussionService
     discussion.assign_attributes_and_files(params)
     unless discussion.valid?
       Sentry.metrics.count("discussion.update_failed", attributes: { columns: discussion.errors.attribute_names.join(',') })
-      return false
+      return discussion
     end
     topic_item = nil
     Discussion.transaction do
@@ -145,7 +148,8 @@ class DiscussionService
       topic_item
     end
     MessageChannelService.publish_topic_model(discussion) unless topic_item
-    topic_item || discussion
+    on_topic_item&.call(topic_item) if topic_item
+    discussion
   end
 
   def self.discard(discussion:, actor:)

--- a/app/services/discussion_template_service.rb
+++ b/app/services/discussion_template_service.rb
@@ -4,7 +4,7 @@ class DiscussionTemplateService
 
     discussion_template.assign_attributes(author: actor)
 
-    return false unless discussion_template.valid?
+    return discussion_template unless discussion_template.valid?
 
     discussion_template.key = nil if discussion_template.key
     discussion_template.save!
@@ -17,7 +17,7 @@ class DiscussionTemplateService
     actor.ability.authorize! :update, discussion_template
 
     discussion_template.assign_attributes_and_files(params.except(:group_id))
-    return false unless discussion_template.valid?
+    return discussion_template unless discussion_template.valid?
     discussion_template.save!
 
     discussion_template

--- a/app/services/group_service.rb
+++ b/app/services/group_service.rb
@@ -92,7 +92,7 @@ module GroupService
 
     unless group.valid?
       Sentry.metrics.count("group.create_failed", attributes: { columns: group.errors.attribute_names.join(',') })
-      return false
+      return group
     end
 
     if group.is_parent?
@@ -111,6 +111,7 @@ module GroupService
 
     Sentry.metrics.count("group.create", attributes: { is_subgroup: !group.is_parent? })
     EventBus.broadcast('group_create', group, actor)
+    group
   end
 
   def self.update(group:, params:, actor:)
@@ -123,7 +124,7 @@ module GroupService
 
     unless group.valid?
       Sentry.metrics.count("group.update_failed", attributes: { columns: group.errors.attribute_names.join(',') })
-      return false
+      return group
     end
 
     Group.transaction do
@@ -140,6 +141,7 @@ module GroupService
 
     Sentry.metrics.count("group.update")
     EventBus.broadcast('group_update', group, params, actor)
+    group
   end
 
   def self.destroy(group:, actor:)

--- a/app/services/login_token_service.rb
+++ b/app/services/login_token_service.rb
@@ -6,5 +6,6 @@ class LoginTokenService
 
     UserMailer.login(actor.id, token.id).deliver_now
     EventBus.broadcast('login_token_create', token, actor)
+    token
   end
 end

--- a/app/services/membership_request_service.rb
+++ b/app/services/membership_request_service.rb
@@ -1,8 +1,8 @@
 class MembershipRequestService
   def self.create(membership_request:, actor:)
     membership_request.requestor = actor
-    return false unless membership_request.valid?
     actor.ability.authorize!(:create, membership_request)
+    return membership_request unless membership_request.valid?
 
     MembershipRequest.transaction do
       membership_request.save!

--- a/app/services/membership_service.rb
+++ b/app/services/membership_service.rb
@@ -118,12 +118,13 @@ class MembershipService
     actor.ability.authorize! :update, membership
 
     membership.assign_attributes(params.slice(:title))
-    return false unless membership.valid?
+    return membership unless membership.valid?
     membership.save!
 
     update_user_titles_and_broadcast(membership.id)
 
     EventBus.broadcast 'membership_update', membership, params, actor
+    membership
   end
 
   def self.update_user_titles_and_broadcast(membership_id)

--- a/app/services/outcome_service.rb
+++ b/app/services/outcome_service.rb
@@ -27,7 +27,7 @@ class OutcomeService
     users
   end
 
-  def self.create(outcome:, actor:, params: {})
+  def self.create(outcome:, actor:, params: {}, &on_topic_item)
     actor.ability.authorize! :create, outcome
 
     UserInviter.authorize!(user_ids: params[:recipient_user_ids],
@@ -39,7 +39,7 @@ class OutcomeService
     outcome.assign_attributes(author: actor)
     unless outcome.valid?
       Sentry.metrics.count("outcome.create_failed", attributes: { columns: outcome.errors.attribute_names.join(',') })
-      return false
+      return outcome
     end
     topic_item = Outcome.transaction do
       outcome.poll.outcomes.update_all(latest: false)
@@ -74,7 +74,8 @@ class OutcomeService
 
     Sentry.metrics.count("outcome.create")
     EventBus.broadcast 'outcome_create', outcome, actor
-    topic_item
+    on_topic_item&.call(topic_item)
+    outcome
   end
 
   def self.update(outcome:, actor:, params: {})
@@ -89,7 +90,7 @@ class OutcomeService
     outcome.assign_attributes_and_files(params.slice(:review_on, :statement, :statement_format, :event_summary, :event_location, :files, :image_files, :link_previews, :poll_option_id))
     unless outcome.valid?
       Sentry.metrics.count("outcome.update_failed", attributes: { columns: outcome.errors.attribute_names.join(',') })
-      return false
+      return outcome
     end
 
     Outcome.transaction do

--- a/app/services/poll_service.rb
+++ b/app/services/poll_service.rb
@@ -34,13 +34,13 @@ class PollService
     poll
   end
 
-  def self.create(params:, actor:)
+  def self.create(params:, actor:, &on_topic_item)
     poll = build(params: params, actor: actor)
+    actor.ability.authorize!(:create, poll)
+    TagService.authorize_create_tag_names!(poll.group, poll.topic.tags, actor)
+    return poll unless TopicService.validate_topicable(poll)
 
-    Poll.transaction do
-      actor.ability.authorize!(:create, poll)
-      TagService.authorize_create_tag_names!(poll.group, poll.topic.tags, actor)
-
+    topic_item = Poll.transaction do
       poll.save!
       if poll.detached_anonymous?
         create_anonymous_poll_voters(poll: poll, actor: actor, params: params)
@@ -62,13 +62,15 @@ class PollService
         actor: actor
       )
       announce_poll_opened(poll) if poll.opened_at && poll.notify_on_open
+      topic_item
     end
     EventBus.broadcast('poll_create', poll, actor)
     publish_topic_if_active(poll) if poll.opened_at
+    on_topic_item&.call(topic_item)
     poll
   end
 
-  def self.update(poll:, params:, actor:)
+  def self.update(poll:, params:, actor:, &on_topic_item)
     actor.ability.authorize! :update, poll
     UserInviter.authorize!(
       user_ids: params[:recipient_user_ids],
@@ -88,7 +90,7 @@ class PollService
 
     unless poll.valid?
       Sentry.metrics.count("poll.update_failed", attributes: { columns: poll.errors.attribute_names.join(',') })
-      return false
+      return poll
     end
 
     was_opened = false
@@ -146,7 +148,8 @@ class PollService
     EventBus.broadcast('poll_update', poll, actor)
     MessageChannelService.publish_topic_model(poll) unless topic_item
     publish_topic_if_active(poll) if was_opened
-    topic_item || poll
+    on_topic_item&.call(topic_item) if topic_item
+    poll
   end
 
   def self.invite(poll:, actor:, params:)
@@ -305,7 +308,7 @@ class PollService
     Stance.where(participant_id: users.pluck(:id), poll_id: poll.id, latest: true)
   end
 
-  def self.discard(poll:, actor:)
+  def self.discard(poll:, actor:, &on_topic_item)
     actor.ability.authorize!(:destroy, poll)
 
     Sentry.metrics.count("poll.discard", attributes: { poll_type: poll.poll_type })
@@ -322,10 +325,11 @@ class PollService
 
     ReindexPollWorker.perform_later(poll.id)
     MessageChannelService.publish_models([poll.created_topic_item], scope: {current_user: actor, current_user_id: actor.id}, group_id: poll.group_id)
-    poll.created_topic_item
+    on_topic_item&.call(poll.created_topic_item)
+    poll
   end
 
-  def self.close(poll:, actor:)
+  def self.close(poll:, actor:, &on_topic_item)
     actor.ability.authorize! :close, poll
     topic_item = Poll.transaction do
       do_closing_work(poll: poll)
@@ -336,10 +340,11 @@ class PollService
       )
     end
     publish_topic_if_active(poll)
-    topic_item
+    on_topic_item&.call(topic_item)
+    poll
   end
 
-  def self.reopen(poll:, params:, actor:)
+  def self.reopen(poll:, params:, actor:, &on_topic_item)
     actor.ability.authorize! :reopen, poll
 
     poll.assign_attributes(closing_at: params[:closing_at], closed_at: nil, opening_at: nil, opened_at: Time.now)
@@ -361,7 +366,8 @@ class PollService
     end
     EventBus.broadcast('poll_reopen', poll, actor)
     publish_topic_if_active(poll)
-    topic_item
+    on_topic_item&.call(topic_item)
+    poll
   end
 
   def self.publish_closing_soon(now: Time.current)

--- a/app/services/poll_template_service.rb
+++ b/app/services/poll_template_service.rb
@@ -68,7 +68,7 @@ class PollTemplateService
 
     poll_template.assign_attributes(author: actor)
 
-    return false unless poll_template.valid?
+    return poll_template unless poll_template.valid?
 
     if poll_template.key
       poll_template.group.hidden_poll_templates += Array(poll_template.key)
@@ -84,7 +84,7 @@ class PollTemplateService
     actor.ability.authorize! :update, poll_template
 
     poll_template.assign_attributes_and_files(params.except(:group_id))
-    return false unless poll_template.valid?
+    return poll_template unless poll_template.valid?
     poll_template.save!
 
     poll_template

--- a/app/services/reaction_service.rb
+++ b/app/services/reaction_service.rb
@@ -7,7 +7,7 @@ class ReactionService
 
     unless reaction.valid?
       Sentry.metrics.count("reaction.create_failed", attributes: { columns: reaction.errors.attribute_names.join(',') })
-      return false
+      return reaction
     end
     Reaction.transaction do
       reaction.save!

--- a/app/services/received_email_service.rb
+++ b/app/services/received_email_service.rb
@@ -77,7 +77,9 @@ class ReceivedEmailService
     when /[^\s]+\+u=.+&k=.+/
       # personal email-to-group, eg. enspiral+u=99&k=adsfghjl@mail.loomio.com
       if AppConfig.app_features[:thread_from_mail]
-        DiscussionService.create(params: discussion_params(email), actor: actor_from_email(email))
+        discussion = DiscussionService.create(params: discussion_params(email), actor: actor_from_email(email))
+        raise ActiveRecord::RecordInvalid, discussion if discussion.invalid?
+
         email.update_attribute(:released, true)
         return
       end
@@ -111,7 +113,9 @@ class ReceivedEmailService
         if actor = actor_from_email_and_group(email, group)
           email.update!(group: group)
           Rails.logger.info("creating discussion from email: #{email.route_path}")
-          DiscussionService.create(params: discussion_params(email), actor: actor)
+          discussion = DiscussionService.create(params: discussion_params(email), actor: actor)
+          raise ActiveRecord::RecordInvalid, discussion if discussion.invalid?
+
           return email.update_attribute(:released, true)
         else
           Rails.logger.info("unrecognised sender for route: #{email.sender_email}, #{email.route_path}")
@@ -270,7 +274,12 @@ class ReceivedEmailService
   end
 
   def self.create_comment_from_email(email)
-    CommentService.create(comment: Comment.new(comment_params(email)), actor: actor_from_email(email))
+    comment = CommentService.create(comment: Comment.new(comment_params(email)), actor: actor_from_email(email))
+    return comment if comment.errors.empty?
+
+    Rails.logger.info("email comment invalid: #{comment.errors.full_messages.join(', ')}")
+    send_comment_rejected_email(email, comment)
+    nil
   rescue ActiveRecord::RecordInvalid => e
     Rails.logger.info("email comment invalid: #{e.record.errors.full_messages.join(', ')}")
     send_comment_rejected_email(email, e.record)

--- a/app/services/stance_service.rb
+++ b/app/services/stance_service.rb
@@ -1,11 +1,13 @@
 class StanceService
-  def self.create(stance:, actor:)
+  def self.create(stance:, actor:, &on_topic_item)
     actor.ability.authorize!(:vote_in, stance.poll)
 
     stance.participant = actor
     stance.cast_at ||= Time.zone.now
     stance.revoked_at = nil
     stance.revoker_id = nil
+    return stance unless stance.valid?
+
     publication = Stance.transaction do
       stance.save!
       stance.poll.update_counts!
@@ -14,7 +16,8 @@ class StanceService
 
     publish_stance_directly!(stance, publication)
     Sentry.metrics.count("stance.create", attributes: { poll_type: stance.poll.poll_type })
-    publication[:topic_item] || stance
+    on_topic_item&.call(publication[:topic_item]) if publication[:topic_item]
+    stance
   end
 
   def self.uncast(stance:, actor:)
@@ -29,7 +32,7 @@ class StanceService
     new_stance.poll.update_counts!
   end
 
-  def self.update(stance: , actor: , params: )
+  def self.update(stance: , actor: , params: , &on_topic_item)
     actor.ability.authorize!(:update, stance)
     params = params.to_h.with_indifferent_access.except(:poll_id)
     is_update = !!stance.cast_at
@@ -37,11 +40,21 @@ class StanceService
     new_stance = stance.build_replacement
     new_stance.assign_attributes_and_files(params)
 
+    creates_replacement = is_update && stance.option_scores != new_stance.build_option_scores && (Comment.kept.where(parent: stance).exists? || stance.updated_at < 15.minutes.ago)
+    stance_changed = creates_replacement ? new_stance : stance
+    unless creates_replacement
+      stance.stance_choices = []
+      stance.assign_attributes_and_files(params)
+      stance.cast_at ||= Time.zone.now
+      stance.revoked_at = nil
+      stance.revoker_id = nil
+    end
+    return stance_changed unless stance_changed.valid?
+
     stance_to_publish = nil
-    stance_changed = nil
     metric_name = nil
     publication = Stance.transaction do
-      if is_update && stance.option_scores != new_stance.build_option_scores && (Comment.kept.where(parent: stance).exists? ||  stance.updated_at < 15.minutes.ago)
+      if creates_replacement
         # they've changed their position, and someone has replied to them or it's been a while and people will have seeen their position
 
         new_stance.cast_at = Time.zone.now
@@ -53,11 +66,6 @@ class StanceService
         metric_name = "stance.update"
         publish_stance_change!(stance: new_stance, kind: "stance_created")
       else
-        stance.stance_choices = []
-        stance.assign_attributes_and_files(params)
-        stance.cast_at ||= Time.zone.now
-        stance.revoked_at = nil
-        stance.revoker_id = nil
         stance.save!
         stance.poll.update_counts!
         stance_changed = stance
@@ -74,7 +82,8 @@ class StanceService
     end
     publish_stance_directly!(stance_changed, publication)
     Sentry.metrics.count(metric_name, attributes: { poll_type: stance.poll.poll_type })
-    publication[:topic_item] || stance_changed
+    on_topic_item&.call(publication[:topic_item]) if publication[:topic_item]
+    stance_changed
   end
 
   def self.redeem(stance:, actor:)

--- a/app/services/tag_service.rb
+++ b/app/services/tag_service.rb
@@ -6,7 +6,7 @@ class TagService
     tag.name = clean_tag_name(tag.name)
     actor.ability.authorize! :create, tag
 
-    return false unless tag.valid?
+    return tag unless tag.valid?
     tag.save!
     EventBus.broadcast 'tag_create', tag, actor
     MessageChannelService.publish_models([tag], group_id: tag.group.id)

--- a/app/services/topic_service.rb
+++ b/app/services/topic_service.rb
@@ -6,6 +6,15 @@ class TopicService
     group ? !group.public_discussions_only? : true
   end
 
+  def self.validate_topicable(topicable)
+    topicable_valid = topicable.valid?
+    topic_valid = topicable.topic.valid?
+    topicable.topic.errors.each do |error|
+      topicable.errors.add(error.attribute, error.message)
+    end
+    topicable_valid && topic_valid
+  end
+
   def self.invite(topic:, actor:, params:)
     UserInviter.authorize!(user_ids: params[:recipient_user_ids],
                            emails: params[:recipient_emails],
@@ -53,8 +62,11 @@ class TopicService
     actor.ability.authorize! :update, topic
     topic.assign_attributes(params)
     rearrange = topic.max_depth_changed?
+    return topic unless topic.valid?
+
     topic.save!
     RepairTopicWorker.perform_later(topic.id) if rearrange
+    topic
   end
 
   def self.update_tags(topic:, tags:, actor:)

--- a/app/services/user_service.rb
+++ b/app/services/user_service.rb
@@ -75,7 +75,7 @@ class UserService
     user.assign_attributes_and_files(params)
     unless user.valid?
       Sentry.metrics.count("user.update_failed", attributes: { columns: user.errors.attribute_names.join(',') })
-      return false
+      return user
     end
     password_changed = user.password_digest_changed?
     user.save!
@@ -85,6 +85,7 @@ class UserService
     end
     EventBus.broadcast('user_update', user, actor, params)
     ReindexAuthorWorker.perform_later(user.id) if user.name_previously_changed?
+    user
   end
 
   def self.disable_edit_user_profile?

--- a/app/views/admin/subscriptions/edit.rb
+++ b/app/views/admin/subscriptions/edit.rb
@@ -22,6 +22,7 @@ class Views::Admin::Subscriptions::Edit < Views::Admin::Layout
       field(form, :chargify_subscription_id)
       field(form, :owner_id, type: :number_field)
       form.submit("Save subscription", class: "admin-button")
+      form.button("Save and refresh from Chargify", name: "refresh_from_chargify", value: "1", class: "admin-button")
     end
   end
 end

--- a/test/controllers/admin/subscriptions_controller_test.rb
+++ b/test/controllers/admin/subscriptions_controller_test.rb
@@ -48,11 +48,40 @@ class Admin::SubscriptionsControllerTest < ActionController::TestCase
     assert_equal SubscriptionService::PLANS.keys.map(&:to_s), select_values(document, "subscription_plan")
     assert_equal Subscription::PAYMENT_METHODS, select_values(document, "subscription_payment_method")
     assert_equal Subscription::STATES, select_values(document, "subscription_state")
+    assert_includes response.body, "Save and refresh from Chargify"
 
     put :update, params: { id: @subscription.id, subscription: { plan: "community", max_members: 200 } }
     assert_redirected_to admin_subscription_path(@subscription)
     assert_equal "community", @subscription.reload.plan
     assert_equal 200, @subscription.max_members
+  end
+
+  test "admin can update the Chargify ID and refresh in one action" do
+    sign_in @admin
+    payload = { "subscription" => { "state" => "active" } }
+    fetched_id = nil
+    updated = nil
+
+    service = Object.new
+    service.define_singleton_method(:chargify_get) do |id|
+      fetched_id = id
+      payload
+    end
+    service.define_singleton_method(:update) { |subscription:, params:| updated = [ subscription, params ] }
+
+    @controller.stub(:subscription_service, service) do
+      put :update, params: {
+        id: @subscription.id,
+        subscription: { chargify_subscription_id: 67890 },
+        refresh_from_chargify: "1"
+      }
+    end
+
+    assert_equal 67890, @subscription.reload.chargify_subscription_id
+    assert_equal 67890, fetched_id
+    assert_equal [ @subscription, payload ], updated
+    assert_redirected_to admin_subscription_path(@subscription)
+    assert_equal "Subscription updated and refreshed from Chargify", flash[:notice]
   end
 
   test "subscription update rejects unpermitted attributes" do
@@ -84,13 +113,13 @@ class Admin::SubscriptionsControllerTest < ActionController::TestCase
 
     service = Object.new
     service.define_singleton_method(:chargify_get) { |_id| payload }
-    service.define_singleton_method(:update) { |subscription:, params:| updated = [subscription, params] }
+    service.define_singleton_method(:update) { |subscription:, params:| updated = [ subscription, params ] }
 
     @controller.stub(:subscription_service, service) do
       post :refresh, params: { id: @subscription.id }
     end
 
-    assert_equal [@subscription, payload], updated
+    assert_equal [ @subscription, payload ], updated
     assert_redirected_to admin_subscription_path(@subscription)
   end
 

--- a/test/controllers/api/v1/topic_items_controller_test.rb
+++ b/test/controllers/api/v1/topic_items_controller_test.rb
@@ -15,7 +15,8 @@ class Api::V1::TopicItemsControllerTest < ActionController::TestCase
   test "pin topic_item pins an topic_item" do
     sign_in @admin
     comment = Comment.new(parent: @discussion, body: "Test comment")
-    topic_item = CommentService.create(comment: comment, actor: @user)
+    topic_item = nil
+    CommentService.create(comment: comment, actor: @user) { |created_topic_item| topic_item = created_topic_item }
 
     patch :pin, params: { id: topic_item.id, pinned_title: "Pinned context" }
 
@@ -45,7 +46,8 @@ class Api::V1::TopicItemsControllerTest < ActionController::TestCase
   test "index filters by discussion" do
     sign_in @user
     comment = Comment.new(parent: @discussion, body: "Test comment")
-    topic_item = CommentService.create(comment: comment, actor: @user)
+    topic_item = nil
+    CommentService.create(comment: comment, actor: @user) { |created_topic_item| topic_item = created_topic_item }
 
     get :index, params: { discussion_id: @discussion.id }, format: :json
     json = JSON.parse(response.body)
@@ -58,7 +60,8 @@ class Api::V1::TopicItemsControllerTest < ActionController::TestCase
   test "comment returns topic_items from a comment" do
     sign_in @user
     comment = Comment.new(parent: @discussion, body: "Test comment")
-    topic_item = CommentService.create(comment: comment, actor: @user)
+    topic_item = nil
+    CommentService.create(comment: comment, actor: @user) { |created_topic_item| topic_item = created_topic_item }
 
     get :comment, params: { discussion_id: @discussion.id, comment_id: topic_item.itemable.id }
     json = JSON.parse(response.body)
@@ -76,7 +79,8 @@ class Api::V1::TopicItemsControllerTest < ActionController::TestCase
   test "comment does not leak a comment from a different topic (IDOR)" do
     # A comment lives in a discussion the actor is NOT allowed to see...
     secret_comment = Comment.new(parent: discussions(:alien_discussion), body: "secret")
-    secret_event = CommentService.create(comment: secret_comment, actor: users(:alien))
+    secret_event = nil
+    CommentService.create(comment: secret_comment, actor: users(:alien)) { |created_topic_item| secret_event = created_topic_item }
 
     # ...and the actor supplies a topic they CAN see plus the foreign comment id.
     sign_in @user
@@ -89,7 +93,8 @@ class Api::V1::TopicItemsControllerTest < ActionController::TestCase
 
   test "index does not use a comment from another topic as its starting point" do
     secret_comment = Comment.new(parent: discussions(:alien_discussion), body: "secret")
-    secret_event = CommentService.create(comment: secret_comment, actor: users(:alien))
+    secret_event = nil
+    CommentService.create(comment: secret_comment, actor: users(:alien)) { |created_topic_item| secret_event = created_topic_item }
     sign_in @user
 
     get :index, params: {
@@ -122,8 +127,10 @@ class Api::V1::TopicItemsControllerTest < ActionController::TestCase
 
   test "index unread_or_newest returns unread topic_items by discussion key" do
     sign_in @user
-    read_event = CommentService.create(comment: Comment.new(parent: @discussion, body: "Read comment"), actor: @admin)
-    unread_event = CommentService.create(comment: Comment.new(parent: @discussion, body: "Unread comment"), actor: @admin)
+    read_event = nil
+    CommentService.create(comment: Comment.new(parent: @discussion, body: "Read comment"), actor: @admin) { |created_topic_item| read_event = created_topic_item }
+    unread_event = nil
+    CommentService.create(comment: Comment.new(parent: @discussion, body: "Unread comment"), actor: @admin) { |created_topic_item| unread_event = created_topic_item }
     TopicReader.for(user: @user, topic: @discussion.topic).viewed!([0, read_event.sequence_id])
 
     get :index, params: { discussion_key: @discussion.key, unread_or_newest: 1, per: 10 }, format: :json
@@ -136,7 +143,8 @@ class Api::V1::TopicItemsControllerTest < ActionController::TestCase
 
   test "index unread_or_newest includes root topic_item when unread" do
     sign_in @user
-    topic_item = CommentService.create(comment: Comment.new(parent: @discussion, body: "Unread comment"), actor: @admin)
+    topic_item = nil
+    CommentService.create(comment: Comment.new(parent: @discussion, body: "Unread comment"), actor: @admin) { |created_topic_item| topic_item = created_topic_item }
 
     get :index, params: { discussion_key: @discussion.key, unread_or_newest: 1, per: 10 }, format: :json
     json = JSON.parse(response.body)
@@ -147,9 +155,12 @@ class Api::V1::TopicItemsControllerTest < ActionController::TestCase
 
   test "index unread_or_newest returns newest topic_items when fully read" do
     sign_in @user
-    first_event = CommentService.create(comment: Comment.new(parent: @discussion, body: "First comment"), actor: @admin)
-    second_event = CommentService.create(comment: Comment.new(parent: @discussion, body: "Second comment"), actor: @admin)
-    third_event = CommentService.create(comment: Comment.new(parent: @discussion, body: "Third comment"), actor: @admin)
+    first_event = nil
+    CommentService.create(comment: Comment.new(parent: @discussion, body: "First comment"), actor: @admin) { |created_topic_item| first_event = created_topic_item }
+    second_event = nil
+    CommentService.create(comment: Comment.new(parent: @discussion, body: "Second comment"), actor: @admin) { |created_topic_item| second_event = created_topic_item }
+    third_event = nil
+    CommentService.create(comment: Comment.new(parent: @discussion, body: "Third comment"), actor: @admin) { |created_topic_item| third_event = created_topic_item }
     TopicReader.for(user: @user, topic: @discussion.topic).viewed!(@discussion.topic.reload.items.pluck(:sequence_id))
 
     get :index, params: { discussion_key: @discussion.key, unread_or_newest: 1, per: 2 }, format: :json
@@ -170,7 +181,8 @@ class Api::V1::TopicItemsControllerTest < ActionController::TestCase
       poll_option_names: %w[agree disagree],
       closing_at: 3.days.from_now
     }, actor: @admin)
-    later_event = CommentService.create(comment: Comment.new(parent: @discussion, body: "After poll"), actor: @admin)
+    later_event = nil
+    CommentService.create(comment: Comment.new(parent: @discussion, body: "After poll"), actor: @admin) { |created_topic_item| later_event = created_topic_item }
 
     get :index, params: { poll_key: poll.key, unread_or_newest: 1, per: 10 }, format: :json
     json = JSON.parse(response.body)
@@ -224,10 +236,11 @@ class Api::V1::TopicItemsControllerTest < ActionController::TestCase
       poll_option_names: %w[agree disagree],
       closing_at: 3.days.from_now
     }, actor: @admin)
-    unread_event = CommentService.create(
+    unread_event = nil
+    CommentService.create(
       comment: Comment.new(parent: @discussion, body: 'Unread comment'),
       actor: @admin
-    )
+    ) { |created_topic_item| unread_event = created_topic_item }
     TopicReader.for(user: @user, topic: @discussion.topic).viewed!([0, poll.created_topic_item.sequence_id])
 
     get :index, params: {
@@ -251,13 +264,16 @@ class Api::V1::TopicItemsControllerTest < ActionController::TestCase
   test "index handles parent_id parameter with correct filtering" do
     sign_in @user
     parent_comment = Comment.new(parent: @discussion, body: "Parent comment")
-    parent_topic_item = CommentService.create(comment: parent_comment, actor: @user)
+    parent_topic_item = nil
+    CommentService.create(comment: parent_comment, actor: @user) { |created_topic_item| parent_topic_item = created_topic_item }
 
     child_comment = Comment.new(body: "Child comment", parent: parent_comment)
-    child_topic_item = CommentService.create(comment: child_comment, actor: @user)
+    child_topic_item = nil
+    CommentService.create(comment: child_comment, actor: @user) { |created_topic_item| child_topic_item = created_topic_item }
 
     unrelated_comment = Comment.new(parent: @discussion, body: "Unrelated comment")
-    unrelated_event = CommentService.create(comment: unrelated_comment, actor: @user)
+    unrelated_event = nil
+    CommentService.create(comment: unrelated_comment, actor: @user) { |created_topic_item| unrelated_event = created_topic_item }
 
     get :index, params: { discussion_id: @discussion.id, parent_id: parent_topic_item.id }
     json = JSON.parse(response.body)
@@ -272,10 +288,11 @@ class Api::V1::TopicItemsControllerTest < ActionController::TestCase
 
   test "logged out user can see topic_items for public discussion" do
     @public_group.add_member!(@user)
-    topic_item = CommentService.create(
+    topic_item = nil
+    CommentService.create(
       comment: Comment.new(body: "Public comment", parent: @public_discussion),
       actor: @user
-    )
+    ) { |created_topic_item| topic_item = created_topic_item }
 
     get :index, params: { discussion_id: @public_discussion.id }, format: :json
     assert_response :success
@@ -297,14 +314,16 @@ class Api::V1::TopicItemsControllerTest < ActionController::TestCase
     other_discussion = discussions(:discussion_in_subgroup)
 
     sign_in @user
-    event1 = CommentService.create(
+    event1 = nil
+    CommentService.create(
       comment: Comment.new(body: "In first discussion", parent: @discussion),
       actor: @user
-    )
-    event2 = CommentService.create(
+    ) { |created_topic_item| event1 = created_topic_item }
+    event2 = nil
+    CommentService.create(
       comment: Comment.new(body: "In other discussion", parent: other_discussion),
       actor: @user
-    )
+    ) { |created_topic_item| event2 = created_topic_item }
 
     get :index, params: { discussion_id: @discussion.id }, format: :json
     json = JSON.parse(response.body)

--- a/test/controllers/dev/poll_mailer_test.rb
+++ b/test/controllers/dev/poll_mailer_test.rb
@@ -69,7 +69,8 @@ class Dev::PollMailerTest < ActiveSupport::TestCase
 
     stance = poll.stances.find_by(participant_id: user.id, latest: true)
     return unless stance
-    topic_item = StanceService.update(stance: stance, actor: user, params: cast_stance_params(poll))
+    topic_item = nil
+    StanceService.update(stance: stance, actor: user, params: cast_stance_params(poll)) { |created_topic_item| topic_item = created_topic_item }
     stance.reload
     topic_item
   end

--- a/test/controllers/email_actions_controller_test.rb
+++ b/test/controllers/email_actions_controller_test.rb
@@ -122,7 +122,8 @@ class EmailActionsControllerTest < ActionController::TestCase
   end
 
   test "marks a comment as read" do
-    comment_event = CommentService.create(comment: Comment.new(parent: @discussion, body: "hello"), actor: @author)
+    comment_event = nil
+    CommentService.create(comment: Comment.new(parent: @discussion, body: "hello"), actor: @author) { |created_topic_item| comment_event = created_topic_item }
     reader = TopicReader.for(user: @user, topic: @topic)
     refute reader.has_read?(comment_event.sequence_id)
 

--- a/test/models/discussion_test.rb
+++ b/test/models/discussion_test.rb
@@ -104,7 +104,8 @@ class DiscussionTest < ActiveSupport::TestCase
   test "creating a comment increments correctly" do
     discussion = DiscussionService.create(params: { group_id: @group.id, title: "Test #{SecureRandom.hex(4)}" }, actor: @admin)
     comment = Comment.new(parent: discussion, body: "A comment")
-    topic_item = CommentService.create(comment: comment, actor: @admin)
+    topic_item = nil
+    CommentService.create(comment: comment, actor: @admin) { |created_topic_item| topic_item = created_topic_item }
     topic_item.reload
     topic = discussion.topic.reload
     assert_equal 2, topic.items_count
@@ -130,10 +131,12 @@ class DiscussionTest < ActiveSupport::TestCase
   test "deleting first comment of two decrements correctly" do
     discussion = DiscussionService.create(params: { group_id: @group.id, title: "Test #{SecureRandom.hex(4)}" }, actor: @admin)
     comment1 = Comment.new(parent: discussion, body: "First")
-    event1 = CommentService.create(comment: comment1, actor: @admin)
+    event1 = nil
+    CommentService.create(comment: comment1, actor: @admin) { |created_topic_item| event1 = created_topic_item }
 
     comment2 = Comment.new(parent: discussion, body: "Second")
-    event2 = CommentService.create(comment: comment2, actor: @admin)
+    event2 = nil
+    CommentService.create(comment: comment2, actor: @admin) { |created_topic_item| event2 = created_topic_item }
 
     event1.reload
     event2.reload
@@ -151,10 +154,12 @@ class DiscussionTest < ActiveSupport::TestCase
   test "deleting last comment of two decrements correctly" do
     discussion = DiscussionService.create(params: { group_id: @group.id, title: "Test #{SecureRandom.hex(4)}" }, actor: @admin)
     comment1 = Comment.new(parent: discussion, body: "First")
-    event1 = CommentService.create(comment: comment1, actor: @admin)
+    event1 = nil
+    CommentService.create(comment: comment1, actor: @admin) { |created_topic_item| event1 = created_topic_item }
 
     comment2 = Comment.new(parent: discussion, body: "Second")
-    event2 = CommentService.create(comment: comment2, actor: @admin)
+    event2 = nil
+    CommentService.create(comment: comment2, actor: @admin) { |created_topic_item| event2 = created_topic_item }
 
     event1.reload
     comment2.reload

--- a/test/models/poll_test.rb
+++ b/test/models/poll_test.rb
@@ -112,9 +112,10 @@ class PollTest < ActiveSupport::TestCase
   end
 
   test "score bounds must be nonnegative and ordered" do
-    assert_raises(ActiveRecord::RecordInvalid) do
-      create_poll(poll_type: "score", poll_option_names: %w[apple orange], min_score: -1)
-    end
+    invalid_poll = create_poll(poll_type: "score", poll_option_names: %w[apple orange], min_score: -1)
+
+    assert_predicate invalid_poll, :invalid?
+    assert_not invalid_poll.persisted?
 
     poll = create_poll(poll_type: "score", poll_option_names: %w[apple orange])
 

--- a/test/models/topic_item_test.rb
+++ b/test/models/topic_item_test.rb
@@ -356,7 +356,8 @@ class EventTest < ActiveSupport::TestCase
     @poll.update!(hide_results: 'until_vote')
     stance = @poll.stances.create!(participant: @user_thread_normal, inviter: @admin, latest: true, reason: "Response")
     stance.choice = @poll.poll_option_names.first
-    topic_item = StanceService.create(stance: stance, actor: @user_thread_normal)
+    topic_item = nil
+    StanceService.create(stance: stance, actor: @user_thread_normal) { |created_topic_item| topic_item = created_topic_item }
 
     assert_equal @poll.topic_id, topic_item.topic_id
     assert_not Notification.about(stance).exists?(kind: "stance_created")
@@ -373,12 +374,12 @@ class EventTest < ActiveSupport::TestCase
     stance = @poll.stances.create!(participant: @user_thread_normal, inviter: @admin, latest: true, reason: "Hidden response")
     stance.choice = @poll.poll_option_names.first
     publish_count = 0
-    result = nil
+    created_stance = nil
     MessageChannelService.stub(:publish_topic_model, ->(*) { publish_count += 1 }) do
-      result = StanceService.create(stance: stance, actor: @user_thread_normal)
+      created_stance = StanceService.create(stance: stance, actor: @user_thread_normal)
     end
 
-    assert_equal stance, result
+    assert_equal stance, created_stance
     assert_not Notification.about(stance).exists?(kind: "stance_created")
     assert_equal 0, publish_count
   end

--- a/test/models/topic_reader_test.rb
+++ b/test/models/topic_reader_test.rb
@@ -26,10 +26,12 @@ class TopicReaderTest < ActiveSupport::TestCase
     @reader.update!(last_read_at: 6.days.ago)
 
     comment1 = Comment.new(parent: @discussion, body: "Older", author: @admin)
-    older_event = CommentService.create(comment: comment1, actor: @admin)
+    older_event = nil
+    CommentService.create(comment: comment1, actor: @admin) { |created_topic_item| older_event = created_topic_item }
 
     comment2 = Comment.new(parent: @discussion, body: "Newer", author: @admin)
-    newer_event = CommentService.create(comment: comment2, actor: @admin)
+    newer_event = nil
+    CommentService.create(comment: comment2, actor: @admin) { |created_topic_item| newer_event = created_topic_item }
 
     @reader.viewed!([newer_event, older_event].map(&:sequence_id))
     assert_equal 2, @reader.read_items_count
@@ -40,10 +42,12 @@ class TopicReaderTest < ActiveSupport::TestCase
     @reader.update!(last_read_at: 6.days.ago)
 
     comment1 = Comment.new(parent: @discussion, body: "Older", author: @admin)
-    older_event = CommentService.create(comment: comment1, actor: @admin)
+    older_event = nil
+    CommentService.create(comment: comment1, actor: @admin) { |created_topic_item| older_event = created_topic_item }
 
     comment2 = Comment.new(parent: @discussion, body: "Newer", author: @admin)
-    newer_event = CommentService.create(comment: comment2, actor: @admin)
+    newer_event = nil
+    CommentService.create(comment: comment2, actor: @admin) { |created_topic_item| newer_event = created_topic_item }
 
     @reader.viewed!(newer_event.sequence_id)
     assert_not @reader.has_read?(older_event.sequence_id)
@@ -55,7 +59,8 @@ class TopicReaderTest < ActiveSupport::TestCase
     @reader.update!(last_read_at: 6.days.ago)
 
     comment = Comment.new(parent: @discussion, body: "Older", author: @admin)
-    topic_item = CommentService.create(comment: comment, actor: @admin)
+    topic_item = nil
+    CommentService.create(comment: comment, actor: @admin) { |created_topic_item| topic_item = created_topic_item }
 
     @reader.viewed!(topic_item.sequence_id)
     assert_equal 1, @reader.read_items_count

--- a/test/services/anonymous_ballot_service_test.rb
+++ b/test/services/anonymous_ballot_service_test.rb
@@ -130,7 +130,10 @@ class AnonymousBallotServiceTest < ActiveSupport::TestCase
       actor: @admin
     )
 
-    refute PollService.update(poll: identified_poll, params: { anonymous: true }, actor: @admin)
+    updated_poll = PollService.update(poll: identified_poll, params: { anonymous: true }, actor: @admin)
+
+    assert_same identified_poll, updated_poll
+    assert_predicate updated_poll, :invalid?
     refute identified_poll.reload.anonymous?
   end
 

--- a/test/services/comment_reply_notification_test.rb
+++ b/test/services/comment_reply_notification_test.rb
@@ -40,7 +40,8 @@ class CommentReplyNotificationTest < ActiveSupport::TestCase
       body_format: "md",
       parent: @parent
     )
-    topic_item = CommentService.create(comment: comment, actor: @reply_author)
+    topic_item = nil
+    CommentService.create(comment: comment, actor: @reply_author) { |created_topic_item| topic_item = created_topic_item }
 
     assert_no_difference [ "Notification.count", "NotificationDelivery.count" ] do
       PublishSubscriberEmailsTopicItemWorker.perform_now(topic_item.id)

--- a/test/services/comment_service_test.rb
+++ b/test/services/comment_service_test.rb
@@ -11,7 +11,7 @@ class CommentServiceTest < ActiveSupport::TestCase
     @discussion = discussions(:discussion)
   end
 
-  test "creates a comment and returns an topic_item" do
+  test "creates a comment, returns it, and yields its topic item" do
     comment = Comment.new(
       parent: @discussion,
       author: @user,
@@ -19,8 +19,10 @@ class CommentServiceTest < ActiveSupport::TestCase
       body_format: "md"
     )
 
-    topic_item = CommentService.create(comment: comment, actor: @user)
+    topic_item = nil
+    created_comment = CommentService.create(comment: comment, actor: @user) { |created_topic_item| topic_item = created_topic_item }
 
+    assert_equal comment, created_comment
     assert_kind_of TopicItem, topic_item
     assert comment.persisted?
     assert_equal "My body is ready", comment.body
@@ -38,7 +40,7 @@ class CommentServiceTest < ActiveSupport::TestCase
 
     topic_item = nil
     NotificationService.stub(:create!, ->(**) { raise "notification creation is not expected" }) do
-      topic_item = CommentService.create(comment: comment, actor: @user)
+      CommentService.create(comment: comment, actor: @user) { |created_topic_item| topic_item = created_topic_item }
     end
 
     assert_predicate comment, :persisted?
@@ -93,13 +95,14 @@ class CommentServiceTest < ActiveSupport::TestCase
       body_format: "md"
     )
 
-    topic_item = CommentService.create(comment: comment, actor: @user)
+    topic_item = nil
+    CommentService.create(comment: comment, actor: @user) { |created_topic_item| topic_item = created_topic_item }
 
     assert reader.reload.has_read?(topic_item.sequence_id)
     assert_equal 0, reader.unread_items_count
   end
 
-  test "raises when creating invalid comment" do
+  test "returns an invalid comment without creating it" do
     comment = Comment.new(
       parent: @discussion,
       author: @user,
@@ -107,9 +110,10 @@ class CommentServiceTest < ActiveSupport::TestCase
       body_format: "md"
     )
 
-    assert_raises ActiveRecord::RecordInvalid do
-      CommentService.create(comment: comment, actor: @user)
-    end
+    created_comment = CommentService.create(comment: comment, actor: @user)
+
+    assert_same comment, created_comment
+    assert_predicate created_comment, :invalid?
     assert_not comment.persisted?
   end
 
@@ -122,9 +126,9 @@ class CommentServiceTest < ActiveSupport::TestCase
       body_format: "md"
     )
 
-    assert_raises ActiveRecord::RecordInvalid do
-      CommentService.create(comment: comment, actor: @user)
-    end
+    created_comment = CommentService.create(comment: comment, actor: @user)
+
+    assert_same comment, created_comment
     assert_not comment.persisted?
     assert_includes comment.errors[:body], "Comment must be 10 characters or less"
   end
@@ -138,9 +142,9 @@ class CommentServiceTest < ActiveSupport::TestCase
       body_format: "md"
     )
 
-    assert_raises ActiveRecord::RecordInvalid do
-      CommentService.create(comment: comment, actor: @user)
-    end
+    created_comment = CommentService.create(comment: comment, actor: @user)
+
+    assert_same comment, created_comment
     assert_includes comment.errors[:body], "Comment must be 1 characters or less"
   end
 
@@ -168,9 +172,9 @@ class CommentServiceTest < ActiveSupport::TestCase
       body_format: "html"
     )
 
-    assert_raises ActiveRecord::RecordInvalid do
-      CommentService.create(comment: comment, actor: @user)
-    end
+    created_comment = CommentService.create(comment: comment, actor: @user)
+
+    assert_same comment, created_comment
     assert_includes comment.errors[:body], "Comment must be 4 characters or less"
   end
 
@@ -296,12 +300,14 @@ class CommentServiceTest < ActiveSupport::TestCase
       actor: @user
     )
 
-    refute CommentService.update(
+    updated_comment = CommentService.update(
       comment: comment,
       params: { parent_type: 'Discussion', parent_id: other_discussion.id },
       actor: @user
     )
 
+    assert_same comment, updated_comment
+    assert_predicate updated_comment, :invalid?
     comment.reload
     assert_equal @discussion, comment.parent
   end
@@ -358,9 +364,11 @@ class CommentServiceTest < ActiveSupport::TestCase
 
   test "destroying an topic_item reparents its timeline children" do
     comment = Comment.new(parent: @discussion, author: @user, body: "Parent")
-    topic_item = CommentService.create(comment: comment, actor: @user)
+    topic_item = nil
+    CommentService.create(comment: comment, actor: @user) { |created_topic_item| topic_item = created_topic_item }
     reply = Comment.new(parent: comment, author: @user, body: "Reply")
-    reply_event = CommentService.create(comment: reply, actor: @user)
+    reply_event = nil
+    CommentService.create(comment: reply, actor: @user) { |created_topic_item| reply_event = created_topic_item }
 
     topic_item.destroy!
 
@@ -370,9 +378,11 @@ class CommentServiceTest < ActiveSupport::TestCase
 
   test "destroying a topic root destroys its complete topic_item tree" do
     comment = Comment.new(parent: @discussion, author: @user, body: "Parent")
-    topic_item = CommentService.create(comment: comment, actor: @user)
+    topic_item = nil
+    CommentService.create(comment: comment, actor: @user) { |created_topic_item| topic_item = created_topic_item }
     reply = Comment.new(parent: comment, author: @user, body: "Reply")
-    reply_event = CommentService.create(comment: reply, actor: @user)
+    reply_event = nil
+    CommentService.create(comment: reply, actor: @user) { |created_topic_item| reply_event = created_topic_item }
 
     @discussion.created_topic_item.destroy!
 

--- a/test/services/discussion_service_test.rb
+++ b/test/services/discussion_service_test.rb
@@ -40,22 +40,20 @@ class DiscussionServiceTest < ActiveSupport::TestCase
     assert_equal false, discussion.topic.private
   end
 
-  test "raises a validation error when discussion privacy is not permitted by the group" do
+  test "returns an invalid discussion when its privacy is not permitted by the group" do
     group = Group.create!(
       name: "Open Group #{SecureRandom.hex(4)}",
       group_privacy: 'open'
     )
     Membership.create!(user: @user, group: group, accepted_at: Time.current, admin: true)
 
-    error = assert_raises ActiveRecord::RecordInvalid do
-      DiscussionService.create(
-        params: { title: 'Private Discussion', group_id: group.id, private: true },
-        actor: @user
-      )
-    end
+    discussion = DiscussionService.create(
+      params: { title: 'Private Discussion', group_id: group.id, private: true },
+      actor: @user
+    )
 
-    assert_equal ['must be public'], error.record.errors[:private]
-    assert_not error.record.persisted?
+    assert_equal ['must be public'], discussion.errors[:private]
+    assert_not discussion.persisted?
   end
 
   test "does not allow unauthorized user to create discussion" do
@@ -157,6 +155,23 @@ class DiscussionServiceTest < ActiveSupport::TestCase
     assert_equal 'New Title', discussion.reload.title
   end
 
+  test "returns an invalid discussion without updating it" do
+    discussion = discussions(:discussion)
+    original_title = discussion.title
+    topic_item_was_yielded = false
+
+    updated_discussion = DiscussionService.update(
+      discussion: discussion,
+      actor: @user,
+      params: { title: '' }
+    ) { topic_item_was_yielded = true }
+
+    assert_same discussion, updated_discussion
+    assert_predicate updated_discussion, :invalid?
+    assert_not topic_item_was_yielded
+    assert_equal original_title, discussion.reload.title
+  end
+
   test "updating a discussion preserves its topic tags" do
     discussion = discussions(:discussion)
     discussion.topic.update!(tags: [ 'literature' ])
@@ -207,7 +222,8 @@ class DiscussionServiceTest < ActiveSupport::TestCase
     recipient = users(:member)
     TopicReader.for(user: recipient, topic: discussion.topic).set_volume!(:normal)
 
-    topic_item = DiscussionService.update(
+    topic_item = nil
+    updated_discussion = DiscussionService.update(
       discussion: discussion,
       actor: @user,
       params: {
@@ -215,7 +231,8 @@ class DiscussionServiceTest < ActiveSupport::TestCase
         recipient_user_ids: [ recipient.id ],
         recipient_message: "Please review the changes"
       }
-    )
+    ) { |created_topic_item| topic_item = created_topic_item }
+    assert_equal discussion, updated_discussion
     notification = Notification.find_by!(kind: "discussion_edited", subject: topic_item)
 
     assert_equal "discussion_edited", topic_item.kind

--- a/test/services/notification_delivery_resolution_service_test.rb
+++ b/test/services/notification_delivery_resolution_service_test.rb
@@ -486,14 +486,15 @@ class NotificationDeliveryResolverTest < ActiveSupport::TestCase
     recipient = users(:member)
     TopicReader.for(user: recipient, topic: discussion.topic).set_volume!(:loud)
 
-    topic_item = DiscussionService.update(
+    topic_item = nil
+    DiscussionService.update(
       discussion: discussion,
       actor: @author,
       params: {
         recipient_user_ids: [ recipient.id ],
         recipient_message: "Please review this edit"
       }
-    )
+    ) { |created_topic_item| topic_item = created_topic_item }
     notification = Notification.find_by!(kind: "discussion_edited", subject: topic_item)
 
     ResolveNotificationDeliveriesWorker.perform_now(notification.id)

--- a/test/services/outcome_service_test.rb
+++ b/test/services/outcome_service_test.rb
@@ -36,7 +36,7 @@ class OutcomeServiceTest < ActiveSupport::TestCase
 
     topic_item = nil
     assert_difference 'Outcome.count', 1 do
-      topic_item = OutcomeService.create(outcome: @new_outcome, actor: @user)
+      OutcomeService.create(outcome: @new_outcome, actor: @user) { |created_topic_item| topic_item = created_topic_item }
     end
 
     assert_equal @new_outcome.statement, @poll.reload.current_outcome.statement
@@ -62,11 +62,13 @@ class OutcomeServiceTest < ActiveSupport::TestCase
     recipient = users(:member)
     TopicReader.for(user: recipient, topic: @poll.topic).set_volume!(:normal)
 
-    topic_item = OutcomeService.create(
+    topic_item = nil
+    created_outcome = OutcomeService.create(
       outcome: @new_outcome,
       actor: @user,
       params: { recipient_user_ids: [ recipient.id ] }
-    )
+    ) { |created_topic_item| topic_item = created_topic_item }
+    assert_equal @new_outcome, created_outcome
     notification = Notification.find_by!(kind: "outcome_created", subject: topic_item)
 
     assert_equal @poll.topic_id, topic_item.topic_id
@@ -153,10 +155,25 @@ class OutcomeServiceTest < ActiveSupport::TestCase
 
   test "does not create an invalid outcome" do
     @new_outcome.statement = ""
+    topic_item_was_yielded = false
 
     assert_difference 'Outcome.count', 0 do
-      OutcomeService.create(outcome: @new_outcome, actor: @user)
+      created_outcome = OutcomeService.create(outcome: @new_outcome, actor: @user) { topic_item_was_yielded = true }
+
+      assert_same @new_outcome, created_outcome
+      assert_predicate created_outcome, :invalid?
     end
+    assert_not topic_item_was_yielded
+  end
+
+  test "returns an invalid outcome without updating it" do
+    original_statement = @outcome.statement
+
+    updated_outcome = OutcomeService.update(outcome: @outcome, actor: @user, params: { statement: "" })
+
+    assert_same @outcome, updated_outcome
+    assert_predicate updated_outcome, :invalid?
+    assert_equal original_statement, @outcome.reload.statement
   end
 
   test "invitation rolls back a newly created recipient when notification creation fails" do

--- a/test/services/poll_service_test.rb
+++ b/test/services/poll_service_test.rb
@@ -227,11 +227,15 @@ class PollServiceTest < ActiveSupport::TestCase
   end
 
   test "does not create an invalid poll" do
+    topic_item_was_yielded = false
+
     assert_no_difference 'Poll.count' do
-      assert_raises ActiveRecord::RecordInvalid do
-        PollService.create(params: poll_params(title: ""), actor: @user)
-      end
+      poll = PollService.create(params: poll_params(title: ""), actor: @user) { topic_item_was_yielded = true }
+
+      assert_predicate poll, :invalid?
+      assert_not poll.persisted?
     end
+    assert_not topic_item_was_yielded
   end
 
   test "does not allow unauthorized users to create polls" do
@@ -324,7 +328,12 @@ class PollServiceTest < ActiveSupport::TestCase
   test "does not save an invalid poll on update" do
     poll = create_poll
     old_title = poll.title
-    PollService.update(poll: poll, params: { title: "" }, actor: @user)
+    topic_item_was_yielded = false
+    updated_poll = PollService.update(poll: poll, params: { title: "" }, actor: @user) { topic_item_was_yielded = true }
+
+    assert_same poll, updated_poll
+    assert_predicate updated_poll, :invalid?
+    assert_not topic_item_was_yielded
     assert_equal old_title, poll.reload.title
   end
 
@@ -347,7 +356,8 @@ class PollServiceTest < ActiveSupport::TestCase
     recipient = users(:member)
     TopicReader.for(user: recipient, topic: poll.topic).set_volume!(:normal)
 
-    topic_item = PollService.update(
+    topic_item = nil
+    updated_poll = PollService.update(
       poll: poll,
       params: {
         title: "Notification-backed poll edit",
@@ -355,7 +365,8 @@ class PollServiceTest < ActiveSupport::TestCase
         recipient_message: "Please review the poll changes"
       },
       actor: @user
-    )
+    ) { |created_topic_item| topic_item = created_topic_item }
+    assert_equal poll, updated_poll
     notification = Notification.find_by!(kind: "poll_edited", subject: topic_item)
 
     assert_equal "poll_edited", topic_item.kind
@@ -414,7 +425,8 @@ class PollServiceTest < ActiveSupport::TestCase
 
   test "closes a poll" do
     poll = create_poll
-    topic_item = PollService.close(poll: poll, actor: @user)
+    topic_item = nil
+    PollService.close(poll: poll, actor: @user) { |created_topic_item| topic_item = created_topic_item }
     assert_not_nil poll.reload.closed_at
     assert_equal poll.topic_id, topic_item.topic_id
     assert_not Notification.about(poll).exists?(kind: "poll_closed_by_user")
@@ -436,7 +448,8 @@ class PollServiceTest < ActiveSupport::TestCase
     end
 
     stub_request(:post, chatbot.server).to_return(status: 200)
-    topic_item = PollService.close(poll: poll, actor: @user)
+    topic_item = nil
+    PollService.close(poll: poll, actor: @user) { |created_topic_item| topic_item = created_topic_item }
     Resolv.stub(:getaddresses, [ "93.184.216.34" ]) do
       PublishChatbotTopicItemWorker.perform_now(topic_item.id)
     end
@@ -450,7 +463,7 @@ class PollServiceTest < ActiveSupport::TestCase
 
     topic_item = nil
     NotificationService.stub(:create!, ->(**) { raise "notification creation is not expected" }) do
-      topic_item = PollService.close(poll: poll, actor: @user)
+      PollService.close(poll: poll, actor: @user) { |created_topic_item| topic_item = created_topic_item }
     end
 
     assert_not_nil poll.reload.closed_at

--- a/test/services/stance_service_test.rb
+++ b/test/services/stance_service_test.rb
@@ -28,7 +28,9 @@ class StanceServiceTest < ActiveSupport::TestCase
     stance.choice = @poll.poll_option_names.first
     stance.reason = "I agree"
 
-    topic_item = StanceService.create(stance: stance, actor: @user)
+    topic_item = nil
+    created_stance = StanceService.create(stance: stance, actor: @user) { |created_topic_item| topic_item = created_topic_item }
+    assert_equal stance, created_stance
     assert_kind_of TopicItem, topic_item
     assert reader.reload.has_read?(topic_item.sequence_id)
     assert_equal 0, reader.unread_items_count
@@ -43,7 +45,8 @@ class StanceServiceTest < ActiveSupport::TestCase
     stance.reason = "Visible response"
 
     ActionMailer::Base.deliveries.clear
-    topic_item = StanceService.create(stance: stance, actor: @user)
+    topic_item = nil
+    StanceService.create(stance: stance, actor: @user) { |created_topic_item| topic_item = created_topic_item }
     PublishSubscriberEmailsTopicItemWorker.perform_now(topic_item.id)
 
     assert_includes ActionMailer::Base.deliveries.flat_map(&:to), subscriber.email
@@ -57,9 +60,9 @@ class StanceServiceTest < ActiveSupport::TestCase
     stance.choice = @poll.poll_option_names.first
 
     ActionMailer::Base.deliveries.clear
-    result = StanceService.create(stance: stance, actor: @user)
+    created_stance = StanceService.create(stance: stance, actor: @user)
 
-    assert_equal stance, result
+    assert_equal stance, created_stance
     assert_not TopicItem.exists?(itemable: stance, kind: "stance_created")
     assert_not Notification.about(stance).exists?(kind: "stance_created")
     assert_not_includes ActionMailer::Base.deliveries.flat_map(&:to), subscriber.email
@@ -73,10 +76,10 @@ class StanceServiceTest < ActiveSupport::TestCase
     stance.choice = @poll.poll_option_names.first
     stance.reason = "Hidden response"
 
-    result = StanceService.create(stance: stance, actor: @user)
+    created_stance = StanceService.create(stance: stance, actor: @user)
     PollService.close(poll: @poll, actor: @admin)
 
-    assert_equal stance, result
+    assert_equal stance, created_stance
     assert TopicItem.exists?(itemable: stance, kind: "stance_created", topic: @poll.topic)
     assert_not Notification.about(stance).exists?(kind: "stance_created")
   end
@@ -118,16 +121,18 @@ class StanceServiceTest < ActiveSupport::TestCase
     stance.reason = "Initial response"
     StanceService.create(stance: stance, actor: @user)
 
-    result = StanceService.update(
+    topic_item_was_yielded = false
+    updated_stance = StanceService.update(
       stance: stance,
       actor: @user,
       params: {
         reason: "Edited response",
         stance_choices_attributes: [ { poll_option_id: option.id } ]
       }
-    )
+    ) { topic_item_was_yielded = true }
 
-    assert_equal stance, result
+    assert_equal stance, updated_stance
+    assert_not topic_item_was_yielded
     assert_not TopicItem.exists?(itemable: stance, kind: "stance_updated")
     assert_not Notification.about(stance).exists?(kind: "stance_updated")
   end
@@ -151,9 +156,11 @@ class StanceServiceTest < ActiveSupport::TestCase
   test "does not create an invalid stance" do
     invalid_stance = Stance.new(poll: @poll)
 
-    assert_raises ActiveRecord::RecordInvalid do
-      StanceService.create(stance: invalid_stance, actor: @user)
-    end
+    created_stance = StanceService.create(stance: invalid_stance, actor: @user)
+
+    assert_same invalid_stance, created_stance
+    assert_predicate created_stance, :invalid?
+    assert_not created_stance.persisted?
   end
 
   test "invalid ballot update preserves the previous vote and result counts" do
@@ -163,14 +170,14 @@ class StanceServiceTest < ActiveSupport::TestCase
     counts_before = @poll.reload.stance_counts
     topic_items_before = TopicItem.count
 
-    assert_raises ActiveRecord::RecordInvalid do
-      StanceService.update(
-        stance: stance,
-        actor: @user,
-        params: { stance_choices_attributes: [{ poll_option_id: agree.id, score: -1 }] }
-      )
-    end
+    updated_stance = StanceService.update(
+      stance: stance,
+      actor: @user,
+      params: { stance_choices_attributes: [{ poll_option_id: agree.id, score: -1 }] }
+    )
 
+    assert_same stance, updated_stance
+    assert_predicate updated_stance, :invalid?
     assert_equal({ agree.id.to_s => 1 }, stance.reload.option_scores)
     assert_equal counts_before, @poll.reload.stance_counts
     assert_equal topic_items_before, TopicItem.count
@@ -192,7 +199,8 @@ class StanceServiceTest < ActiveSupport::TestCase
     stance = @poll.stances.undecided.find_by!(participant_id: @user.id, latest: true)
     stance.choice = @poll.poll_option_names.first
     stance.reason = "hello"
-    topic_item = StanceService.create(stance: stance, actor: @user)
+    topic_item = nil
+    StanceService.create(stance: stance, actor: @user) { |created_topic_item| topic_item = created_topic_item }
 
     assert_equal poll_created_topic_item.id, topic_item.parent.id
   end

--- a/test/services/topic_service_test.rb
+++ b/test/services/topic_service_test.rb
@@ -17,9 +17,9 @@ class TopicServiceTest < ActiveSupport::TestCase
     @comment3 = Comment.new(body: "comment3", parent: @comment2)
 
     @discussion_event = @discussion.created_topic_item
-    @comment1_event = CommentService.create(comment: @comment1, actor: @user)
-    @comment2_event = CommentService.create(comment: @comment2, actor: @user)
-    @comment3_event = CommentService.create(comment: @comment3, actor: @user)
+    CommentService.create(comment: @comment1, actor: @user) { |created_topic_item| @comment1_event = created_topic_item }
+    CommentService.create(comment: @comment2, actor: @user) { |created_topic_item| @comment2_event = created_topic_item }
+    CommentService.create(comment: @comment3, actor: @user) { |created_topic_item| @comment3_event = created_topic_item }
 
     poll = PollService.create(params: {
       title: "Test Poll",

--- a/test/workers/move_comments_worker_test.rb
+++ b/test/workers/move_comments_worker_test.rb
@@ -13,7 +13,8 @@ class MoveCommentsWorkerTest < ActiveSupport::TestCase
 
   test "moves a top-level comment to target thread" do
     comment = Comment.new(parent: @source, body: "move me", author: @user)
-    topic_item = CommentService.create(comment: comment, actor: @user)
+    topic_item = nil
+    CommentService.create(comment: comment, actor: @user) { |created_topic_item| topic_item = created_topic_item }
 
     MoveCommentsWorker.new.perform([topic_item.id], @source.topic_id, @target.topic_id)
 
@@ -26,10 +27,12 @@ class MoveCommentsWorkerTest < ActiveSupport::TestCase
 
   test "moves a comment and its reply together" do
     c1 = Comment.new(parent: @source, body: "parent comment", author: @user)
-    e1 = CommentService.create(comment: c1, actor: @user)
+    e1 = nil
+    CommentService.create(comment: c1, actor: @user) { |created_topic_item| e1 = created_topic_item }
 
     c2 = Comment.new(parent: c1, body: "reply", author: @user)
-    e2 = CommentService.create(comment: c2, actor: @user)
+    e2 = nil
+    CommentService.create(comment: c2, actor: @user) { |created_topic_item| e2 = created_topic_item }
 
     MoveCommentsWorker.new.perform([e1.id], @source.topic_id, @target.topic_id)
 
@@ -47,10 +50,12 @@ class MoveCommentsWorkerTest < ActiveSupport::TestCase
 
   test "reparents reply whose parent comment was not moved" do
     c1 = Comment.new(parent: @source, body: "stays behind", author: @user)
-    e1 = CommentService.create(comment: c1, actor: @user)
+    e1 = nil
+    CommentService.create(comment: c1, actor: @user) { |created_topic_item| e1 = created_topic_item }
 
     c2 = Comment.new(parent: c1, body: "gets moved", author: @user)
-    e2 = CommentService.create(comment: c2, actor: @user)
+    e2 = nil
+    CommentService.create(comment: c2, actor: @user) { |created_topic_item| e2 = created_topic_item }
 
     # Only move the reply, not the parent
     MoveCommentsWorker.new.perform([e2.id], @source.topic_id, @target.topic_id)
@@ -78,7 +83,8 @@ class MoveCommentsWorkerTest < ActiveSupport::TestCase
     StanceService.create(stance: stance, actor: @user)
 
     comment = Comment.new(parent: stance, body: "comment on stance", author: @user)
-    topic_item = CommentService.create(comment: comment, actor: @user)
+    topic_item = nil
+    CommentService.create(comment: comment, actor: @user) { |created_topic_item| topic_item = created_topic_item }
 
     MoveCommentsWorker.new.perform([topic_item.id], @source.topic_id, @target.topic_id)
 
@@ -117,7 +123,8 @@ class MoveCommentsWorkerTest < ActiveSupport::TestCase
     source_topic_id = poll.topic_id
     poll_event = poll.created_topic_item
     comment = Comment.new(parent: poll, body: "poll comment", author: @user)
-    comment_event = CommentService.create(comment: comment, actor: @user)
+    comment_event = nil
+    CommentService.create(comment: comment, actor: @user) { |created_topic_item| comment_event = created_topic_item }
 
     MoveCommentsWorker.new.perform([poll_event.id], source_topic_id, @target.topic_id, @admin.id)
 
@@ -135,7 +142,8 @@ class MoveCommentsWorkerTest < ActiveSupport::TestCase
   test "does not move topic_items from another topic" do
     other = DiscussionService.create(params: { title: "Other #{SecureRandom.hex(4)}", group_id: @group.id }, actor: @admin)
     comment = Comment.new(parent: other, body: "wrong thread", author: @user)
-    topic_item = CommentService.create(comment: comment, actor: @user)
+    topic_item = nil
+    CommentService.create(comment: comment, actor: @user) { |created_topic_item| topic_item = created_topic_item }
 
     MoveCommentsWorker.new.perform([topic_item.id], @source.topic_id, @target.topic_id)
 
@@ -146,7 +154,8 @@ class MoveCommentsWorkerTest < ActiveSupport::TestCase
 
   test "repairs both source and target threads" do
     comment = Comment.new(parent: @source, body: "move me", author: @user)
-    topic_item = CommentService.create(comment: comment, actor: @user)
+    topic_item = nil
+    CommentService.create(comment: comment, actor: @user) { |created_topic_item| topic_item = created_topic_item }
 
     source_items_before = @source.topic.reload.items_count
     target_items_before = @target.topic.reload.items_count


### PR DESCRIPTION
## Summary

- make create and update services return their domain model on success and validation failure
- keep authorization and persistence failures as exceptions
- expose optional timeline items through a callback after the transaction commits
- remove `capture_topic_item` and controller return-type guards
- preserve invalid inbound-email handling and rejected-comment notifications

## Failure contract

- validation failure returns the invalid model with its errors and does not yield a topic item
- authorization failure raises before persistence
- persistence or dependent-record failure raises and rolls back the transaction
- successful eventless updates return the model without yielding

## Security review

- authorization checks and access scopes are unchanged; membership-request authorization now runs before validation
- stance changes, stance choices, poll counts, notifications, and topic items remain within their existing transactions
- topic-item callbacks run only after successful commits
- the stance response remains scoped to the current participant and poll and uses `TopicItemSerializer`

## Testing

- `bin/rails test`
- 1,920 runs, 6,323 assertions, 0 failures, 0 errors, 1 existing skip
- pre-push Brakeman: 0 warnings
- pre-push Bundler Audit: no vulnerabilities
