### PR TITLE
Load group panels from the authorized parent page

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -82,6 +82,7 @@ jobs:
         rm -rf node_modules
         npm install
         npm run test:unit
+        npm run test:component
         npm run build
     - name: run e2es
       env:

--- a/vue/package-lock.json
+++ b/vue/package-lock.json
@@ -68,6 +68,8 @@
       "devDependencies": {
         "@originjs/vite-plugin-commonjs": "latest",
         "@vitejs/plugin-vue": "^6.0.8",
+        "@vue/test-utils": "^2.5.0",
+        "jsdom": "^24.1.3",
         "nightwatch": "^3.15.0",
         "pagefind": "1.5.2",
         "pug": "latest",
@@ -75,25 +77,12 @@
         "vite": "8.2.2",
         "vite-plugin-env-compatible": "latest",
         "vite-plugin-vuetify": "latest",
+        "vitest": "^4.1.11",
         "yaml": "^2.9.0"
       },
       "engines": {
         "node": "24.18.0",
         "npm": "11.16.0"
-      }
-    },
-    "node_modules/@asamuzakjp/css-color": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
-      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@csstools/css-calc": "^2.1.3",
-        "@csstools/css-color-parser": "^3.0.9",
-        "@csstools/css-parser-algorithms": "^3.0.4",
-        "@csstools/css-tokenizer": "^3.0.3",
-        "lru-cache": "^10.4.3"
       }
     },
     "node_modules/@babel/generator": {
@@ -230,121 +219,6 @@
       "optional": true,
       "engines": {
         "node": ">=0.1.90"
-      }
-    },
-    "node_modules/@csstools/color-helpers": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
-      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/csstools"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/csstools"
-        }
-      ],
-      "license": "MIT-0",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@csstools/css-calc": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
-      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/csstools"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/csstools"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@csstools/css-parser-algorithms": "^3.0.5",
-        "@csstools/css-tokenizer": "^3.0.4"
-      }
-    },
-    "node_modules/@csstools/css-color-parser": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
-      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/csstools"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/csstools"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@csstools/color-helpers": "^5.1.0",
-        "@csstools/css-calc": "^2.1.4"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@csstools/css-parser-algorithms": "^3.0.5",
-        "@csstools/css-tokenizer": "^3.0.4"
-      }
-    },
-    "node_modules/@csstools/css-parser-algorithms": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
-      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/csstools"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/csstools"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@csstools/css-tokenizer": "^3.0.4"
-      }
-    },
-    "node_modules/@csstools/css-tokenizer": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
-      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/csstools"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/csstools"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/@floating-ui/core": {
@@ -878,6 +752,13 @@
       "dependencies": {
         "archiver": "^5.3.1"
       }
+    },
+    "node_modules/@one-ini/wasm": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@one-ini/wasm/-/wasm-0.2.1.tgz",
+      "integrity": "sha512-TUqERXGNTifZ9y2g3wPxQrw3HpHv/02DsW3D90T9x0hhonrL1ZqpSmNrU2XkoIq0fP1N6gZfVQzy2Fw1ZvGBNg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@originjs/vite-plugin-commonjs": {
       "version": "1.0.3",
@@ -1868,6 +1749,13 @@
         }
       }
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tiptap/core": {
       "version": "3.30.2",
       "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.30.2.tgz",
@@ -2318,6 +2206,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/jsesc": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/@types/jsesc/-/jsesc-2.5.1.tgz",
@@ -2370,6 +2272,150 @@
       "peerDependencies": {
         "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0",
         "vue": "^3.2.25"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.11.tgz",
+      "integrity": "sha512-VX2x5vNJXET47KAFzwERI+KRMtTTCSWTfSMKsW7JsUsXV4psq++e3DvZpuTDOpHcxytiDs6p2nhVb2tVDiiUYw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.11",
+        "@vitest/utils": "4.1.11",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/expect/node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@vitest/expect/node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.11.tgz",
+      "integrity": "sha512-2XJVD55d1o5AZous5CCGKS74g/riOj9odEt2bQpCVZeblHyHdnMeFl4jl0XjU21stf4mbjUkew2eXQZt65g5CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.11",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.11.tgz",
+      "integrity": "sha512-yiZzPbGTS9Sr/JpFl8zHrcIkAofNbFV6k21vIgQN/cY/oxZeXhJv5sc/MBJ5jFKWmWs+oJHw0UXLZjmf931+Vw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.11.tgz",
+      "integrity": "sha512-LztvUgdwMNJMIkj3hQnnxiC2Xy1zNxq928W/xhjCLaNCzqTZOudjwbQf6v9IntZGPw132i2Lq2rgTRZHD3JHNw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.11",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.11.tgz",
+      "integrity": "sha512-pN7ikn1ON7h8ee4gIAp4AzyK+zBtJPzVbqOgu5LCEh4VaJVbPQcgYQYJIMGQPXVeJJq1fnfazis7a5pFNPahog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.11",
+        "@vitest/utils": "4.1.11",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.11.tgz",
+      "integrity": "sha512-apNa/prQy2qCeywhnixOHPRCgGNhvg7T4Dapfl1GahLp/R+uhBm5cPyFoNVyqsNd2h1nJxL6BqqdIjiABL60YA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.11.tgz",
+      "integrity": "sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.11",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vue-macros/common": {
@@ -2533,6 +2579,27 @@
       "integrity": "sha512-IOnwSCma8j+9xJT6b8H0dEYidC80NsYmNMlZxRsukYcSoGaDBohog5hDxzeUXdFeGWFA++vWvxqOmrr96VlqMA==",
       "license": "MIT"
     },
+    "node_modules/@vue/test-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@vue/test-utils/-/test-utils-2.5.0.tgz",
+      "integrity": "sha512-6Clu5EKR/r6cDPYrKsu+8wenciWJJ3rhS9OEGsfDlZeZIhlJeEPGIZQHxE4lHRJCzPSq3EWMsFxQUqCvrbHQuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-beautify": "^2.0.0",
+        "vue-component-type-helpers": "^3.0.0"
+      },
+      "peerDependencies": {
+        "@vue/compiler-dom": "3.x",
+        "@vue/server-renderer": "3.x",
+        "vue": "3.x"
+      },
+      "peerDependenciesMeta": {
+        "@vue/server-renderer": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vuetify/loader-shared": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/@vuetify/loader-shared/-/loader-shared-2.1.2.tgz",
@@ -2545,6 +2612,16 @@
       "peerDependencies": {
         "vue": "^3.0.0",
         "vuetify": ">=3"
+      }
+    },
+    "node_modules/abbrev": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-5.0.0.tgz",
+      "integrity": "sha512-/XrFJgzQQQHpti1raDJC6m4ws6aNktmjBlhk8Fdlk7LwCEuDoieEJJY9OFHjfiFJFFRM2tK+Ky/IsfbbmlMu1w==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
       }
     },
     "node_modules/acorn": {
@@ -3094,6 +3171,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chai-nightwatch": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/chai-nightwatch/-/chai-nightwatch-0.5.3.tgz",
@@ -3301,6 +3388,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/compress-commons": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-4.1.2.tgz",
@@ -3330,6 +3427,17 @@
       "integrity": "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==",
       "license": "MIT"
     },
+    "node_modules/config-chain": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
+      "integrity": "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ini": "^1.3.4",
+        "proto-list": "~1.2.1"
+      }
+    },
     "node_modules/constantinople": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/constantinople/-/constantinople-4.0.1.tgz",
@@ -3340,6 +3448,13 @@
         "@babel/parser": "^7.6.0",
         "@babel/types": "^7.6.1"
       }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/core-util-is": {
       "version": "1.0.3",
@@ -3397,6 +3512,142 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/cssstyle/node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/cssstyle/node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cssstyle/node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/cssstyle/node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/cssstyle/node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/cssstyle/node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cssstyle/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/cssstyle/node_modules/rrweb-cssom": {
       "version": "0.8.0",
@@ -3679,6 +3930,77 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/editorconfig": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-3.0.2.tgz",
+      "integrity": "sha512-T0ix8GhtxyKVfUFEcvdNDt3YGqlwkFHbD4/5bgFUDgFmxhI/cSRAeJ87/Sz//Cq8Eam6JX/e23RkoFO71P7aAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@one-ini/wasm": "0.2.1",
+        "commander": "^14.0.3",
+        "minimatch": "~10.2.4",
+        "semver": "^7.7.4"
+      },
+      "bin": {
+        "editorconfig": "bin/editorconfig"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/editorconfig/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/editorconfig/node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/editorconfig/node_modules/minimatch": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.8"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/editorconfig/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/ejs": {
       "version": "3.1.10",
       "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
@@ -3803,6 +4125,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.2.tgz",
+      "integrity": "sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
@@ -3860,6 +4189,16 @@
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
       "license": "MIT"
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/exsolve": {
       "version": "1.0.8",
@@ -4353,6 +4692,13 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/internal-slot": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
@@ -4808,6 +5154,92 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/js-beautify": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-2.0.3.tgz",
+      "integrity": "sha512-cyFbh3tkPhknnTD/0bLf0T0yy2ZIbqL05mttzbt4y1Zfr7NxqXQZ62dkBLKs3oHH/lpjmDRAnciJiSUyOy8XwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "config-chain": "^1.1.13",
+        "editorconfig": "^3.0.2",
+        "glob": "^13.0.6",
+        "js-cookie": "^3.0.8",
+        "nopt": "^10.0.1"
+      },
+      "bin": {
+        "css-beautify": "js/bin/css-beautify.js",
+        "html-beautify": "js/bin/html-beautify.js",
+        "js-beautify": "js/bin/js-beautify.js"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/js-beautify/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/js-beautify/node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/js-beautify/node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/js-beautify/node_modules/minimatch": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.8"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/js-cookie": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.8.tgz",
+      "integrity": "sha512-yeJd4aNAdYZQjaon2bpD/Gb0B/omw7HQOsynXXcOiWVCacbBcPlgn8S/d1X6blFSaHao7ozqtW7NZW19xpCtIw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/js-stringify": {
       "version": "1.0.2",
@@ -5435,11 +5867,14 @@
       }
     },
     "node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
       "dev": true,
-      "license": "ISC"
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
     },
     "node_modules/magic-string": {
       "version": "0.30.21",
@@ -5550,6 +5985,16 @@
       "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
     },
     "node_modules/mlly": {
       "version": "1.8.2",
@@ -5792,6 +6237,22 @@
         "axe-core": "^4.11.1"
       }
     },
+    "node_modules/nopt": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-10.0.1.tgz",
+      "integrity": "sha512-df3sBr/6ax9hSGuC3CspvLlbnX8cP5L5nZwXF8cGN8l0zSWR6BvzmQ6jPUKjvo6+/xdpkNvEcucBNUdBeeV13g==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "abbrev": "^5.0.0"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+      }
+    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -5809,9 +6270,9 @@
       "license": "MIT"
     },
     "node_modules/nwsapi": {
-      "version": "2.2.23",
-      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.23.tgz",
-      "integrity": "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==",
+      "version": "2.2.26",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.26.tgz",
+      "integrity": "sha512-LPmrA6J31t9ac9294T/WZV6AK5CUcFZ+VXQ7pNNc1+JAjeKthW7vqekOBu6pXzsxD7slwJ7M4XMhamojG3T4oA==",
       "dev": true,
       "license": "MIT"
     },
@@ -6081,6 +6542,23 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/pathe": {
       "version": "2.0.3",
@@ -6359,6 +6837,13 @@
         "prosemirror-state": "^1.0.0",
         "prosemirror-transform": "^1.1.0"
       }
+    },
+    "node_modules/proto-list": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+      "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/psl": {
       "version": "1.15.0",
@@ -6971,6 +7456,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
@@ -6992,6 +7484,13 @@
       "resolved": "https://registry.npmjs.org/spark-md5/-/spark-md5-3.0.2.tgz",
       "integrity": "sha512-wcFzz9cDfbuqe0FZzfi2or1sgyIrsDwmPwfZC4hiNidPdPINjeUwNfv5kldczoEAcjl9Y1L3SM7Uz2PUEQzxQw==",
       "license": "(WTFPL OR MIT)"
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stacktrace-parser": {
       "version": "0.1.10",
@@ -7015,6 +7514,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
@@ -7149,6 +7655,23 @@
       "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+      "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
@@ -7192,6 +7715,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+      "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tmp": {
@@ -7667,6 +8200,109 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.11.tgz",
+      "integrity": "sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.11",
+        "@vitest/mocker": "4.1.11",
+        "@vitest/pretty-format": "4.1.11",
+        "@vitest/runner": "4.1.11",
+        "@vitest/snapshot": "4.1.11",
+        "@vitest/spy": "4.1.11",
+        "@vitest/utils": "4.1.11",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.11",
+        "@vitest/browser-preview": "4.1.11",
+        "@vitest/browser-webdriverio": "4.1.11",
+        "@vitest/coverage-istanbul": "4.1.11",
+        "@vitest/coverage-v8": "4.1.11",
+        "@vitest/ui": "4.1.11",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+      "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/void-elements": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
@@ -7707,6 +8343,13 @@
         "chart.js": "^3.7.0",
         "vue": "^3.0.0-0 || ^2.6.0"
       }
+    },
+    "node_modules/vue-component-type-helpers": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/vue-component-type-helpers/-/vue-component-type-helpers-3.3.11.tgz",
+      "integrity": "sha512-LwcxzeliO9fkQcpJG0PoX8X5kmAhKmH9wkpDLxNabwzkQ9Zeib2YVHwFV4pcWmMLfXVfjr/dSV+DaJ3cIPgSNA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vue-i18n": {
       "version": "11.4.4",
@@ -8006,6 +8649,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/widest-line": {

--- a/vue/package.json
+++ b/vue/package.json
@@ -11,6 +11,7 @@
     "build": "vite build",
     "vv": "vite --version",
     "test:unit": "node --test tests/unit/*.test.mjs",
+    "test:component": "vitest run",
     "test": "nightwatch --retries 3 --headless"
   },
   "dependencies": {
@@ -74,6 +75,8 @@
   "devDependencies": {
     "@originjs/vite-plugin-commonjs": "latest",
     "@vitejs/plugin-vue": "^6.0.8",
+    "@vue/test-utils": "^2.5.0",
+    "jsdom": "^24.1.3",
     "nightwatch": "^3.15.0",
     "pagefind": "1.5.2",
     "pug": "latest",
@@ -81,6 +84,7 @@
     "vite": "8.2.2",
     "vite-plugin-env-compatible": "latest",
     "vite-plugin-vuetify": "latest",
+    "vitest": "^4.1.11",
     "yaml": "^2.9.0"
   },
   "overrides": {

--- a/vue/src/components/group/discussions_panel.vue
+++ b/vue/src/components/group/discussions_panel.vue
@@ -78,11 +78,8 @@ function query() {
   if (route.query.tag) chain = chain.where(topic => topic.tags.includes(route.query.tag));
 
   let pageTopics = [];
-  if (loader.value.pageWindow[page.value]) {
-    chain = page.value === 1
-      ? chain.find({lastActivityAt: {$gte: loader.value.pageWindow[page.value][0]}})
-      : chain.find({lastActivityAt: {$jbetween: loader.value.pageWindow[page.value]}});
-    pageTopics = chain.data();
+  if (loader.value.pageIds[page.value]) {
+    pageTopics = chain.find({id: {$in: loader.value.pageIds[page.value]}}).data();
   }
   topics.value = pinnedTopics.concat(pageTopics);
 

--- a/vue/src/components/group/discussions_panel.vue
+++ b/vue/src/components/group/discussions_panel.vue
@@ -1,242 +1,151 @@
-<script lang="js">
-import Records            from '@/shared/services/records';
-import AbilityService     from '@/shared/services/ability_service';
-import EventBus           from '@/shared/services/event_bus';
-import PageLoader         from '@/shared/services/page_loader';
+<script setup>
+import { computed, ref, watch } from 'vue';
+import { useRoute, useRouter } from 'vue-router';
+import { useI18n } from 'vue-i18n';
+import Records from '@/shared/services/records';
+import AbilityService from '@/shared/services/ability_service';
+import EventBus from '@/shared/services/event_bus';
+import PageLoader from '@/shared/services/page_loader';
 import Session from '@/shared/services/session';
-import { mdiMagnify } from '@mdi/js';
+import { identity, pickBy } from 'lodash-es';
 import TagsFilterMenu from '@/components/tags/filter_menu';
-import WatchRecords from '@/mixins/watch_records';
-import UrlFor from '@/mixins/url_for';
+import { useWatchRecords } from '@/composables/useWatchRecords';
 
-export default
-{
-  components: { TagsFilterMenu },
-  mixins: [WatchRecords, UrlFor],
-  created() {
-    this.watchRecords({
-      key: this.$route.params.key,
-      collections: ['topics', 'groups', 'memberships'],
-      query: this.query
-    });
+const { group } = defineProps({
+  group: {type: Object, required: true}
+});
+const route = useRoute();
+const router = useRouter();
+const { t } = useI18n();
+const { watchRecords } = useWatchRecords();
+const topics = ref([]);
+const loader = ref(null);
+const isMember = ref(false);
+const dummyQuery = ref(null);
+const per = 25;
+const page = computed({
+  get: () => parseInt(route.query.page) || 1,
+  set: value => router.replace({query: {...route.query, page: value}})
+});
+const totalPages = computed(() => Math.max(1, Math.ceil((loader.value?.total || 0) / per)));
+const loading = computed(() => loader.value?.loading || false);
+const noThreads = computed(() => !loading.value && topics.value.length === 0);
+const noThreadsMatchingFilters = computed(() => noThreads.value && group.discussionsCount > 0);
+const canViewPrivateContent = computed(() => AbilityService.canViewPrivateContent(group));
+const canStartThread = computed(() => AbilityService.canStartThread(group));
+const unreadCount = computed(() => topics.value.filter(topic => topic.isUnread()).length);
+const suggestLockedThreads = computed(() =>
+  !['locked', 'unread', 'all'].includes(String(route.query.t)) &&
+  group.discussionsCount > (loader.value?.total || 0)
+);
 
-    this.refresh();
-    EventBus.$on('signedIn', this.hardRefresh);
-    EventBus.$on('joinedGroup', this.hardRefresh);
-  },
+function mergeQuery(values) {
+  return {query: pickBy({...route.query, ...values}, identity)};
+}
 
-  beforeDestroy() {
-    EventBus.$off('signedIn', this.hardRefresh);
-    EventBus.$off('joinedGroup', this.hardRefresh);
-  },
+function routeQuery(values) {
+  router.replace(mergeQuery(values));
+}
 
-  data() {
-    return {
-      group: null,
-      topics: [],
-      loader: null,
-      isMember: false,
-      per: 25,
-      dummyQuery: null,
-      mdiMagnify
-    };
-  },
+function selectTag(tag) {
+  routeQuery({tag, page: null});
+}
 
-  methods: {
-    routeQuery(o) {
-      this.$router.replace(this.mergeQuery(o));
-    },
-
-    selectTag(tag) {
-      this.routeQuery({tag, page: null});
-    },
-
-    hardRefresh() {
-      Records.groups.remote.fetchById(this.$route.params.key).then(this.refresh);
-    },
-
-    refresh() {
-      Records.groups.findOrFetch(this.$route.params.key).then(group => {
-        this.group = group;
-        this.isMember = !!Session.user().membershipFor(this.group);
-
-        this.loader = new PageLoader({
-          path: 'topics',
-          order: 'lastActivityAt',
-          params: {
-            group_id: this.group.id,
-            exclude_types: 'reaction',
-            topicable_type: 'Discussion',
-            subgroups: 'mine',
-            filter: this.$route.query.t === 'all' ? undefined : (this.$route.query.t || 'unlocked'),
-            tags: this.$route.query.tag,
-            per: this.per
-          }
-        });
-
-        this.fetch();
-        this.query();
-      }).catch(() => {
-        // GroupPage owns route-level group fetch error handling.
-      });
-    },
-
-    query() {
-      if (!this.group) { return }
-
-      const groupIds = this.group.organisationIds();
-
-      let pinnedTopics = [];
-      if (this.page == 1 && !this.$route.query.tag && !['locked', 'unread'].includes(this.$route.query.t)) {
-        pinnedTopics = Records.topics.collection.chain().find({
-          groupId: {$in: groupIds},
-          topicableType: 'Discussion',
-          pinnedAt: {$ne: null}
-        }).simplesort('pinnedAt', true).data();
-      }
-
-      let chain = Records.topics.collection.chain().find({
-        groupId: {$in: groupIds},
-        topicableType: 'Discussion',
-        id: {$nin: pinnedTopics.map(t => t.id)}
-      }).simplesort('lastActivityAt', true);
-
-      switch (this.$route.query.t) {
-        case 'unread':
-          chain = chain.where(topic => topic.isUnread());
-          break;
-        case 'locked':
-          chain = chain.find({lockedAt: {$ne: null}});
-          break;
-        case 'all':
-          break;
-        default: // null or 'unlocked' — show only unlocked threads
-          chain = chain.find({lockedAt: null});
-          break;
-      }
-
-      if (this.$route.query.tag) {
-        const tagName = this.$route.query.tag;
-        chain = chain.where(topic => topic.tags.includes(tagName));
-      }
-
-      let topics = [];
-      if (this.loader.pageWindow[this.page]) {
-        if (this.page === 1) {
-          chain = chain.find({lastActivityAt: {$gte: this.loader.pageWindow[this.page][0]}});
-        } else {
-          chain = chain.find({lastActivityAt: {$jbetween: this.loader.pageWindow[this.page]}});
-        }
-        topics = chain.data();
-      }
-      this.topics = pinnedTopics.concat(topics);
-
-      EventBus.$emit('currentComponent', {
-        page: 'groupPage',
-        title: this.group.name,
-        group: this.group,
-        search: {
-          placeholder: this.$t('navbar.search_discussions_in_group', {name: this.group.parentOrSelf().name})
-        }
-      });
-    },
-
-    fetch() {
-      this.loader.fetch(this.page).then(this.query);
-    },
-
-    filterName(filter) {
-      switch (filter) {
-        case 'unread': return 'discussions_panel.unread';
-        case 'locked': return 'discussions_panel.locked';
-        case 'all': return 'discussions_panel.all';
-        default:
-          return 'discussions_panel.unlocked';
-      }
-    },
-
-    openSearchModal() {
-      let initialOrgId = null;
-      let initialGroupId = null;
-
-      if (this.group.isParent()) {
-        initialOrgId = this.group.id;
-      } else {
-        initialOrgId = this.group.parentId;
-        initialGroupId = this.group.id;
-      }
-
-      EventBus.$emit('openModal', {
-        component: 'SearchModal',
-        persistent: false,
-        maxWidth: 900,
-        props: {
-          initialOrgId,
-          initialGroupId,
-          initialQuery: this.dummyQuery
-        }
-      }
-      );
-    }
-  },
-
-  watch: {
-    '$route.params': 'refresh',
-    '$route.query': 'refresh',
-    'page'() {
-      this.fetch();
-      this.query();
-    }
-  },
-
-  computed: {
-    page: {
-      get() { return parseInt(this.$route.query.page) || 1; },
-      set(val) {
-        return this.$router.replace({query: Object.assign({}, this.$route.query, {page: val})});
-      }
-    },
-
-    totalPages() {
-      return Math.max(1, Math.ceil((this.loader.total || 0) / this.per));
-    },
-
-    loading() {
-      return this.loader.loading;
-    },
-
-    noThreads() {
-      return !this.loading && this.topics.length === 0
-    },
-
-    noThreadsMatchingFilters() {
-      return this.noThreads && this.group.discussionsCount > 0;
-    },
-
-    canViewPrivateContent() {
-      return AbilityService.canViewPrivateContent(this.group);
-    },
-
-    canStartThread() {
-      return AbilityService.canStartThread(this.group);
-    },
-
-    isLoggedIn() {
-      return Session.isSignedIn();
-    },
-
-    unreadCount() {
-      return this.topics.filter(topic => topic.isUnread()).length;
-    },
-
-    suggestLockedThreads() {
-      return !['locked', 'unread', 'all'].includes(String(this.$route.query.t)) &&
-        this.group && this.loader &&
-        this.group.discussionsCount > this.loader.total;
-    }
+function query() {
+  const groupIds = group.organisationIds();
+  let pinnedTopics = [];
+  if (page.value === 1 && !route.query.tag && !['locked', 'unread'].includes(route.query.t)) {
+    pinnedTopics = Records.topics.collection.chain().find({
+      groupId: {$in: groupIds},
+      topicableType: 'Discussion',
+      pinnedAt: {$ne: null}
+    }).simplesort('pinnedAt', true).data();
   }
-};
 
+  let chain = Records.topics.collection.chain().find({
+    groupId: {$in: groupIds},
+    topicableType: 'Discussion',
+    id: {$nin: pinnedTopics.map(topic => topic.id)}
+  }).simplesort('lastActivityAt', true);
+
+  switch (route.query.t) {
+    case 'unread': chain = chain.where(topic => topic.isUnread()); break;
+    case 'locked': chain = chain.find({lockedAt: {$ne: null}}); break;
+    case 'all': break;
+    default: chain = chain.find({lockedAt: null});
+  }
+
+  if (route.query.tag) chain = chain.where(topic => topic.tags.includes(route.query.tag));
+
+  let pageTopics = [];
+  if (loader.value.pageWindow[page.value]) {
+    chain = page.value === 1
+      ? chain.find({lastActivityAt: {$gte: loader.value.pageWindow[page.value][0]}})
+      : chain.find({lastActivityAt: {$jbetween: loader.value.pageWindow[page.value]}});
+    pageTopics = chain.data();
+  }
+  topics.value = pinnedTopics.concat(pageTopics);
+
+  EventBus.$emit('currentComponent', {
+    page: 'groupPage',
+    title: group.name,
+    group,
+    search: {placeholder: t('navbar.search_discussions_in_group', {name: group.parentOrSelf().name})}
+  });
+}
+
+function fetch() {
+  return loader.value.fetch(page.value).then(query);
+}
+
+function refresh() {
+  isMember.value = !!Session.user().membershipFor(group);
+  loader.value = new PageLoader({
+    path: 'topics',
+    order: 'lastActivityAt',
+    params: {
+      group_id: group.id,
+      exclude_types: 'reaction',
+      topicable_type: 'Discussion',
+      subgroups: 'mine',
+      filter: route.query.t === 'all' ? undefined : (route.query.t || 'unlocked'),
+      tags: route.query.tag,
+      per
+    }
+  });
+  fetch();
+  query();
+}
+
+function filterName(filter) {
+  switch (filter) {
+    case 'unread': return 'discussions_panel.unread';
+    case 'locked': return 'discussions_panel.locked';
+    case 'all': return 'discussions_panel.all';
+    default: return 'discussions_panel.unlocked';
+  }
+}
+
+function openSearchModal() {
+  EventBus.$emit('openModal', {
+    component: 'SearchModal',
+    persistent: false,
+    maxWidth: 900,
+    props: {
+      initialOrgId: group.isParent() ? group.id : group.parentId,
+      initialGroupId: group.isParent() ? null : group.id,
+      initialQuery: dummyQuery.value
+    }
+  });
+}
+
+refresh();
+watchRecords({
+  key: route.params.key,
+  collections: ['topics', 'groups', 'memberships'],
+  query
+});
+watch(() => route.query, refresh);
 </script>
 
 <template lang="pug">

--- a/vue/src/components/group/emails_panel.vue
+++ b/vue/src/components/group/emails_panel.vue
@@ -1,104 +1,77 @@
-<script lang="js">
-import Records  from '@/shared/services/records';
-import EventBus from "@/shared/services/event_bus";
-import Flash from "@/shared/services/flash";
-import WatchRecords from '@/mixins/watch_records';
-import UrlFor from '@/mixins/url_for';
+<script setup>
+import { onMounted, ref } from 'vue';
+import Records from '@/shared/services/records';
+import EventBus from '@/shared/services/event_bus';
+import Flash from '@/shared/services/flash';
+import { useWatchRecords } from '@/composables/useWatchRecords';
 
-export default
-{
-  mixins: [WatchRecords, UrlFor],
-  data() {
-    return {
-      requests: [],
-      group: null,
-      emails: [],
-      aliases: []
-    };
-  },
+const { group } = defineProps({
+  group: {type: Object, required: true}
+});
+const emails = ref([]);
+const aliases = ref([]);
+const { watchRecords } = useWatchRecords();
 
-  mounted() {
-    Records.groups.findOrFetch(this.$route.params.key).then(group => {
-      this.group = group;
+function fetchAliases() {
+  Records.fetch({path: 'received_emails/aliases', params: {group_id: group.id}}).then(data => {
+    aliases.value = data.aliases;
+  });
+}
 
-      this.fetchEmails();
-      this.fetchAliases();
+function fetchEmails() {
+  return Records.fetch({path: 'received_emails', params: {group_id: group.id}});
+}
 
-      this.watchRecords({
-        key: "receivedEmails#{group.id}",
-        collections: ['receivedEmails'],
-        query: store => {
-          this.emails = store.receivedEmails.find({groupId: this.group.id, released: false})
-        }
-      });
-    }).catch(() => {
-      // GroupPage owns route-level group fetch error handling.
-    });
-  },
+function userById(id) {
+  return Records.users.find(id);
+}
 
-  methods: {
-    fetchAliases() {
-      Records.fetch({path: 'received_emails/aliases', params: {group_id: this.group.id}}).then(data => {
-        this.aliases = data.aliases
-      })
-    },
+function allow(email) {
+  EventBus.$emit('openModal', {
+    component: 'MemberEmailAliasModal',
+    props: {receivedEmail: email, group, callbackFn: fetchAliases}
+  });
+}
 
-    fetchEmails() {
-      Records.fetch({path: 'received_emails', params: {group_id: this.group.id }})
-    },
+function block(email) {
+  EventBus.$emit('openModal', {
+    component: 'ConfirmModal',
+    props: {
+      confirm: {
+        submit: () => Records.receivedEmails.remote.postMember(email.id, 'block').then(() => {
+          EventBus.$emit('closeModal');
+          Flash.success('email_to_group.email_blocked');
+          fetchAliases();
+        }),
+        text: {
+          title: 'email_to_group.confirm_block',
+          helptext: 'email_to_group.confirm_block_body',
+          submit: 'email_to_group.block_email'
+        },
+        textArgs: {sender: email.senderEmail}
+      }
+    }
+  });
+}
 
-    userById(id) {
-      return Records.users.find(id)
-    },
+function destroyAlias(alias) {
+  Records.remote.destroy('received_emails/destroy_alias', {id: alias.id}).then(() => {
+    fetchAliases();
+    fetchEmails();
+  });
+}
 
-    allow(email) {
-      EventBus.$emit('openModal', {
-        component: 'MemberEmailAliasModal',
-        props: {
-          receivedEmail: email,
-          group: this.group,
-          callbackFn: () => {
-            this.fetchAliases();
-          }
-        }
-      });
-    },
-
-    block(email) {
-      EventBus.$emit('openModal', {
-        component: 'ConfirmModal',
-        props: {
-          confirm: {
-            submit: () => {
-              return Records.receivedEmails.remote.postMember(email.id, 'block').then(() => {
-                EventBus.$emit('closeModal');
-                Flash.success('email_to_group.email_blocked')
-                this.fetchAliases();
-              });
-            },
-            text: {
-              title:    'email_to_group.confirm_block',
-              helptext: 'email_to_group.confirm_block_body',
-              submit:   'email_to_group.block_email'
-            },
-            textArgs: {
-              sender: email.senderEmail
-            }
-
-          }
-        }
-      });
-    },
-
-    destroyAlias(alias) {
-      Records.remote.destroy('received_emails/destroy_alias', {id: alias.id}).then(() => {
-        this.fetchAliases();
-        this.fetchEmails();
-      })
-    },
-  }
-
-};
+onMounted(() => {
+  fetchEmails();
+  fetchAliases();
+  watchRecords({
+    key: `receivedEmails${group.id}`,
+    collections: ['receivedEmails'],
+    query: () => {
+      emails.value = Records.receivedEmails.find({groupId: group.id, released: false});
+    }
+  });
+});
 </script>
 <template lang="pug">
 .group-emails-panel

--- a/vue/src/components/group/files_panel.vue
+++ b/vue/src/components/group/files_panel.vue
@@ -1,114 +1,78 @@
-<script lang="js">
-import Records           from '@/shared/services/records';
-import RecordLoader      from '@/shared/services/record_loader';
-import EventBus          from '@/shared/services/event_bus';
-import AbilityService    from '@/shared/services/ability_service';
-
+<script setup>
+import { computed, onUnmounted, ref, watch } from 'vue';
+import { useRoute, useRouter } from 'vue-router';
+import { useI18n } from 'vue-i18n';
+import Records from '@/shared/services/records';
+import RecordLoader from '@/shared/services/record_loader';
+import EventBus from '@/shared/services/event_bus';
+import AbilityService from '@/shared/services/ability_service';
 import { mdiMagnify } from '@mdi/js';
 import { debounce, orderBy, uniq, escapeRegExp } from 'lodash-es';
-import WatchRecords from '@/mixins/watch_records';
-import UrlFor from '@/mixins/url_for';
-import FormatDate from '@/mixins/format_date';
+import { useWatchRecords } from '@/composables/useWatchRecords';
 
-export default
-{
-  mixins: [WatchRecords, UrlFor, FormatDate],
-  data() {
-    return {
-      group: null,
-      attachmentLoader: null,
-      searchQuery: '',
-      items: [],
-      attachmentIds: [],
-      per: 25,
-      from: 0,
-      mdiMagnify
-    };
-  },
+const { group } = defineProps({
+  group: {type: Object, required: true}
+});
+const route = useRoute();
+const router = useRouter();
+const { t } = useI18n();
+const { watchRecords } = useWatchRecords();
+const attachmentLoader = ref(new RecordLoader({
+  collection: 'attachments',
+  params: {group_id: group.id, per: 25, from: 0}
+}));
+const searchQuery = ref(route.query.q || '');
+const items = ref([]);
+const attachmentIds = ref([]);
+const loading = computed(() => attachmentLoader.value.loading);
+const canAdminister = computed(() => AbilityService.canAdminister(group));
+const onQueryInput = debounce(value => router.replace({query: {q: value}}), 400);
 
-  created() {
-    this.onQueryInput = debounce(val => {
-      return this.$router.replace({ query: { q: val } });
-    } , 400);
+function query() {
+  const attachments = Records.attachments.collection.chain()
+    .find({id: {$in: attachmentIds.value}})
+    .find({filename: {$regex: new RegExp(escapeRegExp(searchQuery.value), 'i')}})
+    .data();
+  items.value = orderBy(attachments, 'createdAt', 'desc');
+}
 
-    this.group = Records.groups.fuzzyFind(this.$route.params.key);
+function fetch() {
+  return attachmentLoader.value.fetchRecords({q: searchQuery.value}).then(data => {
+    attachmentIds.value = uniq(attachmentIds.value.concat((data.attachments || []).map(attachment => attachment.id)));
+  }).then(query);
+}
 
-    EventBus.$emit('currentComponent', {
-      page: 'groupPage',
-      title: this.group.name,
-      group: this.group,
-      search: {
-        placeholder: this.$t('navbar.search_files', {name: this.group.parentOrSelf().name})
-      }
-    });
-
-    this.attachmentLoader = new RecordLoader({
-      collection: 'attachments',
-      params: {
-        group_id: this.group.id,
-        per: this.per,
-        from: this.from
-      }
-    });
-
-    this.watchRecords({
-      collections: ['attachments'],
-      query: () => this.query()
-    });
-
-    this.searchQuery = this.$route.query.q || '';
-    this.fetch();
-  },
-
-  watch: {
-    '$route.query.q'(val) {
-      this.searchQuery = val || '';
-      this.fetch();
-      this.query();
-    }
-  },
-
-  methods: {
-    query() {
-      const attachments = Records.attachments.collection.chain().
-                     find({id: {$in: this.attachmentIds}}).
-                     find({filename: {$regex: new RegExp(`${escapeRegExp(this.searchQuery)}`, 'i')}}).
-                     data();
-
-      this.items = orderBy(attachments, 'createdAt', 'desc');
-    },
-
-    fetch() {
-      this.attachmentLoader.fetchRecords({q: this.searchQuery}).then(data => {
-        this.attachmentIds = uniq(this.attachmentIds.concat((data.attachments || []).map(a => a.id)));
-      }).then(() => this.query());
-    },
-
-    deleteAttachment(item) {
-      EventBus.$emit('openModal', {
-        component: 'ConfirmModal',
-        props: {
-          confirm: {
-            submit: item.destroy,
-            text: {
-              title: 'comment_form.attachments.remove_attachment',
-              helptext: 'group_files_panel.delete_confirmation',
-              submit: 'common.action.delete',
-              flash: 'poll_common_delete_modal.success'
-            }
-          }
+function deleteAttachment(item) {
+  EventBus.$emit('openModal', {
+    component: 'ConfirmModal',
+    props: {
+      confirm: {
+        submit: item.destroy,
+        text: {
+          title: 'comment_form.attachments.remove_attachment',
+          helptext: 'group_files_panel.delete_confirmation',
+          submit: 'common.action.delete',
+          flash: 'poll_common_delete_modal.success'
         }
-      });
+      }
     }
-  },
+  });
+}
 
-  computed: {
-    showLoadMore() { return !this.attachmentLoader.exhausted; },
-    loading() { return this.attachmentLoader.loading; },
-    canAdminister() { return AbilityService.canAdminister(this.group); }
-  }
-};
-
+EventBus.$emit('currentComponent', {
+  page: 'groupPage',
+  title: group.name,
+  group,
+  search: {placeholder: t('navbar.search_files', {name: group.parentOrSelf().name})}
+});
+watchRecords({collections: ['attachments'], query});
+watch(() => route.query.q, value => {
+  searchQuery.value = value || '';
+  fetch();
+  query();
+});
+onUnmounted(() => onQueryInput.cancel());
+fetch();
 </script>
 
 <template lang="pug">

--- a/vue/src/components/group/members_panel.vue
+++ b/vue/src/components/group/members_panel.vue
@@ -1,207 +1,145 @@
-<script lang="js">
-import Records        from '@/shared/services/records';
+<script setup>
+import { computed, onUnmounted, ref, watch } from 'vue';
+import { useRoute, useRouter } from 'vue-router';
+import { useI18n } from 'vue-i18n';
+import Records from '@/shared/services/records';
 import AbilityService from '@/shared/services/ability_service';
-import RecordLoader   from '@/shared/services/record_loader';
-import Session        from '@/shared/services/session';
-import EventBus       from '@/shared/services/event_bus';
-import { intersection, debounce, map } from 'lodash-es';
+import RecordLoader from '@/shared/services/record_loader';
+import Session from '@/shared/services/session';
+import EventBus from '@/shared/services/event_bus';
+import { debounce, identity, intersection, map, pickBy } from 'lodash-es';
 import LmoUrlService from '@/shared/services/lmo_url_service';
-import { exact, approximate } from '@/shared/helpers/format_time';
 import { mdiMagnify } from '@mdi/js';
-import UrlFor from '@/mixins/url_for';
-import WatchRecords from '@/mixins/watch_records';
+import { useWatchRecords } from '@/composables/useWatchRecords';
 
-export default
-{
-  mixins: [UrlFor, WatchRecords],
-  data() {
-    return {
-      mdiMagnify,
-      loader: null,
-      group: null,
-      per: 25,
-      order: 'created_at desc',
-      orders: [
-        {title: this.$t('members_panel.order_by_name'),  value:'users.name' },
-        {title: this.$t('members_panel.order_by_created'), value:'memberships.created_at' },
-        {title: this.$t('members_panel.order_by_created_desc'), value:'memberships.created_at desc' },
-        {title: this.$t('members_panel.order_by_admin_desc'), value:'admin desc' }
-      ],
-      memberships: []
-    };
-  },
-
-  created() {
-    this.onQueryInput = debounce(val => {
-      return this.$router.replace(this.mergeQuery({q: val}));
-    }
-    , 500);
-
-    Records.groups.findOrFetch(this.$route.params.key).then(group => {
-      this.group = group;
-
-      EventBus.$emit('currentComponent', {
-        page: 'groupPage',
-        title: this.group.name,
-        group: this.group,
-        search: {
-          placeholder: this.$t('navbar.search_members', {name: this.group.parentOrSelf().name})
-        }
-      });
-
-      this.loader = new RecordLoader({
-        collection: 'memberships',
-        params: {
-          exclude_types: 'group',
-          group_id: this.group.id,
-          per: this.per,
-          order: this.order,
-          subgroups: this.$route.query.subgroups
-        }
-      });
-
-      this.watchRecords({
-        collections: ['memberships', 'groups'],
-        query: this.query
-      });
-
-      this.refresh();
-    }).catch(() => {
-      // GroupPage owns route-level group fetch error handling.
-    });
-  },
-
-  methods: {
-    exact,
-    approximate,
-
-    query() {
-      let chain = Records.memberships.collection.chain();
-      switch (this.$route.query.subgroups) {
-        case 'mine':
-          chain = chain.find({groupId: {$in: intersection(this.group.organisationIds(), Session.user().groupIds())}});
-          break;
-        case 'all':
-          chain = chain.find({groupId: {$in: this.group.organisationIds()}});
-          break;
-        default:
-          chain = chain.find({groupId: this.group.id});
-      }
-
-      chain = chain.sort((a, b) => {
-        if (a.groupId === this.group.id) { return -1; }
-        if (b.groupId === this.group.id) { return 1; }
-        return 0;
-      });
-
-      const userIds = [];
-      const membershipIds = [];
-      chain.data().forEach(function(m) {
-        if (!userIds.includes(m.userId)) {
-          userIds.push(m.userId);
-          return membershipIds.push(m.id);
-        }
-      });
-
-      // @memberships = Records.memberships.collection.find(id: {$in: membershipIds})
-
-      // drop the chain, get a new one
-
-      chain = Records.memberships.collection.chain().find({id: {$in: membershipIds}});
-
-      if (this.$route.query.q) {
-        const query = this.$route.query.q;
-        const users = Records.users.collection.find({
-          $or: [
-            {name: {'$regex': [`^${query}`, "i"]}},
-            {email: {'$regex': [`${query}`, "i"]}},
-            {username: {'$regex': [`^${query}`, "i"]}},
-            {name: {'$regex': [` ${query}`, "i"]}}
-          ]});
-        const userIds = map(users, 'id');
-
-        chain = chain.where(membership => {
-          return userIds.includes(membership.userId) ||
-                 (membership.title || '').toLowerCase().includes(query.toLowerCase());
-        });
-      }
-
-      switch (this.$route.query.filter) {
-        case 'admin':
-          chain = chain.find({admin: true});
-          break;
-        case 'delegate':
-          chain = chain.find({delegate: true});
-          break;
-        case 'accepted':
-          chain = chain.find({acceptedAt: { $ne: null }});
-          break;
-        case 'pending':
-          chain = chain.find({acceptedAt: null});
-          break;
-      }
-
-      chain = chain.simplesort('id', true);
-
-      this.memberships = chain.data();
-    },
-
-    refresh() {
-      this.loader.fetchRecords({
-        from: 0,
-        q: this.$route.query.q,
-        order: this.order,
-        filter: this.$route.query.filter,
-        subgroups: this.$route.query.subgroups
-      });
-      this.query();
-    },
-    openShareableLinkForm() {
-      EventBus.$emit('openModal', {
-        component: 'GroupShareableLinkForm',
-        props: {
-          group: this.group
-        }
-      });
-    },
-    invite() {
-      EventBus.$emit('openModal', {
-        component: 'GroupInvitationForm',
-        props: {
-          group: this.group
-        }
-      });
-    }
-  },
-
-  computed: {
-    membershipRequestsPath() { return LmoUrlService.membershipRequest(this.group); },
-    showLoadMore() { return !this.loader.exhausted; },
-    totalRecords() {
-      if (this.$route.query.filter == 'pending') {
-        return this.group.pendingMembershipsCount;
-      } else {
-        return this.group.membershipsCount - this.group.pendingMembershipsCount;
-      }
-    },
-
-    canAddMembers() {
-      return AbilityService.canAddMembersToGroup(this.group);
-    },
-
-    showAdminWarning() {
-      return this.group.adminsInclude(Session.user()) &&
-      (this.group.adminMembershipsCount < 2) &&
-      ((this.group.membershipsCount - this.group.adminMembershipsCount) > 0);
-    }
-  },
-
-  watch: {
-    '$route.query': 'refresh'
+const { group } = defineProps({
+  group: {type: Object, required: true}
+});
+const route = useRoute();
+const router = useRouter();
+const { t } = useI18n();
+const { watchRecords } = useWatchRecords();
+const per = 25;
+const order = 'created_at desc';
+const memberships = ref([]);
+const loader = ref(new RecordLoader({
+  collection: 'memberships',
+  params: {
+    exclude_types: 'group',
+    group_id: group.id,
+    per,
+    order,
+    subgroups: route.query.subgroups
   }
-};
+}));
+const canAddMembers = computed(() => AbilityService.canAddMembersToGroup(group));
+const showAdminWarning = computed(() =>
+  group.adminsInclude(Session.user()) &&
+  group.adminMembershipsCount < 2 &&
+  group.membershipsCount - group.adminMembershipsCount > 0
+);
 
+function mergeQuery(values) {
+  return {query: pickBy({...route.query, ...values}, identity)};
+}
 
+function routeFor(model, action, params) {
+  return LmoUrlService.route({model, action, params});
+}
+
+const onQueryInput = debounce(value => router.replace(mergeQuery({q: value})), 500);
+
+function query() {
+  let chain = Records.memberships.collection.chain();
+  switch (route.query.subgroups) {
+    case 'mine':
+      chain = chain.find({groupId: {$in: intersection(group.organisationIds(), Session.user().groupIds())}});
+      break;
+    case 'all':
+      chain = chain.find({groupId: {$in: group.organisationIds()}});
+      break;
+    default:
+      chain = chain.find({groupId: group.id});
+  }
+
+  chain = chain.sort((a, b) => {
+    if (a.groupId === group.id) return -1;
+    if (b.groupId === group.id) return 1;
+    return 0;
+  });
+
+  const userIdsSeen = [];
+  const membershipIds = [];
+  chain.data().forEach(membership => {
+    if (!userIdsSeen.includes(membership.userId)) {
+      userIdsSeen.push(membership.userId);
+      membershipIds.push(membership.id);
+    }
+  });
+  chain = Records.memberships.collection.chain().find({id: {$in: membershipIds}});
+
+  if (route.query.q) {
+    const searchQuery = route.query.q;
+    const users = Records.users.collection.find({
+      $or: [
+        {name: {$regex: [`^${searchQuery}`, 'i']}},
+        {email: {$regex: [`${searchQuery}`, 'i']}},
+        {username: {$regex: [`^${searchQuery}`, 'i']}},
+        {name: {$regex: [` ${searchQuery}`, 'i']}}
+      ]
+    });
+    const userIds = map(users, 'id');
+    chain = chain.where(membership =>
+      userIds.includes(membership.userId) ||
+      (membership.title || '').toLowerCase().includes(searchQuery.toLowerCase())
+    );
+  }
+
+  switch (route.query.filter) {
+    case 'admin': chain = chain.find({admin: true}); break;
+    case 'delegate': chain = chain.find({delegate: true}); break;
+    case 'accepted': chain = chain.find({acceptedAt: {$ne: null}}); break;
+    case 'pending': chain = chain.find({acceptedAt: null}); break;
+  }
+
+  memberships.value = chain.simplesort('id', true).data();
+}
+
+function refresh() {
+  loader.value.fetchRecords({
+    from: 0,
+    q: route.query.q,
+    order,
+    filter: route.query.filter,
+    subgroups: route.query.subgroups
+  });
+  query();
+}
+
+function openShareableLinkForm() {
+  EventBus.$emit('openModal', {
+    component: 'GroupShareableLinkForm',
+    props: {group}
+  });
+}
+
+function invite() {
+  EventBus.$emit('openModal', {
+    component: 'GroupInvitationForm',
+    props: {group}
+  });
+}
+
+EventBus.$emit('currentComponent', {
+  page: 'groupPage',
+  title: group.name,
+  group,
+  search: {placeholder: t('navbar.search_members', {name: group.parentOrSelf().name})}
+});
+watchRecords({collections: ['memberships', 'groups'], query});
+watch(() => route.query, refresh);
+onUnmounted(() => onQueryInput.cancel());
+refresh();
 </script>
 
 <template lang="pug">
@@ -251,7 +189,7 @@ export default
         span(v-t="'members_panel.sharable_link'")
       v-btn.group-page__requests-tab.text-medium-emphasis.ml-2(
         v-if='group.isVisibleToPublic && canAddMembers'
-        :to="urlFor(group, 'membership_requests')"
+        :to="routeFor(group, 'membership_requests')"
         variant="text"
       )
         span(v-t="'members_panel.requests'")
@@ -267,7 +205,7 @@ export default
               user-avatar.mr-2(:user='membership.user()' :size='36')
             v-list-item-title
               template(v-if="membership.acceptedAt")
-                router-link.text-medium-emphasis.text-decoration-none(:to="urlFor(membership.user())") {{ membership.user().name }}
+                router-link.text-medium-emphasis.text-decoration-none(:to="routeFor(membership.user())") {{ membership.user().name }}
                 span.text-medium-emphasis(v-if="membership.acceptedAt && membership.userEmail")
                   space
                   span &lt;{{membership.userEmail}}&gt;

--- a/vue/src/components/group/page.vue
+++ b/vue/src/components/group/page.vue
@@ -1,77 +1,75 @@
-<script lang="js">
-import Session           from '@/shared/services/session';
-import Records           from '@/shared/services/records';
-import EventBus          from '@/shared/services/event_bus';
-import AbilityService    from '@/shared/services/ability_service';
-import GroupService    from '@/shared/services/group_service';
+<script setup>
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue';
+import { useRoute } from 'vue-router';
+import Session from '@/shared/services/session';
+import Records from '@/shared/services/records';
+import EventBus from '@/shared/services/event_bus';
+import AbilityService from '@/shared/services/ability_service';
+import GroupService from '@/shared/services/group_service';
+import LmoUrlService from '@/shared/services/lmo_url_service';
 import { pickBy } from 'lodash-es';
-import UrlFor from '@/mixins/url_for';
-import FormatDate from '@/mixins/format_date';
 
-export default
-{
-  mixins: [UrlFor, FormatDate],
-  data() {
-    return {
-      group: null,
-      activeTab: '',
-      groupFetchError: null
-    };
-  },
+const route = useRoute();
+const group = ref(null);
+const groupLoadVersion = ref(0);
+const activeTab = ref('');
+let groupLoadRequestId = 0;
 
-  created() {
-    this.init();
-    EventBus.$on('signedIn', this.init);
-  },
+const dockActions = computed(() => pickBy(GroupService.actions(group.value), action => action.dock));
+const menuActions = computed(() => pickBy(GroupService.actions(group.value), action => action.menu));
+const canEditGroup = computed(() => AbilityService.canEditGroup(group.value));
+const tabs = computed(() => {
+  if (!group.value) return [];
 
-  beforeDestroy() {
-    EventBus.$off('signedIn', this.init);
-  },
+  return [
+    {id: 0, name: 'discussions', route: LmoUrlService.route({model: group.value})},
+    {id: 1, name: 'polls', route: LmoUrlService.route({model: group.value, action: 'polls'})},
+    {id: 2, name: 'members', route: LmoUrlService.route({model: group.value, action: 'members'})},
+    {id: 4, name: 'files', route: LmoUrlService.route({model: group.value, action: 'files'})},
+  ];
+});
 
-  watch: {
-    '$route.params.key': 'init'
-  },
+function routeFor(model) {
+  return LmoUrlService.route({model});
+}
 
-  computed: {
-    dockActions() {
-      return pickBy(GroupService.actions(this.group), v => v.dock);
-    },
+function titleVisible(visible) {
+  EventBus.$emit('content-title-visible', visible);
+}
 
-    menuActions() {
-      return pickBy(GroupService.actions(this.group), v => v.menu);
-    },
+// Only the latest authorization response may populate the page. Successful
+// refreshes remount the routed panel so it initializes from the verified group.
+async function loadGroup() {
+  const requestId = ++groupLoadRequestId;
+  group.value = null;
 
-    canEditGroup() {
-      return AbilityService.canEditGroup(this.group);
-    },
+  try {
+    const loadedGroup = await Records.groups.findOrFetch(route.params.key);
+    if (requestId !== groupLoadRequestId) return;
 
-    tabs() {
-      if (!this.group) { return; }
-      let query = '';
+    group.value = loadedGroup;
+    groupLoadVersion.value += 1;
+    if (loadedGroup.newHost) window.location.host = loadedGroup.newHost;
+  } catch (error) {
+    if (requestId !== groupLoadRequestId) return;
 
-      return [
-        {id: 0, name: 'discussions',   route: this.urlFor(this.group, null)+query},
-        {id: 1, name: 'polls',     route: this.urlFor(this.group, 'polls')+query},
-        {id: 2, name: 'members',   route: this.urlFor(this.group, 'members')+query},
-        {id: 4, name: 'files',     route: this.urlFor(this.group, 'files')+query},
-      ].filter(obj => !((obj.name === "subgroups") && this.group.parentId));
-    }
-  },
-
-  methods: {
-    init() {
-      this.group = null;
-      Records.groups.findOrFetch(this.$route.params.key).then(group => {
-        this.group = group;
-        if (this.group.newHost) { window.location.host = this.group.newHost; }
-      }).catch(error => {
-        EventBus.$emit('pageError', error);
-        if ((error.status === 403) && !Session.isSignedIn()) { EventBus.$emit('openAuthModal'); }
-      });
-    }
+    EventBus.$emit('pageError', error);
+    if (error.status === 403 && !Session.isSignedIn()) EventBus.$emit('openAuthModal');
   }
-};
+}
 
+watch(() => route.params.key, loadGroup, {immediate: true});
+
+onMounted(() => {
+  EventBus.$on('signedIn', loadGroup);
+  EventBus.$on('joinedGroup', loadGroup);
+});
+
+onBeforeUnmount(() => {
+  groupLoadRequestId += 1;
+  EventBus.$off('signedIn', loadGroup);
+  EventBus.$off('joinedGroup', loadGroup);
+});
 </script>
 
 <template lang="pug">
@@ -102,7 +100,7 @@ v-main
       //  eager)
     h1.text-headline-large.my-4(tabindex="-1" v-intersect="{handler: titleVisible}")
       span(v-if="group && group.parentId")
-        router-link.text-high-emphasis.text-decoration-none.underline-on-hover(:to="urlFor(group.parent())")
+        router-link.text-high-emphasis.text-decoration-none.underline-on-hover(:to="routeFor(group.parent())")
           plain-text(:model="group.parent()" field="name")
         space
         span.text-medium-emphasis.text--lighten-1 &gt;
@@ -139,7 +137,8 @@ v-main
       )
         //- common-icon(name="mdi-comment-multiple")
         span(v-t="'group_page.'+tab.name")
-    router-view
+    router-view(v-slot="{ Component }")
+      component(:is="Component" :key="groupLoadVersion" :group="group")
 </template>
 
 <style lang="css">

--- a/vue/src/components/group/page.vue
+++ b/vue/src/components/group/page.vue
@@ -8,11 +8,13 @@ import AbilityService from '@/shared/services/ability_service';
 import GroupService from '@/shared/services/group_service';
 import LmoUrlService from '@/shared/services/lmo_url_service';
 import { pickBy } from 'lodash-es';
+import { useWatchRecords } from '@/composables/useWatchRecords';
 
 const route = useRoute();
 const group = ref(null);
 const groupLoadVersion = ref(0);
 const activeTab = ref('');
+const { watchRecords } = useWatchRecords();
 let groupLoadRequestId = 0;
 
 const dockActions = computed(() => pickBy(GroupService.actions(group.value), action => action.dock));
@@ -37,19 +39,26 @@ function titleVisible(visible) {
   EventBus.$emit('content-title-visible', visible);
 }
 
-// Only the latest authorization response may populate the page. Successful
-// refreshes remount the routed panel so it initializes from the verified group.
+function refreshGroup() {
+  const loadedGroup = Records.groups.fuzzyFind(route.params.key);
+  if (!loadedGroup) return;
+
+  group.value = loadedGroup;
+  if (loadedGroup.newHost) window.location.host = loadedGroup.newHost;
+}
+
+// Render cached group data immediately, then authorize and refresh it from the
+// server. Only the latest request may report an error or remount its panel.
 async function loadGroup() {
   const requestId = ++groupLoadRequestId;
-  group.value = null;
+  group.value = Records.groups.fuzzyFind(route.params.key) || null;
 
   try {
-    const loadedGroup = await Records.groups.findOrFetch(route.params.key);
+    await Records.groups.remote.fetchById(route.params.key);
     if (requestId !== groupLoadRequestId) return;
 
-    group.value = loadedGroup;
+    refreshGroup();
     groupLoadVersion.value += 1;
-    if (loadedGroup.newHost) window.location.host = loadedGroup.newHost;
   } catch (error) {
     if (requestId !== groupLoadRequestId) return;
 
@@ -58,6 +67,7 @@ async function loadGroup() {
   }
 }
 
+watchRecords({collections: ['groups'], query: refreshGroup});
 watch(() => route.params.key, loadGroup, {immediate: true});
 
 onMounted(() => {

--- a/vue/src/components/group/polls_panel.vue
+++ b/vue/src/components/group/polls_panel.vue
@@ -1,184 +1,138 @@
-<script lang="js">
+<script setup>
+import { computed, ref, watch } from 'vue';
+import { useRoute, useRouter } from 'vue-router';
 import AppConfig from '@/shared/services/app_config';
 import AbilityService from '@/shared/services/ability_service';
 import Records from '@/shared/services/records';
 import PageLoader from '@/shared/services/page_loader';
-import EventBus       from '@/shared/services/event_bus';
-import Session       from '@/shared/services/session';
-import { intersection, uniq } from 'lodash-es';
+import EventBus from '@/shared/services/event_bus';
+import Session from '@/shared/services/session';
+import { identity, intersection, pickBy, uniq } from 'lodash-es';
 import { mdiMagnify } from '@mdi/js';
 import TagsFilterMenu from '@/components/tags/filter_menu';
-import WatchRecords from '@/mixins/watch_records';
-import UrlFor from '@/mixins/url_for';
+import { useWatchRecords } from '@/composables/useWatchRecords';
 
-export default
-{
-  components: { TagsFilterMenu },
-  mixins: [WatchRecords, UrlFor],
-  data() {
-    return {
-      mdiMagnify,
-      group: null,
-      polls: [],
-      loader: null,
-      pollTypes: AppConfig.pollTypes,
-      per: 25,
-      dummyQuery: null
-    };
-  },
+const { group } = defineProps({
+  group: {type: Object, required: true}
+});
+const route = useRoute();
+const router = useRouter();
+const { watchRecords } = useWatchRecords();
+const polls = ref([]);
+const loader = ref(null);
+const pollTypes = AppConfig.pollTypes;
+const per = 25;
+const dummyQuery = ref(null);
+const page = computed({
+  get: () => parseInt(route.query.page) || 1,
+  set: value => router.replace({query: {...route.query, page: value}})
+});
+const totalPages = computed(() => Math.max(1, Math.ceil((loader.value?.total || 0) / per)));
+const canStartPoll = computed(() => AbilityService.canStartPoll(group));
 
-  created() {
-    this.group = Records.groups.find(this.$route.params.key);
+function mergeQuery(values) {
+  return {query: pickBy({...route.query, ...values}, identity)};
+}
 
-    this.initLoader();
+function startNewPoll() {
+  router.push(`/p/new?group_id=${group.id}`);
+}
 
-    this.watchRecords({
-      collections: ['polls', 'groups', 'stances'],
-      query: () => this.findRecords()
-    });
+function selectTag(tag) {
+  router.replace(mergeQuery({tag, page: null}));
+}
 
-    this.fetch().then(() => {
-      EventBus.$emit('currentComponent', {
-        page: 'groupPage',
-        title: this.group.name,
-        group: this.group
-      });
-    });
-  },
+function openSearchModal() {
+  const initialOrgId = group.isParent() ? group.id : group.parentId;
+  const initialGroupId = group.isParent() ? null : group.id;
 
-  methods: {
-    startNewPoll() {
-      this.$router.push('/p/new?group_id=' + this.group.id);
-    },
-
-    selectTag(tag) {
-      this.$router.replace(this.mergeQuery({tag, page: null}));
-    },
-
-    openSearchModal() {
-      let initialOrgId = null;
-      let initialGroupId = null;
-
-      if (this.group.isParent()) {
-        initialOrgId = this.group.id;
-      } else {
-        initialOrgId = this.group.parentId;
-        initialGroupId = this.group.id;
-      }
-
-      EventBus.$emit('openModal', {
-        component: 'SearchModal',
-        persistent: false,
-        maxWidth: 900,
-        props: {
-          initialType: 'Poll',
-          initialOrgId,
-          initialGroupId,
-          initialQuery: this.dummyQuery
-        }
-      });
-    },
-
-    initLoader() {
-      return this.loader = new PageLoader({
-        path: 'polls',
-        order: 'createdAt',
-        params: {
-          exclude_types: 'group reaction',
-          group_key: this.$route.params.key,
-          status: this.$route.query.status,
-          poll_type: this.$route.query.poll_type,
-          tags: this.$route.query.tag,
-          subgroups: this.$route.query.subgroups,
-          per: this.per
-        }
-      });
-    },
-
-    fetch() {
-      return this.loader.fetch(this.page).then(() => this.findRecords());
-    },
-
-    findRecords() {
-      const groupIds = (() => { switch (this.$route.query.subgroups || 'mine') {
-        case 'all': return this.group.organisationIds();
-        case 'none': return [this.group.id];
-        case 'mine': return uniq([this.group.id].concat(intersection(this.group.organisationIds(), Session.user().groupIds())));
-      } })();
-
-      let chain = Records.polls.collection.chain();
-      chain = chain.find({groupId: {$in: groupIds}});
-      chain = chain.find({discardedAt: null});
-
-      switch (this.$route.query.status) {
-        case 'active':
-          chain = chain.find({'closedAt': null});
-          break;
-        case 'closed':
-          chain = chain.find({'closedAt': {$ne: null}});
-          break;
-        case 'vote':
-          chain = chain.find({'closedAt': null}).where(p => p.iCanVote() && !p.iHaveVoted());
-          break;
-      }
-
-      if (this.$route.query.poll_type) {
-        chain = chain.find({'pollType': this.$route.query.poll_type});
-      }
-
-      if (this.$route.query.tag) {
-        const tagName = this.$route.query.tag;
-        chain = chain.where(poll => poll.topic().tags.includes(tagName));
-      }
-
-      if (this.loader.pageWindow[this.page]) {
-        if (this.page === 1) {
-          chain = chain.find({createdAt: {$gte: this.loader.pageWindow[this.page][0]}});
-        } else {
-          chain = chain.find({createdAt: {$jbetween: this.loader.pageWindow[this.page]}});
-        }
-        this.polls = chain.simplesort('createdAt', true).data();
-      } else {
-        this.polls = [];
-      }
+  EventBus.$emit('openModal', {
+    component: 'SearchModal',
+    persistent: false,
+    maxWidth: 900,
+    props: {
+      initialType: 'Poll',
+      initialOrgId,
+      initialGroupId,
+      initialQuery: dummyQuery.value
     }
-  },
+  });
+}
 
-  watch: {
-    '$route.query.status'() {
-      this.initLoader();
-      this.fetch();
-    },
-    '$route.query.poll_type'() {
-      this.initLoader();
-      this.fetch();
-    },
-    '$route.query.tag'() {
-      this.initLoader();
-      this.fetch();
-    },
-    '$route.query.subgroups'() {
-      this.initLoader();
-      this.fetch();
-    },
-    '$route.query.page'() {
-      this.fetch();
+function initLoader() {
+  loader.value = new PageLoader({
+    path: 'polls',
+    order: 'createdAt',
+    params: {
+      exclude_types: 'group reaction',
+      group_key: route.params.key,
+      status: route.query.status,
+      poll_type: route.query.poll_type,
+      tags: route.query.tag,
+      subgroups: route.query.subgroups,
+      per
     }
-  },
+  });
+}
 
-  computed: {
-    totalPages() {
-      return Math.max(1, Math.ceil((this.loader.total || 0) / this.per));
-    },
-    canStartPoll() { return AbilityService.canStartPoll(this.group); },
-    page: {
-      get() { return parseInt(this.$route.query.page) || 1; },
-      set(val) {
-        return this.$router.replace({query: Object.assign({}, this.$route.query, {page: val})});
-      }
+function fetch() {
+  return loader.value.fetch(page.value).then(findRecords);
+}
+
+function findRecords() {
+  const groupIds = (() => {
+    switch (route.query.subgroups || 'mine') {
+      case 'all': return group.organisationIds();
+      case 'none': return [group.id];
+      case 'mine': return uniq([group.id].concat(intersection(group.organisationIds(), Session.user().groupIds())));
     }
+  })();
+
+  let chain = Records.polls.collection.chain()
+    .find({groupId: {$in: groupIds}})
+    .find({discardedAt: null});
+
+  switch (route.query.status) {
+    case 'active': chain = chain.find({closedAt: null}); break;
+    case 'closed': chain = chain.find({closedAt: {$ne: null}}); break;
+    case 'vote': chain = chain.find({closedAt: null}).where(poll => poll.iCanVote() && !poll.iHaveVoted()); break;
   }
-};
+
+  if (route.query.poll_type) chain = chain.find({pollType: route.query.poll_type});
+  if (route.query.tag) chain = chain.where(poll => poll.topic().tags.includes(route.query.tag));
+
+  const pageWindow = loader.value.pageWindow[page.value];
+  if (!pageWindow) {
+    polls.value = [];
+    return;
+  }
+
+  chain = page.value === 1
+    ? chain.find({createdAt: {$gte: pageWindow[0]}})
+    : chain.find({createdAt: {$jbetween: pageWindow}});
+  polls.value = chain.simplesort('createdAt', true).data();
+}
+
+initLoader();
+watchRecords({
+  collections: ['polls', 'groups', 'stances'],
+  query: findRecords
+});
+watch(
+  () => [route.query.status, route.query.poll_type, route.query.tag, route.query.subgroups],
+  () => {
+    initLoader();
+    fetch();
+  }
+);
+watch(() => route.query.page, fetch);
+fetch().then(() => {
+  EventBus.$emit('currentComponent', {
+    page: 'groupPage',
+    title: group.name,
+    group
+  });
+});
 </script>
 
 <template lang="pug">

--- a/vue/src/components/group/requests_panel.vue
+++ b/vue/src/components/group/requests_panel.vue
@@ -1,53 +1,34 @@
-<script lang="js">
-import Records        from '@/shared/services/records';
+<script setup>
+import { computed, ref } from 'vue';
+import Records from '@/shared/services/records';
 import AbilityService from '@/shared/services/ability_service';
-import RecordLoader   from '@/shared/services/record_loader';
-import Session        from '@/shared/services/session';
 import { orderBy } from 'lodash-es';
-import LmoUrlService from '@/shared/services/lmo_url_service';
-import { exact, approximate } from '@/shared/helpers/format_time';
-import UrlFor from '@/mixins/url_for';
-import WatchRecords from '@/mixins/watch_records';
+import { useWatchRecords } from '@/composables/useWatchRecords';
 
-export default
-{
-  mixins: [UrlFor, WatchRecords],
-  data() {
-    return {
-      requests: [],
-      group: null
-    };
-  },
+const { group } = defineProps({
+  group: {type: Object, required: true}
+});
+const requests = ref([]);
+const { watchRecords } = useWatchRecords();
 
-  created() {
-    Records.groups.findOrFetch(this.$route.params.key).then(group => {
-      this.group = group;
+const unapprovedRequestsByOldestFirst = computed(() => {
+  const unapproved = requests.value.filter(request => !request.respondedAt);
+  return orderBy(unapproved, ['createdAt'], ['asc']);
+});
 
-      if (AbilityService.canManageMembershipRequests(this.group)) {
-        Records.membershipRequests.fetchPendingByGroup(this.group.key, {per: 100});
-        Records.membershipRequests.fetchPreviousByGroup(this.group.key, {per: 100});
-        this.watchRecords({
-          collections: ['membershipRequests'],
-          query: store => {this.requests = this.group.membershipRequests(); }
-        });
-      }
-    }).catch(() => {
-      // GroupPage owns route-level group fetch error handling.
-    });
-  },
+const approvedRequestsByNewestFirst = computed(() => {
+  const approved = requests.value.filter(request => request.respondedAt);
+  return orderBy(approved, ['respondedAt'], ['desc']);
+});
 
-  computed: {
-    unapprovedRequestsByOldestFirst() {
-      const unapproved = this.requests.filter(request => !request.respondedAt);
-      return orderBy(unapproved, ['createdAt'], ['asc']);
-    },
-
-    approvedRequestsByNewestFirst() {
-      const approved = this.requests.filter(request => request.respondedAt);
-      return orderBy(approved, ['respondedAt'], ['desc']);
-    }
-  }
-};
+if (AbilityService.canManageMembershipRequests(group)) {
+  Records.membershipRequests.fetchPendingByGroup(group.key, {per: 100});
+  Records.membershipRequests.fetchPreviousByGroup(group.key, {per: 100});
+  watchRecords({
+    collections: ['membershipRequests'],
+    query: () => { requests.value = group.membershipRequests(); }
+  });
+}
 </script>
 <template lang="pug">
 .requests-panel

--- a/vue/src/components/group/tags_panel.vue
+++ b/vue/src/components/group/tags_panel.vue
@@ -1,62 +1,41 @@
-<script lang="js">
-import AppConfig from '@/shared/services/app_config';
-import AbilityService from '@/shared/services/ability_service';
+<script setup>
+import { ref, watch } from 'vue';
+import { useRoute } from 'vue-router';
 import Records from '@/shared/services/records';
 import RecordLoader from '@/shared/services/record_loader';
-import EventBus from '@/shared/services/event_bus';
-import Session from '@/shared/services/session';
-import WatchRecords from '@/mixins/watch_records';
+import { useWatchRecords } from '@/composables/useWatchRecords';
 
-export default
-{
-  mixins: [WatchRecords],
-  data() {
-    return {
-      group: null,
-      topicsLoader: null,
-      topics: []
-    };
-  },
+const { group } = defineProps({
+  group: {type: Object, required: true}
+});
+const route = useRoute();
+const topicsLoader = ref(null);
+const topics = ref([]);
+const { watchRecords } = useWatchRecords();
 
-  created() {
-    this.init();
+function findRecords() {
+  topics.value = Records.topics.collection.chain()
+    .find({groupId: {$in: group.selfAndSubgroupIds()}})
+    .find({tags: {$contains: route.params.tag}})
+    .simplesort('lastActivityAt', true)
+    .data();
+}
 
-    return this.watchRecords({
-      collections: ['topics', 'groups', 'discussions', 'polls'],
-      query: () => this.findRecords()
-    });
-  },
+function init() {
+  topicsLoader.value = new RecordLoader({
+    collection: 'topics',
+    params: {filter: 'all', tags: route.params.tag, group_id: group.id}
+  });
+  topicsLoader.value.fetchRecords();
+  findRecords();
+}
 
-  watch: {
-    '$route.params.tag': 'init'
-  },
-
-  methods: {
-    init() {
-      this.group = Records.groups.find(this.$route.params.key);
-
-      this.topicsLoader = new RecordLoader({
-        collection: 'topics',
-        params: {
-          filter: 'all',
-          tags: this.$route.params.tag,
-          group_id: this.group.id
-        }
-      });
-
-      this.topicsLoader.fetchRecords();
-      this.findRecords();
-    },
-
-    findRecords() {
-      this.topics = Records.topics.collection.chain().
-        find({groupId: {$in: this.group.selfAndSubgroupIds()}}).
-        find({tags: {$contains: this.$route.params.tag}}).
-        simplesort('lastActivityAt', true).data();
-    }
-  }
-};
-
+watchRecords({
+  collections: ['topics', 'groups', 'discussions', 'polls'],
+  query: findRecords
+});
+watch(() => route.params.tag, init);
+init();
 </script>
 
 <template lang="pug">

--- a/vue/tests/component/group_page.test.js
+++ b/vue/tests/component/group_page.test.js
@@ -1,0 +1,134 @@
+import { defineComponent, nextTick, reactive } from 'vue';
+import { flushPromises, shallowMount } from '@vue/test-utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  route: {params: {key: 'cached-group'}},
+  groupCurrent: null,
+  groupFetch: null,
+  watchRecordsQuery: null,
+  eventBus: {$emit: vi.fn(), $on: vi.fn(), $off: vi.fn()},
+  fetchById: vi.fn(),
+  fuzzyFind: vi.fn()
+}));
+
+vi.mock('vue-router', () => ({
+  useRoute: () => reactive(mocks.route)
+}));
+
+vi.mock('@/shared/services/records', () => ({
+  default: {
+    groups: {
+      fuzzyFind: mocks.fuzzyFind,
+      remote: {fetchById: mocks.fetchById}
+    }
+  }
+}));
+
+vi.mock('@/shared/services/session', () => ({
+  default: {isSignedIn: () => false}
+}));
+
+vi.mock('@/shared/services/event_bus', () => ({default: mocks.eventBus}));
+vi.mock('@/shared/services/ability_service', () => ({
+  default: {canEditGroup: () => false}
+}));
+vi.mock('@/shared/services/group_service', () => ({
+  default: {actions: () => ({})}
+}));
+vi.mock('@/shared/services/lmo_url_service', () => ({
+  default: {route: () => '/cached-group'}
+}));
+vi.mock('@/composables/useWatchRecords', () => ({
+  useWatchRecords: () => ({
+    watchRecords: ({query}) => { mocks.watchRecordsQuery = query; }
+  })
+}));
+
+import GroupPage from '@/components/group/page.vue';
+
+const RoutedPanel = defineComponent({
+  name: 'RoutedPanel',
+  props: {group: Object},
+  template: '<div class="routed-panel">{{ group.name }}</div>'
+});
+
+const RouterView = defineComponent({
+  name: 'RouterView',
+  setup(_, {slots}) {
+    return () => slots.default({Component: RoutedPanel});
+  }
+});
+
+function deferred() {
+  let resolve;
+  let reject;
+  const promise = new Promise((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return {promise, reject, resolve};
+}
+
+function mountPage() {
+  return shallowMount(GroupPage, {
+    global: {
+      mocks: {$t: key => key},
+      directives: {
+        intersect: () => {},
+        t: () => {}
+      },
+      stubs: {
+        VContainer: {template: '<div><slot /></div>'},
+        VMain: {template: '<main><slot /></main>'},
+        'router-link': true,
+        'router-view': RouterView
+      }
+    }
+  });
+}
+
+describe('GroupPage', () => {
+  beforeEach(() => {
+    mocks.route.params.key = 'cached-group';
+    mocks.groupCurrent = {id: 1, key: 'cached-group', name: 'Cached group'};
+    mocks.groupFetch = deferred();
+    mocks.watchRecordsQuery = null;
+    mocks.eventBus.$emit.mockReset();
+    mocks.fetchById.mockReset().mockReturnValue(mocks.groupFetch.promise);
+    mocks.fuzzyFind.mockReset().mockImplementation(() => mocks.groupCurrent);
+  });
+
+  it('renders a cached group while authorizing it from the server', async () => {
+    const wrapper = mountPage();
+    await nextTick();
+
+    expect(mocks.fetchById).toHaveBeenCalledWith('cached-group');
+    expect(wrapper.findComponent(RoutedPanel).props('group').name).toBe('Cached group');
+  });
+
+  it('refreshes the routed panel when watchRecords receives the updated group', async () => {
+    const wrapper = mountPage();
+    await nextTick();
+    const refreshedGroup = {id: 1, key: 'cached-group', name: 'Refreshed group'};
+
+    mocks.groupCurrent = refreshedGroup;
+    mocks.watchRecordsQuery();
+    await nextTick();
+
+    expect(wrapper.findComponent(RoutedPanel).props('group').name).toBe('Refreshed group');
+  });
+
+  it('reports an authorization failure when no cached group is available', async () => {
+    mocks.groupCurrent = null;
+    const wrapper = mountPage();
+    const error = {status: 403};
+
+    mocks.groupFetch.reject(error);
+    await flushPromises();
+
+    expect(wrapper.findComponent(RoutedPanel).exists()).toBe(false);
+    expect(mocks.eventBus.$emit).toHaveBeenCalledWith('pageError', error);
+    expect(mocks.eventBus.$emit).toHaveBeenCalledWith('openAuthModal');
+  });
+});

--- a/vue/tests/e2e/specs/group.js
+++ b/vue/tests/e2e/specs/group.js
@@ -82,6 +82,28 @@ module.exports = {
     page.expectNoElement('.group-page__name')
   },
 
+  'loads each routed panel from the parent group': (test) => {
+    page = pageHelper(test)
+
+    const openPanel = (path, selector) => {
+      test.execute((panelPath) => {
+        const parts = window.location.pathname.split('/').filter(Boolean)
+        const groupPath = parts[0] === 'g' ? `/g/${parts[1]}` : `/${parts[0]}`
+        window.location.href = `${groupPath}/${panelPath}`
+      }, [path])
+      test.waitForElementVisible(selector, 20000)
+    }
+
+    page.loadPath('setup_group')
+    page.expectElement('.discussions-panel')
+    openPanel('polls', '.polls-panel')
+    openPanel('members', '.members-panel')
+    openPanel('files', '.group-files-panel')
+    openPanel('tags', '.tags-panel')
+    openPanel('membership_requests', '.requests-panel')
+    openPanel('emails', '.group-emails-panel')
+  },
+
   'displays_threads_from_subgroups_in_the_discussions_card': (test) => {
     page = pageHelper(test)
 

--- a/vue/vite.config.js
+++ b/vue/vite.config.js
@@ -117,5 +117,16 @@ export default defineConfig({
     renderBuiltUrl(filename) {
       return '/client3/' + filename;
     }
+  },
+
+  test: {
+    environment: 'jsdom',
+    include: ['tests/component/**/*.test.js'],
+    restoreMocks: true,
+    server: {
+      deps: {
+        inline: [/vuetify/]
+      }
+    }
   }
 });


### PR DESCRIPTION
Pass the refreshed group into script-setup panels so nested routes do not repeat group fetches and cannot render stale cached access.