### PR TITLE
Drop unused variables from lmo_textarea editor destructuring

### DIFF
--- a/vue/src/components/lmo_textarea/collab_editor.vue
+++ b/vue/src/components/lmo_textarea/collab_editor.vue
@@ -113,7 +113,6 @@ const iconProps = ref({
 const modelRef = toRef(props, 'model');
 
 const {
-  mentionsCache,
   mentions,
   query,
   navigatedUserIndex,
@@ -135,7 +134,6 @@ const htmlMentioning = useHtmlMentioning(
 
 const {
   files,
-  imageFiles,
   resetFiles,
   updateFiles,
   removeFile,

--- a/vue/src/components/lmo_textarea/md_editor.vue
+++ b/vue/src/components/lmo_textarea/md_editor.vue
@@ -35,7 +35,6 @@ const modelRef = toRef(props, 'model');
 const fieldNameRef = toRef(props, 'field');
 
 const {
-  mentionsCache,
   mentions,
   query,
   navigatedUserIndex,
@@ -74,9 +73,7 @@ const {
 
 const {
   files,
-  imageFiles,
   resetFiles,
-  updateFiles,
   removeFile,
   attachFile,
   attachImageFile,


### PR DESCRIPTION
`md_editor.vue` and `collab_editor.vue` both pull a bundle of values out of
the attaching/mentioning composables and then never use some of them -
`imageFiles` and `mentionsCache` in both files, plus `updateFiles` in
`md_editor.vue` (`collab_editor.vue` still calls it, so it stays there).

Just removing the unused names from the destructuring; the composables
themselves are untouched.
