### PR TITLE
Remove untouched legacy trial seed content

### DIFF
--- a/app/services/seeded_content_cleanup_service.rb
+++ b/app/services/seeded_content_cleanup_service.rb
@@ -1,0 +1,494 @@
+# Removes the example discussions and polls that Loomio created for new groups
+# before automatic example content was retired in August 2023. The historical
+# generator used the helper account, not the newer API-account bot flag. Known
+# helper authorship and titles identify seeds, while activity checks preserve
+# anything members subsequently edited, commented on, voted in, or reacted to.
+module SeededContentCleanupService
+  CREATED_BEFORE = Date.new(2023, 8, 5)
+  DELETE_BATCH_SIZE = 200
+  REFERENCE_TABLES = %i[users groups topics discussions polls poll_options topic_items comments stances stance_choices anonymous_ballots anonymous_ballot_choices anonymous_poll_voters outcomes reactions versions active_storage_attachments bookmarks tasks topic_readers].freeze
+
+  HELPER_BOT_EMAILS = %w[
+    contact@loom.io
+    contact@loomio.com
+    contact@loomio.org
+    notifications@loomio.com
+  ].freeze
+
+  DISCUSSION_TITLES = [
+    "How to use Loomio",
+    "How To Use Loomio",
+    "Intro to Loomio",
+    "Comment utiliser Loomio",
+    "Cómo usar Loomio",
+    "Wie man Loomio benutzt",
+    "Como utilizar o Loomio",
+    "Come usare Loomio",
+    "如何使用 Loomio",
+    "Welcome! Please introduce yourself",
+    "Bienvenue ! N'hésitez pas à vous présenter",
+    "Bienvenue ! N'hésitez pas à vous présenter",
+    "Bienvenid@! Por favor  preséntate al grupo",
+    "Willkommen! Bitte stelle dich kurz vor",
+    "Bem-vindo! Por favor, apresente-se",
+    "Example Discussion: Welcome and introduction to Loomio",
+    "Discusión de ejemplo: Bienvenida e introducción a Loomio",
+    "Exemple de Discussion : Bienvenue et introduction sur Loomio",
+    "Hoe gebruik je Loomio",
+    "Como Utilizar o Loomio",
+    "Benvenuto/a! Presentati",
+    "Welkom! Stel jezelf alsjeblieft voor",
+    "歡迎！請自我介紹",
+    "Wie man Loomio benutzen kann",
+    "Exemple de Discussion : Bienvenue et introduction à Loomio",
+    "Discussão de exemplo: Boas vindas e Introdução ao Loomio",
+    "討論範例: 歡迎並介紹 Loomio",
+    "Jak korzystać z Loomio",
+    "Beispieldiskussion: Willkommen und Einführung zu Loomio",
+    "Як використовувати Loomio",
+    "Velkommen, introducér dig selv",
+    "איך להשתמש בלומיו",
+    "Sådan bruger du Loomio",
+    "Welcome and Introduction to Loomio!",
+    "Вітаємо! Розкажіть про себе",
+    "Példa téma: Üdvözlet és bevezetés a Loomióba",
+    "Discussione Esempio: Benvenuto e introduzione a Loomio",
+    "Exemple de discussió: Benvinguda i introducció a Loomio.",
+    "Jak používat Loomio",
+    "Vítejte! Prosím, představte se",
+    "Voorbeeld Discussie: Welkom en introductie tot Loomio",
+    "Πως να χρησιμοποιείς το Loomio",
+    "Example Discussion: Welcome and introduction to Loomio!",
+    "كيفية استخدام لوميو",
+    "Diskussionsexempel: Välkommen och en introduktion till Loomio",
+    "Hogyan kell használni a Loomio-t?",
+    "Loomio Nasıl Kullanılır",
+    "ברוך הבא! אנא הצג את עצמך",
+    "Παράδειγμα Συζήτησης: Καλώς Ήρθατε και συστηθείτε στο Loomio",
+    "Eksempeldiskussion: Velkommen og introduktion til Loomio",
+    "Ukázková diskuze: Přivítání a úvod do Loomio"
+  ].freeze
+
+  DISCUSSION_TITLE_PREFIXES = [
+    "Welcome to ", "Bienvenue dans ", "Bienvenida/o a ", "Bem-vindo ao ",
+    "Willkommen bei ", "歡迎來到 ", "Benvenuto su ", "Welkom bij ",
+    "Καλωσήλθες στην ομάδα ", "أهلا بك في ", "Benvingut a ",
+    "Vítejte v ", "Запрашаем у "
+  ].freeze
+  DISCUSSION_TITLE_SUFFIXES = [ " grubuna hoşgeldiniz" ].freeze
+
+  POLL_TITLES = [
+    "Demonstration proposal",
+    "Have any questions about using Loomio?",
+    "Proposition de démonstration",
+    "Demonstration proposal: let’s go!",
+    "We should have a holiday on the moon!",
+    "Propuesta de demostración",
+    "¿Tienes alguna pregunta acerca de cómo usar Loomio?",
+    "Demo-Vorschlag",
+    "Vous avez des questions sur l'utilisation de Loomio ?",
+    "Proposta de demonstração",
+    "Propuesta de demostración: Aquí vamos!  ",
+    "Proposta dimostrativa",
+    "Proposition de démonstration: c'est parti!",
+    "¡Deberíamos irnos de vacaciones a la luna!",
+    "Proposition de démonstration: c’est parti!",
+    "提案範例",
+    "Proposta demonstração: vamos lá!",
+    "Hast du Fragen zur Verwendung von Loomio?",
+    "Demonstratievoorstel",
+    "Versuchsvorschlag: letz gouuu!",
+    "Demonstratie voorstel",
+    "Masz pytania dotyczące korzystania z Loomio?",
+    "Heb je vragen over het gebruik van Loomio?",
+    "Приклад пропозиції",
+    "Nous devrions passer nos vacances sur la Lune !",
+    "有任何關於使用 Loomio 的問題嗎？",
+    "示範提案：走吧！",
+    "Demonstrations forslag",
+    "Proposta di prova: andiamo!",
+    "Ukázkový návrh",
+    "Nós devíamos passar as férias na lua!",
+    "הדגמת הצעה",
+    "Bemutató javaslat",
+    "Dovremmo andare in vacanza sulla Luna!",
+    "مقترح تجريبي: هيا بنا! ",
+    "We should have a holiday on the moon",
+    "Wir sollten Urlaub auf dem Mond machen!",
+    "Hauríem d'anar de vacances a la Lluna!",
+    "We zouden een vakantie op de maan moeten houden!",
+    "Deberíamos irnos de vacaciones a la luna!",
+    "Demo önerisi: Haydi gidelim!",
+    "Proposta de demostració: som-hi!",
+    "Menjünk nyaralni a Holdra!",
+    "您應該去月球度個假！",
+    "Ми маємо відпочивати на місяці!",
+    "Vi borde åka på semester till månen!",
+    "Ay üzerinde bir tatil yapmalıyız!",
+    "Tem alguma dúvida sobre como usar o Loomio?",
+    "How is your experience with Loomio so far?"
+  ].freeze
+
+  def self.audit
+    result = {
+      discussions: candidate_discussions.distinct.count,
+      polls: candidate_polls.distinct.count
+    }
+    puts "Seeded discussions eligible for deletion: #{result[:discussions]}"
+    puts "Seeded polls eligible for deletion:       #{result[:polls]}"
+    result
+  end
+
+  # Topics are destroyed in bounded transactions so dependent records, counter
+  # caches, and search documents are removed together without paying for one
+  # database commit per topic. Polls embedded in an eligible discussion are
+  # removed with that discussion's topic.
+  def self.delete!(limit: nil, batch_size: DELETE_BATCH_SIZE, content_type: nil, shard_count: 1, shard_index: 0)
+    unless [ nil, "discussions", "polls" ].include?(content_type)
+      raise ArgumentError, "content_type must be discussions or polls"
+    end
+    unless shard_count.positive? && shard_index.between?(0, shard_count - 1)
+      raise ArgumentError, "shard_index must be between 0 and shard_count - 1"
+    end
+
+    discussion_scope = shard(
+      candidate_discussions,
+      record_type: "Discussion",
+      count: shard_count,
+      index: shard_index
+    )
+    poll_scope = shard(
+      candidate_polls,
+      record_type: "Poll",
+      count: shard_count,
+      index: shard_index
+    )
+    discussion_ids = content_type == "polls" ? [] : discussion_scope.order(:id).limit(limit).pluck(:id)
+    poll_ids = content_type == "discussions" ? [] : poll_scope.order(:id).limit(limit).pluck(:id)
+    discussions_deleted = 0
+    polls_deleted = 0
+
+    PaperTrail.request(enabled: false) do
+      discussion_ids.each_slice(batch_size) do |ids|
+        CleanupService.with_write_lock(REFERENCE_TABLES) do
+          discussions_by_id = discussion_scope.where(id: ids).lock.index_by(&:id)
+          ids.each do |id|
+            discussion = discussions_by_id[id]
+            next unless discussion
+
+            discussion.topic.destroy!
+            discussions_deleted += 1
+          end
+        end
+      end
+
+      poll_ids_remaining = Poll.where(id: poll_ids).pluck(:id)
+      polls_deleted = poll_ids.length - poll_ids_remaining.length
+      poll_ids_remaining.each_slice(batch_size) do |ids|
+        CleanupService.with_write_lock(REFERENCE_TABLES) do
+          polls_by_id = poll_scope.where(id: ids).lock.index_by(&:id)
+          ids.each do |id|
+            poll = polls_by_id[id]
+            next unless poll
+
+            if poll.topic.topicable_type == "Poll" && poll.topic.topicable_id == poll.id
+              poll.topic.destroy!
+            else
+              poll.destroy!
+            end
+            polls_deleted += 1
+          end
+        end
+      end
+    end
+
+    result = { discussions: discussions_deleted, polls: polls_deleted }
+    puts "Deleted #{result[:discussions]} seeded discussions and #{result[:polls]} seeded polls"
+    result
+  end
+
+  def self.candidate_discussions
+    scope = Discussion.joins(topic: :group)
+      .where("discussions.created_at < ?", CREATED_BEFORE)
+      .where(discussions: { author_id: helper_bot_ids, discarded_at: nil }, topics: { discarded_at: nil })
+      .where(discussion_title_condition)
+    scope = without_additional_topic_activity(
+      scope,
+      record_type: "Discussion",
+      record_table: "discussions",
+      root_kind: "new_discussion"
+    )
+    scope = without_additional_votes(scope)
+    scope = without_anonymous_votes(scope)
+    scope = without_outcomes(scope)
+    scope = without_member_reactions(scope, record_type: "Discussion")
+    scope = without_poll_reactions(scope)
+    scope = without_member_edits(scope, item_type: "Discussion", record_table: "discussions")
+    scope = without_attached_poll_edits(scope)
+    scope = without_member_comment_activity(scope)
+    scope.where(<<~SQL.squish, poll_titles: POLL_TITLES, helper_bot_ids: helper_bot_ids, created_before: CREATED_BEFORE)
+      NOT EXISTS (
+        SELECT 1 FROM polls attached_polls
+        WHERE attached_polls.topic_id = topics.id
+          AND (
+            attached_polls.title IS NULL OR attached_polls.title NOT IN (:poll_titles)
+            OR attached_polls.author_id IS NULL OR attached_polls.author_id NOT IN (:helper_bot_ids)
+            OR attached_polls.created_at >= :created_before
+          )
+      )
+    SQL
+  end
+
+  def self.candidate_polls
+    scope = Poll.joins(topic: :group)
+      .where("polls.created_at < ?", CREATED_BEFORE)
+      .where(polls: { author_id: helper_bot_ids, title: POLL_TITLES, discarded_at: nil }, topics: { discarded_at: nil })
+    scope = without_additional_topic_activity(
+      scope,
+      record_type: "Poll",
+      record_table: "polls",
+      root_kind: "poll_created"
+    )
+    scope = without_additional_votes(scope)
+    scope = without_anonymous_votes(scope)
+    scope = without_outcomes(scope)
+    scope = without_member_reactions(scope, record_type: "Poll")
+    scope = without_poll_reactions(scope)
+    scope = without_member_edits(scope, item_type: "Poll", record_table: "polls")
+    without_member_comment_activity(scope)
+  end
+
+  def self.discussion_title_condition
+    clauses = [ "discussions.title IN (?)" ]
+    binds = [ DISCUSSION_TITLES ]
+    DISCUSSION_TITLE_PREFIXES.each do |prefix|
+      clauses << "discussions.title = CONCAT(CAST(? AS text), groups.name)"
+      binds << prefix
+    end
+    DISCUSSION_TITLE_SUFFIXES.each do |suffix|
+      clauses << "discussions.title = CONCAT(groups.name, CAST(? AS text))"
+      binds << suffix
+    end
+    [ clauses.join(" OR "), *binds ]
+  end
+
+  def self.without_additional_topic_activity(scope, record_type:, record_table:, root_kind:)
+    record_id = case record_table
+    when "discussions" then "discussions.id"
+    when "polls" then "polls.id"
+    else raise ArgumentError, "unsupported record table"
+    end
+    condition = ActiveRecord::Base.sanitize_sql_array([ <<~SQL.squish, helper_bot_ids: helper_bot_ids, record_type: record_type, root_kind: root_kind ])
+      NOT EXISTS (
+        SELECT 1 FROM topic_items
+        WHERE topic_items.topic_id = topics.id
+          AND topic_items.user_id IS NOT NULL
+          AND topic_items.user_id NOT IN (:helper_bot_ids)
+          AND NOT (
+            topic_items.itemable_type = :record_type
+            AND topic_items.itemable_id = RECORD_ID
+            AND topic_items.kind = :root_kind
+          )
+      )
+    SQL
+    scope.where(Arel.sql(condition.sub("RECORD_ID", record_id)))
+  end
+
+  def self.without_additional_votes(scope)
+    scope.where(<<~SQL.squish, helper_bot_ids: helper_bot_ids)
+      NOT EXISTS (
+        SELECT 1 FROM polls activity_polls
+        JOIN stances ON stances.poll_id = activity_polls.id
+        WHERE activity_polls.topic_id = topics.id
+          AND stances.cast_at IS NOT NULL
+          AND (stances.participant_id IS NULL OR stances.participant_id NOT IN (:helper_bot_ids))
+      )
+    SQL
+  end
+
+  def self.without_anonymous_votes(scope)
+    scope.where(<<~SQL.squish)
+      NOT EXISTS (
+        SELECT 1 FROM polls anonymous_polls
+        JOIN anonymous_ballots ON anonymous_ballots.poll_id = anonymous_polls.id
+        WHERE anonymous_polls.topic_id = topics.id
+      )
+      AND NOT EXISTS (
+        SELECT 1 FROM polls anonymous_polls
+        JOIN anonymous_poll_voters ON anonymous_poll_voters.poll_id = anonymous_polls.id
+        WHERE anonymous_polls.topic_id = topics.id
+          AND anonymous_poll_voters.ballot_submitted = TRUE
+      )
+    SQL
+  end
+
+  def self.without_outcomes(scope)
+    scope.where(<<~SQL.squish)
+      NOT EXISTS (
+        SELECT 1 FROM polls outcome_polls
+        JOIN outcomes ON outcomes.poll_id = outcome_polls.id
+        WHERE outcome_polls.topic_id = topics.id
+      )
+    SQL
+  end
+
+  def self.without_member_reactions(scope, record_type:)
+    record_id = case record_type
+    when "Discussion" then "discussions.id"
+    when "Poll" then "polls.id"
+    else raise ArgumentError, "unsupported record type"
+    end
+    condition = ActiveRecord::Base.sanitize_sql_array([ <<~SQL.squish, helper_bot_ids: helper_bot_ids, record_type: record_type ])
+      NOT EXISTS (
+        SELECT 1 FROM topic_items reaction_items
+        JOIN reactions
+          ON reactions.reactable_type = reaction_items.itemable_type
+         AND reactions.reactable_id = reaction_items.itemable_id
+        WHERE reaction_items.topic_id = topics.id
+          AND (reactions.user_id IS NULL OR reactions.user_id NOT IN (:helper_bot_ids))
+      )
+      AND NOT EXISTS (
+        SELECT 1 FROM reactions
+        WHERE (reactions.user_id IS NULL OR reactions.user_id NOT IN (:helper_bot_ids))
+          AND reactions.reactable_type = :record_type
+          AND reactions.reactable_id = RECORD_ID
+      )
+    SQL
+    scope.where(Arel.sql(condition.sub("RECORD_ID", record_id)))
+  end
+
+  def self.without_poll_reactions(scope)
+    scope.where(<<~SQL.squish, helper_bot_ids: helper_bot_ids)
+      NOT EXISTS (
+        SELECT 1 FROM polls activity_polls
+        JOIN reactions
+          ON reactions.reactable_type = 'Poll'
+         AND reactions.reactable_id = activity_polls.id
+        WHERE activity_polls.topic_id = topics.id
+          AND (reactions.user_id IS NULL OR reactions.user_id NOT IN (:helper_bot_ids))
+      )
+      AND NOT EXISTS (
+        SELECT 1 FROM polls activity_polls
+        JOIN stances ON stances.poll_id = activity_polls.id
+        JOIN reactions
+          ON reactions.reactable_type = 'Stance'
+         AND reactions.reactable_id = stances.id
+        WHERE activity_polls.topic_id = topics.id
+          AND (reactions.user_id IS NULL OR reactions.user_id NOT IN (:helper_bot_ids))
+      )
+      AND NOT EXISTS (
+        SELECT 1 FROM polls activity_polls
+        JOIN outcomes ON outcomes.poll_id = activity_polls.id
+        JOIN reactions
+          ON reactions.reactable_type = 'Outcome'
+         AND reactions.reactable_id = outcomes.id
+        WHERE activity_polls.topic_id = topics.id
+          AND (reactions.user_id IS NULL OR reactions.user_id NOT IN (:helper_bot_ids))
+      )
+    SQL
+  end
+
+  def self.without_member_edits(scope, item_type:, record_table:)
+    record_id = case record_table
+    when "discussions" then "discussions.id"
+    when "polls" then "polls.id"
+    else raise ArgumentError, "unsupported record table"
+    end
+    condition = ActiveRecord::Base.sanitize_sql_array([ <<~SQL.squish, helper_bot_ids: helper_bot_ids, item_type: item_type ])
+      NOT EXISTS (
+        SELECT 1 FROM versions
+        WHERE versions.item_type = :item_type
+          AND versions.item_id = RECORD_ID
+          AND versions.event = 'update'
+          AND (versions.whodunnit IS NULL OR versions.whodunnit NOT IN (:helper_bot_ids))
+      )
+    SQL
+    scope.where(Arel.sql(condition.sub("RECORD_ID", record_id)))
+  end
+
+  def self.without_attached_poll_edits(scope)
+    scope.where(<<~SQL.squish, helper_bot_ids: helper_bot_ids)
+      NOT EXISTS (
+        SELECT 1 FROM versions
+        JOIN polls edited_polls
+          ON versions.item_type = 'Poll'
+         AND versions.item_id = edited_polls.id
+        WHERE edited_polls.topic_id = topics.id
+          AND versions.event = 'update'
+          AND (versions.whodunnit IS NULL OR versions.whodunnit NOT IN (:helper_bot_ids))
+      )
+    SQL
+  end
+
+  # Follow the content graph as well as the timeline: missing timeline entries
+  # must not hide member replies or edits to helper-authored comments. UNION
+  # also bounds traversal if damaged legacy comments contain a parent cycle.
+  # Separate indexed joins keep the anchor small; OR-ed parent subqueries
+  # otherwise cause full comment-table scans for each candidate topic.
+  def self.without_member_comment_activity(scope)
+    scope.where(<<~SQL.squish, helper_bot_ids: helper_bot_ids)
+      NOT EXISTS (
+        WITH RECURSIVE topic_comment_roots AS (
+          SELECT comments.id, comments.user_id FROM comments
+          JOIN discussions ON comments.parent_type = 'Discussion' AND comments.parent_id = discussions.id
+          WHERE discussions.topic_id = topics.id
+          UNION
+          SELECT comments.id, comments.user_id FROM comments
+          JOIN polls ON comments.parent_type = 'Poll' AND comments.parent_id = polls.id
+          WHERE polls.topic_id = topics.id
+          UNION
+          SELECT comments.id, comments.user_id FROM comments
+          JOIN stances ON comments.parent_type = 'Stance' AND comments.parent_id = stances.id
+          JOIN polls ON polls.id = stances.poll_id
+          WHERE polls.topic_id = topics.id
+          UNION
+          SELECT comments.id, comments.user_id FROM comments
+          JOIN outcomes ON comments.parent_type = 'Outcome' AND comments.parent_id = outcomes.id
+          JOIN polls ON polls.id = outcomes.poll_id
+          WHERE polls.topic_id = topics.id
+          UNION
+          SELECT comments.id, comments.user_id FROM comments
+          JOIN topic_items ON topic_items.itemable_type = 'Comment' AND topic_items.itemable_id = comments.id
+          WHERE topic_items.topic_id = topics.id
+        ), topic_comments AS (
+          SELECT id, user_id FROM topic_comment_roots
+          UNION
+          SELECT comments.id, comments.user_id FROM comments
+          JOIN topic_comments parents ON comments.parent_type = 'Comment' AND comments.parent_id = parents.id
+        )
+        SELECT 1 FROM topic_comments
+        WHERE user_id IS NULL OR user_id NOT IN (:helper_bot_ids)
+          OR EXISTS (
+            SELECT 1 FROM versions WHERE item_type = 'Comment' AND item_id = topic_comments.id
+              AND event = 'update' AND (whodunnit IS NULL OR whodunnit NOT IN (:helper_bot_ids))
+          )
+          OR EXISTS (
+            SELECT 1 FROM reactions WHERE reactable_type = 'Comment' AND reactable_id = topic_comments.id
+              AND (user_id IS NULL OR user_id NOT IN (:helper_bot_ids))
+          )
+      )
+    SQL
+  end
+
+  def self.helper_bot_ids
+    User.where(email: HELPER_BOT_EMAILS).pluck(:id).presence || [ -1 ]
+  end
+
+  def self.shard(scope, record_type:, count:, index:)
+    return scope if count == 1
+
+    condition = case record_type
+    when "Discussion" then "MOD(COALESCE(topics.group_id, discussions.id), ?) = ?"
+    when "Poll" then "MOD(COALESCE(topics.group_id, polls.id), ?) = ?"
+    else raise ArgumentError, "unsupported record type"
+    end
+    scope.where(condition, count, index)
+  end
+
+  private_class_method :discussion_title_condition, :without_additional_topic_activity,
+                       :without_additional_votes, :without_anonymous_votes,
+                       :without_outcomes, :without_member_reactions,
+                       :without_poll_reactions, :without_member_edits,
+                       :without_attached_poll_edits, :without_member_comment_activity,
+                       :helper_bot_ids, :shard
+end

--- a/docs/cleanup_safety.md
+++ b/docs/cleanup_safety.md
@@ -5,6 +5,7 @@ Cleanup eligibility is not permission to delete a later version of a record. Lif
 ## Preserved records
 
 - Inactive-account cleanup removes accounts after 60 days without activity, using the most recent account-creation, current-sign-in, previous-sign-in, or last-seen timestamp. It retains instance administrators and accounts with durable ownership, content, membership, access, identity, or notification references.
+- Seeded-content cleanup requires a known historical helper email and a matching legacy title, before the retirement cutoff. The API-account `bot` flag is not historical provenance. Member-authored matching titles are retained. Member activity, edits by unknown actors, and edits or replies to helper-authored comments preserve the affected content, including comments missing their timeline entries.
 - Orphan cleanup retains comments with a surviving parent, a surviving topic link, or dependent replies. It retains damaged timeline ancestors with children and groups with missing parents. These remain visible in integrity audits; cleanup does not silently reparent a private group or grant access to a different hierarchy.
 
 The guards are deliberately conservative. Audit counts for broken references include records retained for repair and are not predictions of how many rows will be deleted.
@@ -15,7 +16,7 @@ Cleanup tests reuse the access and volume fixtures for group topics and direct t
 
 ## Running maintenance
 
-Legacy references are not all protected by foreign keys. Destructive lifecycle rechecks use transactional table locks with `NOWAIT`; they skip busy tables rather than wait for existing writers. New writers can wait while an acquired lock is held. Run large cleanup operations during maintenance, with small batches and application writers drained where practical. Re-audit after a run; skipped candidates do not mean cleanup completed.
+Legacy references are not all protected by foreign keys. Destructive lifecycle rechecks use transactional table locks with `NOWAIT`; they skip busy tables rather than wait for existing writers. New writers can wait while an acquired lock is held. Run large cleanup operations during maintenance, with small batches and application writers drained where practical. Do not run multiple seeded-cleanup shards concurrently: the safety locks serialize their work, and a busy shard may skip candidates. Re-audit after a run; skipped candidates do not mean cleanup completed.
 
 Use an isolated database copy with application workers stopped for destructive validation. Confirm the actual database connection before running a deletion task. Compare the original and resulting record identities and content, not only counts. Do not use a previously cleaned snapshot as an untouched baseline.
 

--- a/lib/tasks/loomio.rake
+++ b/lib/tasks/loomio.rake
@@ -347,6 +347,22 @@ namespace :loomio do
     puts "SearchService.reindex_everything queued as background job"
   end
 
+  desc "Report untouched legacy seeded discussions and polls eligible for deletion"
+  task audit_unused_seeded_content: :environment do
+    SeededContentCleanupService.audit
+  end
+
+  desc "Delete untouched legacy seeded discussions and polls. Supports LIMIT, SEEDED_CONTENT_TYPE, SHARD_COUNT, and SHARD_INDEX."
+  task delete_unused_seeded_content: :environment do
+    limit = ENV["LIMIT"].presence&.to_i
+    SeededContentCleanupService.delete!(
+      limit: limit,
+      content_type: ENV["SEEDED_CONTENT_TYPE"].presence,
+      shard_count: ENV.fetch("SHARD_COUNT", 1).to_i,
+      shard_index: ENV.fetch("SHARD_INDEX", 0).to_i
+    )
+  end
+
   desc "Queue background jobs to resequence legacy topics where poll_created appears after later comments"
   task resequence_legacy_poll_created_topic_items: :environment do
     count = TopicService.enqueue_legacy_poll_created_resequence

--- a/test/services/seeded_content_cleanup_service_test.rb
+++ b/test/services/seeded_content_cleanup_service_test.rb
@@ -1,0 +1,251 @@
+require "test_helper"
+require_relative "../support/access_volume_matrix"
+
+class SeededContentCleanupServiceTest < ActiveSupport::TestCase
+  include AccessVolumeMatrix
+  setup do
+    @member = users(:user)
+    @helper_bot = User.create!(
+      name: "Loomio Helper Bot",
+      email: "notifications@loomio.com",
+      username: "cleanup_helper_bot",
+      email_verified: true,
+      bot: false
+    )
+    @group = Group.create!(
+      name: "Legacy starter group #{SecureRandom.hex(4)}",
+      creator: @member,
+      group_privacy: "secret"
+    )
+    @group.add_admin!(@helper_bot)
+    @group.add_member!(@member)
+  end
+
+  test "finds fixed and group-name seeded discussions and their untouched polls" do
+    fixed = create_seeded_discussion("How to use Loomio")
+    dynamic = create_seeded_discussion("Welcome to #{@group.name}")
+    poll = create_seeded_poll(topic_id: fixed.topic_id)
+
+    assert_includes SeededContentCleanupService.candidate_discussions, fixed
+    assert_includes SeededContentCleanupService.candidate_discussions, dynamic
+    assert_includes SeededContentCleanupService.candidate_polls, poll
+  end
+
+  test "preserves member-authored content even when its title matches a seed" do
+    discussion = create_seeded_discussion("Intro to Loomio", actor: @member)
+
+    assert_not_includes SeededContentCleanupService.candidate_discussions, discussion
+    SeededContentCleanupService.delete!
+    assert Discussion.exists?(discussion.id)
+  end
+
+  test "preserves helper comments edited by a member or an unknown actor" do
+    @group.add_admin!(@member)
+    @group.update!(admins_can_edit_user_content: true)
+    [ @member.id, nil ].each do |editor_id|
+      discussion = create_seeded_discussion("How to use Loomio")
+      poll = create_seeded_poll(topic_id: discussion.topic_id)
+      comment = CommentService.create(comment: Comment.new(parent: discussion, body: "Starter text"), actor: @helper_bot)
+      PaperTrail.request(whodunnit: editor_id) do
+        CommentService.update(comment: comment, params: { body: "Our working instructions" }, actor: @member)
+      end
+      assert comment.versions.where(event: "update", whodunnit: editor_id).exists?
+
+      SeededContentCleanupService.delete!
+
+      assert Discussion.exists?(discussion.id)
+      assert Poll.exists?(poll.id)
+      assert_equal "Our working instructions", comment.reload.body
+    end
+  end
+
+  test "preserves member replies even when their timeline is missing" do
+    discussion = create_seeded_discussion("How to use Loomio")
+    parent = CommentService.create(comment: Comment.new(parent: discussion, body: "Starter text"), actor: @helper_bot)
+    reply = CommentService.create(comment: Comment.new(parent: parent, body: "Actual work"), actor: @member)
+    reply.topic_items.delete_all
+
+    SeededContentCleanupService.delete!
+
+    assert Discussion.exists?(discussion.id)
+    assert Comment.exists?(reply.id)
+  end
+
+  test "preserves a seed containing a member-authored matching-title poll" do
+    discussion = create_seeded_discussion("How to use Loomio")
+    poll = create_seeded_poll(topic_id: discussion.topic_id)
+    poll.update_column(:author_id, @member.id)
+    poll.topic_items.update_all(user_id: @helper_bot.id)
+
+    SeededContentCleanupService.delete!
+
+    assert Discussion.exists?(discussion.id)
+    assert Poll.exists?(poll.id)
+  end
+
+  test "preserves seeded discussions with an additional member comment" do
+    discussion = create_seeded_discussion("How to use Loomio")
+    CommentService.create(
+      comment: Comment.new(parent: discussion, body: "We used this discussion"),
+      actor: @member
+    )
+
+    assert_not_includes SeededContentCleanupService.candidate_discussions, discussion
+  end
+
+  test "preserves seeded polls and their discussion after an additional member vote" do
+    discussion = create_seeded_discussion("How to use Loomio")
+    poll = create_seeded_poll(topic_id: discussion.topic_id)
+    stance = Stance.create!(poll: poll, participant: @member)
+    stance.update_column(:cast_at, Time.current)
+
+    assert_not_includes SeededContentCleanupService.candidate_polls, poll
+    assert_not_includes SeededContentCleanupService.candidate_discussions, discussion
+  end
+
+  test "allows the helper bot comment and vote that were part of seeded content" do
+    discussion = create_seeded_discussion("How to use Loomio")
+    poll = create_seeded_poll(topic_id: discussion.topic_id)
+    CommentService.create(
+      comment: Comment.new(parent: discussion, body: "Seeded helper text"),
+      actor: @helper_bot
+    )
+    stance = Stance.create!(poll: poll, participant: @helper_bot)
+    stance.update_column(:cast_at, Time.current)
+
+    assert_includes SeededContentCleanupService.candidate_polls, poll
+    assert_includes SeededContentCleanupService.candidate_discussions, discussion
+  end
+
+  test "preserves a seeded poll with a submitted anonymous ballot" do
+    discussion = create_seeded_discussion("How to use Loomio")
+    poll = create_seeded_poll(topic_id: discussion.topic_id, anonymous: true)
+    AnonymousPollVoter.create!(
+      poll: poll,
+      voter: @member,
+      group_member: true,
+      ballot_submitted: true
+    )
+
+    assert_not_includes SeededContentCleanupService.candidate_polls, poll
+    assert_not_includes SeededContentCleanupService.candidate_discussions, discussion
+  end
+
+  test "preserves seeded content with a recorded outcome or member reaction" do
+    outcome_discussion = create_seeded_discussion("How to use Loomio")
+    outcome_poll = create_seeded_poll(topic_id: outcome_discussion.topic_id)
+    Outcome.create!(statement: "Decision recorded", poll: outcome_poll, author: @member, latest: true)
+    reacted_discussion = create_seeded_discussion("Welcome! Please introduce yourself")
+    Reaction.create!(reactable: reacted_discussion, user: @member, reaction: "+1")
+
+    assert_not_includes SeededContentCleanupService.candidate_polls, outcome_poll
+    assert_not_includes SeededContentCleanupService.candidate_discussions, outcome_discussion
+    assert_not_includes SeededContentCleanupService.candidate_discussions, reacted_discussion
+  end
+
+  test "preserves reactions whose historical actor is unknown" do
+    discussion = create_seeded_discussion("How to use Loomio")
+    reaction = Reaction.create!(reactable: discussion, user: @member, reaction: "+1")
+    reaction.update_column(:user_id, nil)
+
+    SeededContentCleanupService.delete!
+
+    assert Discussion.exists?(discussion.id)
+    assert Reaction.exists?(reaction.id)
+  end
+
+  test "preserves recent, renamed, and member-edited seeded records" do
+    recent = DiscussionService.create(
+      params: { group_id: @group.id, title: "How to use Loomio" },
+      actor: @helper_bot
+    )
+    renamed = create_seeded_discussion("Our project discussion")
+    edited = create_seeded_discussion("How to use Loomio")
+    PaperTrail::Version.create!(
+      item_type: "Discussion",
+      item_id: edited.id,
+      event: "update",
+      whodunnit: @member.id,
+      object_changes: { description: [ "Seeded", "Changed" ] }
+    )
+
+    candidates = SeededContentCleanupService.candidate_discussions
+    assert_not_includes candidates, recent
+    assert_not_includes candidates, renamed
+    assert_not_includes candidates, edited
+  end
+
+  test "deletes eligible topics and polls while retaining engaged content" do
+    before = access_volume_matrix
+    eligible_discussion = create_seeded_discussion("How to use Loomio")
+    eligible_poll = create_seeded_poll(topic_id: eligible_discussion.topic_id)
+    engaged_discussion = create_seeded_discussion("Welcome! Please introduce yourself")
+    CommentService.create(
+      comment: Comment.new(parent: engaged_discussion, body: "Keep this"),
+      actor: @member
+    )
+
+    result = SeededContentCleanupService.delete!
+
+    assert_equal 1, result[:discussions]
+    assert_equal 1, result[:polls]
+    assert_not Discussion.exists?(eligible_discussion.id)
+    assert_not Poll.exists?(eligible_poll.id)
+    assert Discussion.exists?(engaged_discussion.id)
+    assert_access_volume_matrix_unchanged(before)
+  end
+
+  test "deletes discussions and polls in separate sharded phases" do
+    discussion = create_seeded_discussion("How to use Loomio")
+    embedded_poll = create_seeded_poll(topic_id: discussion.topic_id)
+    standalone_poll = create_seeded_poll
+    shard_index = @group.id % 2
+
+    SeededContentCleanupService.delete!(
+      content_type: "discussions",
+      shard_count: 2,
+      shard_index: shard_index
+    )
+
+    assert_not Discussion.exists?(discussion.id)
+    assert_not Poll.exists?(embedded_poll.id)
+    assert Poll.exists?(standalone_poll.id)
+
+    SeededContentCleanupService.delete!(
+      content_type: "polls",
+      shard_count: 2,
+      shard_index: shard_index
+    )
+
+    assert_not Poll.exists?(standalone_poll.id)
+  end
+
+  private
+
+  def create_seeded_discussion(title, actor: @helper_bot)
+    DiscussionService.create(
+      params: { group_id: @group.id, title: title },
+      actor: actor
+    ).tap do |discussion|
+      discussion.update_column(:created_at, SeededContentCleanupService::CREATED_BEFORE - 1.day)
+    end
+  end
+
+  def create_seeded_poll(topic_id: nil, **overrides)
+    PollService.create(
+      params: {
+        group_id: @group.id,
+        topic_id: topic_id,
+        title: "Demonstration proposal",
+        poll_type: "proposal",
+        poll_option_names: %w[agree disagree],
+        specified_voters_only: true,
+        notify_on_open: false,
+        closing_at: 1.week.from_now
+      }.merge(overrides),
+      actor: @helper_bot
+    ).tap do |poll|
+      poll.update_column(:created_at, SeededContentCleanupService::CREATED_BEFORE - 1.day)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- identify legacy helper-authored trial discussions and polls by historical provenance
- preserve content with member edits, comments, votes, reactions, outcomes, or other activity
- provide separate audit and batched deletion tasks for the one-time production purge

## Production snapshot audit

On the 2026-08-30 production snapshot, the cleanup removed 66,882 eligible discussions and 45,812 polls. A repeat audit reported zero eligible seeded records.

## Verification

- bin/rails test test/services/seeded_content_cleanup_service_test.rb test/services/cleanup_lock_test.rb
- 15 tests, 245 assertions, no failures
- RuboCop on the service and tests
- Brakeman: zero warnings
- bundler-audit: no vulnerabilities

Stacked on #12821 for the shared conservative cleanup lock and preservation work.