### PR TITLE
Clean up expired trial groups

### DIFF
--- a/app/jobs/hourly_task_job.rb
+++ b/app/jobs/hourly_task_job.rb
@@ -22,6 +22,7 @@ class HourlyTaskJob < ApplicationJob
       ThrottleService.reset!('day')
       DestroyExpiredDemoGroupsWorker.perform_later
       CleanupOrphanRecordsWorker.perform_later
+      TrialCleanupWorker.perform_later
       EventBus.broadcast('loomio_daily_tick')
       PublishReviewDueWorker.perform_later
       DeleteOldReceivedEmailsWorker.perform_later

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -20,7 +20,11 @@ class Group < ApplicationRecord
 
   belongs_to :parent, class_name: 'Group'
   scope :empty_no_subscription, -> { joins('left join subscriptions on subscription_id = groups.subscription_id').where('subscriptions.id is null and groups.parent_id is null').where('memberships_count < 2 AND discussions_count < 3 and polls_count < 2 and subgroups_count = 0').where('groups.created_at < ?', 1.year.ago) }
-  scope :expired_trial, -> { joins(:subscription).where('subscriptions.plan = ?', 'trial').where('subscriptions.expires_at < ?', 12.months.ago) }
+  scope :expired_trial, ->(expires_before = 60.days.ago) {
+    joins(:subscription)
+      .where(subscriptions: { plan: "trial" })
+      .where("subscriptions.expires_at < ?", expires_before)
+  }
   scope :any_trial, -> { joins(:subscription).where('subscriptions.plan = ?', 'trial') }
   scope :expired_demo, -> { joins(:subscription).where('subscriptions.plan = ?', 'demo').where('groups.created_at < ?', 7.days.ago) }
   scope :not_demo, -> { joins(:subscription).where('subscriptions.plan != ?', 'demo') }

--- a/app/services/trial_cleanup_service.rb
+++ b/app/services/trial_cleanup_service.rb
@@ -1,0 +1,151 @@
+# Cleans up root trial groups after their subscription has been expired for the
+# retention period. Untouched group trees are deleted immediately. Trials with
+# any evidence of use are archived, their administrators are warned, and the
+# exact archive operation is scheduled for deletion after the warning period.
+module TrialCleanupService
+  RETENTION_PERIOD = 60.days
+  WARNING_PERIOD = 2.weeks
+  BATCH_SIZE = 100
+  REFERENCE_TABLES = %i[groups subscriptions topics memberships discussion_templates poll_templates membership_requests chatbots tags active_storage_attachments received_emails group_identities group_surveys group_handle_redirects member_email_aliases webhooks demos].freeze
+
+  def self.audit(expires_before: RETENTION_PERIOD.ago)
+    eligible_ids = eligible_groups(expires_before: expires_before).pluck(:id)
+    unused_ids = unused_groups(expires_before: expires_before).where(id: eligible_ids).pluck(:id)
+    result = {
+      eligible: eligible_ids.size,
+      unused: unused_ids.size,
+      used: eligible_ids.size - unused_ids.size
+    }
+
+    puts "Expired trial group trees: #{result[:eligible]} (#{result[:unused]} unused, #{result[:used]} used)"
+    result
+  end
+
+  def self.cleanup!(limit: BATCH_SIZE, expires_before: RETENTION_PERIOD.ago)
+    group_ids = eligible_groups(expires_before: expires_before).order("subscriptions.expires_at", :id).limit(limit).pluck(:id)
+    result = { deleted: 0, warned: 0, deferred: 0 }
+
+    group_ids.each do |group_id|
+      outcome = cleanup_group!(group_id, expires_before: expires_before)
+      result[outcome || :deferred] += 1
+    end
+
+    puts "Cleaned expired trials: #{result[:deleted]} deleted, #{result[:warned]} warned, #{result[:deferred]} deferred"
+    result
+  end
+
+  # The eligibility decision and destructive action share one lock window so a
+  # new reference cannot turn an untouched trial into a used one between them.
+  def self.cleanup_group!(group_id, expires_before: RETENTION_PERIOD.ago)
+    CleanupService.with_write_lock(REFERENCE_TABLES) do
+      group = eligible_groups(expires_before: expires_before, root_id: group_id).lock.first
+      next unless group
+
+      if unused_groups(expires_before: expires_before, root_id: group_id).exists?(id: group.id)
+        group.destroy!
+        :deleted
+      else
+        warn_and_schedule!(group)
+        :warned
+      end
+    end
+  end
+
+  def self.eligible_groups(expires_before: RETENTION_PERIOD.ago, root_id: nil)
+    scope = Group.expired_trial(expires_before).where(archived_at: nil)
+    root_id ? scope.where(id: root_id) : scope
+  end
+
+  def self.unused_groups(expires_before: RETENTION_PERIOD.ago, root_id: nil)
+    sql = Group.sanitize_sql_array([ unused_root_ids_sql, { expires_before: expires_before, root_id: root_id } ])
+    Group.where(id: Group.connection.select_values(sql))
+  end
+
+  # Build each eligible root's complete descendant tree before checking use.
+  # Historical activity such as discarded topics or revoked memberships makes
+  # a trial used and therefore entitled to the warning period.
+  def self.unused_root_ids_sql
+    <<~SQL.squish
+      WITH RECURSIVE eligible_roots AS (
+        SELECT groups.id
+        FROM groups
+        JOIN subscriptions ON subscriptions.id = groups.subscription_id
+        WHERE groups.parent_id IS NULL
+          AND groups.archived_at IS NULL
+          AND subscriptions.plan = 'trial'
+          AND subscriptions.expires_at < :expires_before
+          AND (:root_id IS NULL OR groups.id = :root_id)
+      ), group_tree(root_id, group_id) AS (
+        SELECT eligible_roots.id, eligible_roots.id
+        FROM eligible_roots
+        UNION ALL
+        SELECT group_tree.root_id, subgroups.id
+        FROM group_tree
+        JOIN groups subgroups ON subgroups.parent_id = group_tree.group_id
+      ), membership_rollups AS (
+        SELECT group_tree.root_id,
+               COUNT(DISTINCT memberships.user_id) AS user_count,
+               BOOL_OR(memberships.revoked_at IS NOT NULL) AS has_revoked
+        FROM group_tree
+        JOIN memberships ON memberships.group_id = group_tree.group_id
+        GROUP BY group_tree.root_id
+      ), used_roots AS (
+        SELECT DISTINCT reasons.root_id
+        FROM (
+          SELECT group_tree.root_id FROM group_tree JOIN topics ON topics.group_id = group_tree.group_id
+          UNION ALL
+          SELECT group_tree.root_id FROM group_tree JOIN discussion_templates ON discussion_templates.group_id = group_tree.group_id
+          UNION ALL
+          SELECT group_tree.root_id FROM group_tree JOIN poll_templates ON poll_templates.group_id = group_tree.group_id
+          UNION ALL
+          SELECT group_tree.root_id FROM group_tree JOIN membership_requests ON membership_requests.group_id = group_tree.group_id
+          UNION ALL
+          SELECT group_tree.root_id FROM group_tree JOIN chatbots ON chatbots.group_id = group_tree.group_id
+          UNION ALL
+          SELECT group_tree.root_id FROM group_tree JOIN tags ON tags.group_id = group_tree.group_id
+          UNION ALL
+          SELECT group_tree.root_id FROM group_tree JOIN received_emails ON received_emails.group_id = group_tree.group_id
+          UNION ALL
+          SELECT group_tree.root_id FROM group_tree JOIN group_identities ON group_identities.group_id = group_tree.group_id
+          UNION ALL
+          SELECT group_tree.root_id FROM group_tree JOIN group_surveys ON group_surveys.group_id = group_tree.group_id
+          UNION ALL
+          SELECT group_tree.root_id FROM group_tree JOIN demos ON demos.group_id = group_tree.group_id
+          UNION ALL
+          SELECT group_tree.root_id FROM group_tree JOIN webhooks ON webhooks.group_id = group_tree.group_id
+          UNION ALL
+          SELECT group_tree.root_id FROM group_tree JOIN member_email_aliases ON member_email_aliases.group_id = group_tree.group_id
+          UNION ALL
+          SELECT group_tree.root_id FROM group_tree JOIN group_handle_redirects ON group_handle_redirects.group_id = group_tree.group_id
+          UNION ALL
+          SELECT group_tree.root_id FROM group_tree JOIN active_storage_attachments ON active_storage_attachments.group_id = group_tree.group_id
+          UNION ALL
+          SELECT group_tree.root_id
+          FROM group_tree
+          JOIN active_storage_attachments
+            ON active_storage_attachments.record_type = 'Group'
+           AND active_storage_attachments.record_id = group_tree.group_id
+        ) reasons
+      )
+      SELECT eligible_roots.id
+      FROM eligible_roots
+      LEFT JOIN membership_rollups ON membership_rollups.root_id = eligible_roots.id
+      LEFT JOIN used_roots ON used_roots.root_id = eligible_roots.id
+      WHERE used_roots.root_id IS NULL
+        AND COALESCE(membership_rollups.user_count, 0) < 2
+        AND COALESCE(membership_rollups.has_revoked, FALSE) = FALSE
+    SQL
+  end
+
+  def self.warn_and_schedule!(group)
+    admin_ids = group.admins.pluck(:id)
+    group.archive!
+    archived_at = group.archived_at.iso8601(6)
+    ActiveRecord::Base.current_transaction.after_commit do
+      admin_ids.each { |admin_id| GroupMailer.trial_expired(group.id, admin_id).deliver_later }
+      DestroyGroupWorker.set(wait: WARNING_PERIOD).perform_later(group.id, archived_at)
+    end
+  end
+
+  private_class_method :unused_root_ids_sql, :warn_and_schedule!
+end

--- a/app/workers/trial_cleanup_worker.rb
+++ b/app/workers/trial_cleanup_worker.rb
@@ -1,0 +1,7 @@
+class TrialCleanupWorker < ApplicationJob
+  queue_as :low
+
+  def perform
+    TrialCleanupService.cleanup!
+  end
+end

--- a/docs/cleanup_safety.md
+++ b/docs/cleanup_safety.md
@@ -6,6 +6,7 @@ Cleanup eligibility is not permission to delete a later version of a record. Lif
 
 - Inactive-account cleanup removes accounts after 60 days without activity, using the most recent account-creation, current-sign-in, previous-sign-in, or last-seen timestamp. It retains instance administrators and accounts with durable ownership, content, membership, access, identity, or notification references.
 - Seeded-content cleanup requires a known historical helper email and a matching legacy title, before the retirement cutoff. The API-account `bot` flag is not historical provenance. Member-authored matching titles are retained. Member activity, edits by unknown actors, and edits or replies to helper-authored comments preserve the affected content, including comments missing their timeline entries.
+- Trial cleanup starts 60 days after the subscription expiry date. It deletes an untouched trial tree immediately; any configured group or historical activity anywhere in the tree instead triggers an administrator warning, archival, and deletion after two weeks. Free, paid, and demo groups are excluded.
 - Orphan cleanup retains comments with a surviving parent, a surviving topic link, or dependent replies. It retains damaged timeline ancestors with children and groups with missing parents. These remain visible in integrity audits; cleanup does not silently reparent a private group or grant access to a different hierarchy.
 
 The guards are deliberately conservative. Audit counts for broken references include records retained for repair and are not predictions of how many rows will be deleted.
@@ -16,7 +17,7 @@ Cleanup tests reuse the access and volume fixtures for group topics and direct t
 
 ## Running maintenance
 
-Legacy references are not all protected by foreign keys. Destructive lifecycle rechecks use transactional table locks with `NOWAIT`; they skip busy tables rather than wait for existing writers. New writers can wait while an acquired lock is held. Run large cleanup operations during maintenance, with small batches and application writers drained where practical. Do not run multiple seeded-cleanup shards concurrently: the safety locks serialize their work, and a busy shard may skip candidates. Re-audit after a run; skipped candidates do not mean cleanup completed.
+Legacy references are not all protected by foreign keys. Destructive lifecycle rechecks use transactional table locks with `NOWAIT`; they skip busy tables rather than wait for existing writers. New writers can wait while an acquired lock is held. Run large cleanup operations during maintenance, with small batches and application writers drained where practical. Do not run multiple seeded-cleanup shards concurrently: the safety locks serialize their work, and a busy shard may skip candidates. Trial cleanup uses the same locking rule and runs automatically in daily batches of 100. Re-audit after a run; skipped candidates do not mean cleanup completed.
 
 Use an isolated database copy with application workers stopped for destructive validation. Confirm the actual database connection before running a deletion task. Compare the original and resulting record identities and content, not only counts. Do not use a previously cleaned snapshot as an untouched baseline.
 
@@ -26,4 +27,4 @@ New `DestroyGroupWorker` jobs carry the exact archive timestamp recorded when de
 
 Account-merge duplicate removal, reference migration, credential revocation, and search updates are transactional. Avatar purges, newsletter changes, and email are deferred until commit. Blocklist and email-routing replacements retain the previous table contents if replacement fails. Concurrent group exports use separate temporary paths.
 
-Demo expiry is unchanged while the replacement demo system is being developed. Deployment scripts are outside this change.
+YAML-backed demo groups retain their separate seven-day expiry. Deployment scripts are outside this change.

--- a/docs/user_manual/changelog/2026-09-05_cleanup_safety.md
+++ b/docs/user_manual/changelog/2026-09-05_cleanup_safety.md
@@ -5,3 +5,5 @@ Restoring a group cancels its previously scheduled deletion, even if the group i
 If an account merge fails, memberships, direct-topic access, and sign-in credentials are restored with the rest of the account changes. Cleanup also preserves comments with missing timeline entries when their parent content still exists.
 
 Accounts with no durable ownership, content, membership, access, identity, or notification references are deleted after 60 days without activity. Instance administrator accounts are excluded from automatic deletion.
+
+Trial groups are cleaned up 60 days after their trial subscription expires. Untouched trials are deleted immediately; administrators of trials with activity receive a warning two weeks before deletion. Free, paid, and demo groups are not included.

--- a/lib/tasks/loomio.rake
+++ b/lib/tasks/loomio.rake
@@ -363,6 +363,16 @@ namespace :loomio do
     )
   end
 
+  desc "Report trial groups expired beyond the retention period"
+  task audit_trial_groups: :environment do
+    TrialCleanupService.audit
+  end
+
+  desc "Clean up trial groups expired beyond the retention period. Supports LIMIT."
+  task cleanup_trial_groups: :environment do
+    TrialCleanupService.cleanup!(limit: ENV.fetch("LIMIT", TrialCleanupService::BATCH_SIZE).to_i)
+  end
+
   desc "Queue background jobs to resequence legacy topics where poll_created appears after later comments"
   task resequence_legacy_poll_created_topic_items: :environment do
     count = TopicService.enqueue_legacy_poll_created_resequence

--- a/test/jobs/hourly_task_job_test.rb
+++ b/test/jobs/hourly_task_job_test.rb
@@ -25,6 +25,14 @@ class HourlyTaskJobTest < ActiveSupport::TestCase
     end
   end
 
+  test "enqueues trial cleanup at midnight UTC" do
+    travel_to Time.utc(2026, 9, 5) do
+      assert_enqueued_with(job: TrialCleanupWorker) do
+        HourlyTaskJob.perform_now
+      end
+    end
+  end
+
   test "does not enqueue orphan cleanup at midnight in another time zone" do
     travel_to Time.new(2026, 9, 5, 0, 0, 0, "+12:00") do
       assert_no_enqueued_jobs(only: CleanupOrphanRecordsWorker) do

--- a/test/services/trial_cleanup_service_test.rb
+++ b/test/services/trial_cleanup_service_test.rb
@@ -1,0 +1,137 @@
+require "test_helper"
+require_relative "../support/access_volume_matrix"
+
+class TrialCleanupServiceTest < ActiveSupport::TestCase
+  include AccessVolumeMatrix
+
+  setup do
+    @creator = users(:member_quiet)
+    @expires_before = Time.current
+  end
+
+  test "uses subscription expiry rather than group creation for the retention period" do
+    old_group = create_trial_group(name: "Old group, recent expiry", created_at: 5.years.ago, expires_at: 59.days.ago)
+    recent_group = create_trial_group(name: "Recent group, old expiry", created_at: 30.days.ago, expires_at: 61.days.ago)
+
+    assert_not_includes candidates, old_group
+    assert_includes candidates, recent_group
+  end
+
+  test "only includes trial groups" do
+    trial = create_trial_group(name: "Expired trial", expires_at: 61.days.ago)
+    free = create_group(name: "Free group", subscription: create_subscription(plan: "free", expires_at: 61.days.ago))
+    paid = create_group(name: "Paid group", subscription: create_subscription(plan: "2024-starter-monthly", expires_at: 61.days.ago))
+
+    assert_includes candidates, trial
+    assert_not_includes candidates, free
+    assert_not_includes candidates, paid
+  end
+
+  test "deletes an untouched expired trial tree immediately" do
+    root = create_trial_group(name: "Unused trial", expires_at: 61.days.ago)
+    subgroup = create_group(name: "Unused subgroup", parent: root)
+    before = access_volume_matrix
+
+    assert_equal :deleted, TrialCleanupService.cleanup_group!(root.id)
+
+    assert_not Group.exists?(root.id)
+    assert_not Group.exists?(subgroup.id)
+    assert_access_volume_matrix_unchanged(before)
+  end
+
+  test "warns administrators and schedules used trials for deletion" do
+    root = create_trial_group(name: "Used trial", expires_at: 61.days.ago)
+    root.add_admin!(@creator)
+    DiscussionService.create(params: { group_id: root.id, title: "Existing work" }, actor: @creator)
+
+    assert_enqueued_with(job: ActionMailer::MailDeliveryJob) do
+      assert_enqueued_with(job: DestroyGroupWorker, args: ->(args) { args == [ root.id, root.reload.archived_at.iso8601(6) ] }) do
+        assert_equal :warned, TrialCleanupService.cleanup_group!(root.id)
+      end
+    end
+
+    assert root.reload.archived_at
+    assert Group.exists?(root.id)
+  end
+
+  test "preserves a used trial that is restored before its scheduled deletion" do
+    root = create_trial_group(name: "Restored used trial", expires_at: 61.days.ago)
+    root.add_admin!(@creator)
+    DiscussionService.create(params: { group_id: root.id, title: "Existing work" }, actor: @creator)
+    TrialCleanupService.cleanup_group!(root.id)
+    archived_at = root.reload.archived_at.iso8601(6)
+    root.unarchive!
+
+    DestroyGroupWorker.perform_now(root.id, archived_at)
+
+    assert Group.exists?(root.id)
+  end
+
+  test "treats historical activity anywhere in the group tree as use" do
+    matrix = build_group_matrix
+    unused_ids = TrialCleanupService.unused_groups(expires_before: @expires_before)
+                                    .where(id: matrix.values.pluck(:root).map(&:id)).pluck(:id)
+
+    matrix.each do |name, entry|
+      assert_equal entry[:unused], unused_ids.include?(entry[:root].id), name
+      assert_not_includes unused_ids, entry[:subgroup].id, "#{name} subgroup must never be selected separately" if entry[:subgroup]
+    end
+  end
+
+  test "cleanup is idempotent" do
+    root = create_trial_group(name: "One-time cleanup", expires_at: 61.days.ago)
+
+    assert_equal :deleted, TrialCleanupService.cleanup_group!(root.id)
+    assert_nil TrialCleanupService.cleanup_group!(root.id)
+  end
+
+  private
+
+  def candidates
+    TrialCleanupService.eligible_groups(expires_before: 60.days.ago).to_a
+  end
+
+  def create_subscription(plan:, expires_at:)
+    Subscription.create!(owner: @creator, plan: plan, expires_at: expires_at)
+  end
+
+  def create_trial_group(name:, expires_at:, created_at: 2.years.ago)
+    create_group(
+      name: name,
+      subscription: create_subscription(plan: "trial", expires_at: expires_at),
+      created_at: created_at
+    )
+  end
+
+  def create_group(name:, subscription: nil, parent: nil, created_at: 2.years.ago)
+    Group.create!(
+      name: "#{name} #{SecureRandom.hex(4)}",
+      creator: @creator,
+      parent: parent,
+      subscription: subscription,
+      group_privacy: "secret",
+      created_at: created_at
+    )
+  end
+
+  def build_group_matrix
+    matrix = {
+      empty_tree: { root: groups(:orphan_group_tree), subgroup: groups(:orphan_subgroup), unused: true },
+      active_topic: { root: groups(:used_topic_group), unused: false },
+      discarded_topic: { root: groups(:used_discarded_topic_tree), subgroup: groups(:used_discarded_topic_subgroup), unused: false },
+      revoked_membership: { root: groups(:used_revoked_membership_tree), subgroup: groups(:used_revoked_membership_subgroup), unused: false },
+      multiple_users: { root: groups(:used_multiple_members_group), unused: false },
+      discussion_template: { root: groups(:used_discussion_template_group), unused: false },
+      poll_template: { root: groups(:used_poll_template_group), unused: false },
+      membership_request: { root: groups(:used_membership_request_group), unused: false },
+      chatbot: { root: groups(:used_chatbot_group), unused: false },
+      tag: { root: groups(:used_tag_group), unused: false },
+      attachment: { root: groups(:used_attachment_group), unused: false }
+    }
+    matrix.each_value do |entry|
+      subscription = create_subscription(plan: "trial", expires_at: 61.days.ago)
+      entry[:root].update_column(:subscription_id, subscription.id)
+    end
+    matrix
+  end
+end


### PR DESCRIPTION
## Summary

- move ongoing trial cleanup into core alongside the subscription and YAML-demo implementations
- select trial groups only after their subscription expiry is more than 60 days old
- delete untouched trial trees immediately and give used trials a two-week warning period
- run cleanup automatically in daily batches of 100, with manual audit and cleanup tasks for operators

## Cleanup behavior

Eligibility is based on subscriptions.expires_at, not group creation time. Free, paid, and demo groups are excluded.

An untouched trial must have fewer than two distinct historical members and no topic, template, membership request, chatbot, tag, attachment, webhook, identity, survey, received email, redirect, or other configured activity anywhere in its group tree. Eligibility is rechecked while reference writers are locked before direct deletion.

A trial with any such activity is archived, its administrators receive the existing trial-expiry warning, and DestroyGroupWorker receives the exact archive timestamp for deletion two weeks later. Restoring the group invalidates that scheduled deletion.

## Verification

- bin/rails test test/services/trial_cleanup_service_test.rb test/jobs/hourly_task_job_test.rb test/workers/destroy_group_worker_test.rb test/services/seeded_content_cleanup_service_test.rb test/services/demo_service_test.rb test/services/demo_group_template_service_test.rb
- 36 tests, 613 assertions, no failures
- RuboCop: no offenses
- documentation build: 10,373 links and assets validated
- Brakeman: zero warnings
- bundler-audit: no vulnerabilities
- git diff --check