### PR TITLE
Warn before deleting expired subscription groups

### DIFF
--- a/app/controllers/admin/groups_controller.rb
+++ b/app/controllers/admin/groups_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Admin::GroupsController < Admin::BaseController
-  before_action :load_group, only: %i[show edit update move handle discard undiscard delete_group export_group]
+  before_action :load_group, only: %i[show edit update move handle undiscard warn_then_destroy destroy_immediately export_group]
 
   def index
     groups, pagination = paginate(filtered_groups)
@@ -75,19 +75,19 @@ class Admin::GroupsController < Admin::BaseController
     redirect_to admin_group_path(@group), notice: notice
   end
 
-  def discard
-    @group.discard!(actor: current_user)
-    redirect_to admin_group_path(@group), notice: "Group discarded"
-  end
-
   def undiscard
     @group.undiscard!(actor: current_user)
     redirect_to admin_group_path(@group), notice: "Group restored"
   end
 
-  def delete_group
-    GroupService.destroy_without_warning!(@group.id, actor: current_user)
-    redirect_to admin_groups_path, notice: "Group deletion scheduled"
+  def warn_then_destroy
+    GroupService.warn_then_destroy(group: @group, actor: current_user)
+    redirect_to admin_groups_path, notice: "Group administrators warned; deletion scheduled in 2 weeks"
+  end
+
+  def destroy_immediately
+    GroupService.destroy_immediately!(@group.id, actor: current_user)
+    redirect_to admin_groups_path, notice: "Group deletion scheduled immediately"
   end
 
   def export_group

--- a/app/jobs/hourly_task_job.rb
+++ b/app/jobs/hourly_task_job.rb
@@ -22,6 +22,8 @@ class HourlyTaskJob < ApplicationJob
     if hour == 0
       ThrottleService.reset!('day')
       DestroyExpiredDemoGroupsWorker.perform_later
+      CleanupEmptyTrialsWorker.perform_later
+      WarnExpiredSubscriptionGroupsWorker.perform_later
       CleanupOrphanRecordsWorker.perform_later
       EventBus.broadcast('loomio_daily_tick')
       PublishReviewDueWorker.perform_later

--- a/app/mailers/group_mailer.rb
+++ b/app/mailers/group_mailer.rb
@@ -1,16 +1,20 @@
 class GroupMailer < ApplicationMailer
-  def destroy_warning(group_id, recipient_id, deletor_id)
+  def destroy_warning(group_id, recipient_id, requester_id = nil, reason = nil)
     group = Group.find(group_id)
     recipient = User.find(recipient_id)
-    deletor = User.find(deletor_id)
+    requester = User.find(requester_id) if requester_id
 
     component = Views::GroupMailer::DestroyWarning.new(
-      group: group, recipient: recipient, deletor: deletor
+      group: group,
+      recipient: recipient,
+      requester: requester,
+      reason: reason,
+      usage: GroupUsageSummary.for(group)
     )
 
     send_email(to: recipient.name_and_email, locale: recipient.locale, component: component,
                reply_to: ENV['SUPPORT_EMAIL']) {
-      I18n.t("group_mailer.destroy_warning.subject")
+      I18n.t("group_mailer.destroy_warning_with_usage.subject")
     }
   end
 

--- a/app/services/empty_trial_cleanup_service.rb
+++ b/app/services/empty_trial_cleanup_service.rb
@@ -1,0 +1,83 @@
+# Cleanup of topic-free expired trial trees. Memberships, templates and
+# uploads do not make a tree nonempty; any topic, including discarded topics in
+# discarded descendants, does. Billing and subscription links exclude a tree.
+module EmptyTrialCleanupService
+  RETENTION_PERIOD = 60.days
+
+  def self.audit(expires_before: RETENTION_PERIOD.ago, limit: nil)
+    raise ArgumentError, 'limit must be positive' if limit && limit <= 0
+    trees = candidate_trees(expires_before: expires_before)
+    trees = trees.first(limit).to_h if limit
+    { expires_before: expires_before.iso8601, root_ids: trees.keys, group_ids: trees.values.flatten, trees: trees }
+  end
+
+  # Fix and log the plan before deletion, recheck each complete tree, then use
+  # normal destruction callbacks and their transaction, without explicit locks.
+  # Flush each result so interrupted runs are auditable.
+  def self.delete!(io:, expires_before: RETENTION_PERIOD.ago, limit: nil)
+    plan = audit(expires_before: expires_before, limit: limit)
+    log(io, type: 'plan', at: Time.current.iso8601, **plan, counts: record_counts)
+    result = { deleted_roots: 0, deleted_groups: 0, skipped_roots: 0 }
+    plan[:root_ids].each do |root_id|
+      tree = candidate_trees(expires_before: expires_before, root_id: root_id)[root_id]
+      unless tree && tree == plan[:trees][root_id]
+        result[:skipped_roots] += 1
+        log(io, type: 'skipped', root_id: root_id, reason: 'no longer eligible or tree changed')
+        next
+      end
+
+      log(io, type: 'deleting', root_id: root_id, group_ids: tree)
+      PaperTrail.request(enabled: false) { Group.find(root_id).destroy! }
+      result[:deleted_roots] += 1
+      result[:deleted_groups] += tree.size
+      log(io, type: 'deleted', at: Time.current.iso8601, root_id: root_id, group_ids: tree)
+    end
+    log(io, type: 'complete', at: Time.current.iso8601, **result, counts: record_counts)
+    result
+  rescue StandardError => error
+    log(io, type: 'failed', at: Time.current.iso8601, error: error.class.name, message: error.message)
+    raise
+  end
+
+  def self.candidate_trees(expires_before:, root_id: nil)
+    sql = Group.sanitize_sql_array([ <<~SQL, { expires_before: expires_before, root_id: root_id } ])
+      WITH RECURSIVE roots AS (
+        SELECT g.id, g.subscription_id FROM groups g
+        JOIN subscriptions s ON s.id = g.subscription_id
+        WHERE g.parent_id IS NULL
+          AND s.plan = 'trial' AND s.expires_at <= :expires_before
+          AND s.chargify_subscription_id IS NULL AND s.billing_service_subscription_id IS NULL
+          AND (:root_id IS NULL OR g.id = :root_id)
+          AND NOT EXISTS (SELECT 1 FROM groups other WHERE other.parent_id IS NULL
+            AND other.subscription_id = s.id AND other.id != g.id)
+      ), tree AS (
+        SELECT id AS root_id, id AS group_id FROM roots
+        UNION ALL
+        SELECT t.root_id, g.id FROM tree t JOIN groups g ON g.parent_id = t.group_id
+      ), used_roots AS (
+        SELECT t.root_id FROM tree t JOIN topics ON topics.group_id = t.group_id
+        UNION
+        SELECT t.root_id FROM tree t JOIN groups g ON g.id = t.group_id
+        JOIN roots r ON r.id = t.root_id
+        WHERE g.id != r.id AND g.subscription_id IS NOT NULL AND g.subscription_id != r.subscription_id
+      )
+      SELECT t.root_id, t.group_id FROM tree t
+      WHERE NOT EXISTS (SELECT 1 FROM used_roots u WHERE u.root_id = t.root_id)
+      ORDER BY t.root_id, t.group_id
+    SQL
+    Group.connection.select_all(sql).to_a.group_by { |row| row['root_id'] }
+         .transform_values { |rows| rows.map { |row| row['group_id'] } }
+  end
+
+  def self.record_counts
+    { groups: Group.count, topics: Topic.count, discussions: Discussion.count,
+      polls: Poll.count, comments: Comment.count, users: User.count, memberships: Membership.count }
+  end
+
+  def self.log(io, entry)
+    io.puts(entry.to_json)
+    io.flush
+  end
+
+  private_class_method :record_counts, :log
+end

--- a/app/services/expired_subscription_group_cleanup_service.rb
+++ b/app/services/expired_subscription_group_cleanup_service.rb
@@ -1,0 +1,87 @@
+# Warns and schedules deletion for root groups whose trial or cancellation has
+# been inactive for the retention period. Topic-free expired trials are omitted
+# because EmptyTrialCleanupService owns their immediate deletion path.
+module ExpiredSubscriptionGroupCleanupService
+  RETENTION_PERIOD = 60.days
+  REASONS = %w[trial_expired subscription_canceled].freeze
+  LIFECYCLE_ORDER_SQL = "CASE WHEN subscriptions.state = 'canceled' " \
+                        "THEN subscriptions.canceled_at ELSE subscriptions.expires_at END, groups.id".freeze
+
+  def self.audit(as_of: Time.current, limit: nil)
+    raise ArgumentError, "limit must be positive" if limit && limit <= 0
+
+    groups = candidate_groups(as_of: as_of)
+    groups = groups.limit(limit) if limit
+    entries = groups.map do |group|
+      reason = deletion_reason(group.subscription, as_of: as_of)
+      {
+        group_id: group.id,
+        subscription_id: group.subscription_id,
+        reason: reason,
+        lifecycle_at: lifecycle_at(group.subscription, reason).iso8601,
+        usage: GroupUsageSummary.for(group)
+      }
+    end
+    { as_of: as_of.iso8601, retention_days: RETENTION_PERIOD.in_days.to_i, groups: entries }
+  end
+
+  def self.warn_and_schedule!(io:, as_of: Time.current, limit: nil)
+    plan = audit(as_of: as_of, limit: limit)
+    log(io, type: "plan", at: Time.current.iso8601, **plan)
+    result = { warned_groups: 0, skipped_groups: 0 }
+
+    plan[:groups].each do |entry|
+      group = candidate_groups(as_of: as_of, group_id: entry[:group_id]).first
+      reason = group && deletion_reason(group.subscription, as_of: as_of)
+      unless group && reason == entry[:reason]
+        result[:skipped_groups] += 1
+        log(io, type: "skipped", group_id: entry[:group_id], reason: "no longer eligible")
+        next
+      end
+
+      GroupService.warn_then_destroy_subscription(group: group, reason: reason)
+      result[:warned_groups] += 1
+      log(io, type: "warned", at: Time.current.iso8601, **entry)
+    end
+
+    log(io, type: "complete", at: Time.current.iso8601, **result)
+    result
+  rescue StandardError => error
+    log(io, type: "failed", at: Time.current.iso8601, error: error.class.name, message: error.message)
+    raise
+  end
+
+  def self.candidate_groups(as_of:, group_id: nil)
+    cutoff = as_of - RETENTION_PERIOD
+    expired_trials = Subscription.where(plan: "trial", expires_at: ..cutoff)
+    old_cancellations = Subscription.where(state: "canceled", canceled_at: ..cutoff)
+    empty_trial_ids = EmptyTrialCleanupService.candidate_trees(expires_before: cutoff).keys
+
+    scope = Group.kept.parents_only.joins(:subscription)
+                 .merge(expired_trials.or(old_cancellations))
+                 .where.not(id: empty_trial_ids)
+                 .order(Arel.sql(LIFECYCLE_ORDER_SQL))
+    group_id ? scope.where(id: group_id) : scope
+  end
+
+  def self.deletion_reason(subscription, as_of:)
+    return nil unless subscription
+
+    cutoff = as_of - RETENTION_PERIOD
+    return "subscription_canceled" if subscription.state == "canceled" && subscription.canceled_at && subscription.canceled_at <= cutoff
+    return "trial_expired" if subscription.plan == "trial" && subscription.expires_at && subscription.expires_at <= cutoff
+
+    nil
+  end
+
+  def self.lifecycle_at(subscription, reason)
+    reason == "subscription_canceled" ? subscription.canceled_at : subscription.expires_at
+  end
+
+  def self.log(io, entry)
+    io.puts(entry.to_json)
+    io.flush
+  end
+
+  private_class_method :lifecycle_at, :log
+end

--- a/app/services/group_service.rb
+++ b/app/services/group_service.rb
@@ -151,6 +151,10 @@ module GroupService
   end
 
   def self.destroy(group:, actor:)
+    warn_then_destroy(group: group, actor: actor)
+  end
+
+  def self.warn_then_destroy(group:, actor:)
     actor.ability.authorize! :destroy, group
 
     discard_and_schedule_destruction!(group, actor: actor, wait: 2.weeks) do
@@ -162,8 +166,25 @@ module GroupService
     end
   end
 
-  def self.destroy_without_warning!(group_id, actor: nil)
-    discard_and_schedule_destruction!(Group.find(group_id), actor: actor)
+  def self.warn_then_destroy_subscription(group:, reason:)
+    raise ArgumentError, "unknown deletion reason" unless ExpiredSubscriptionGroupCleanupService::REASONS.include?(reason)
+    current_reason = ExpiredSubscriptionGroupCleanupService.deletion_reason(group.subscription, as_of: Time.current)
+    raise CanCan::AccessDenied, "group subscription is not eligible for deletion" unless group.kept? && current_reason == reason
+
+    discard_and_schedule_destruction!(group, actor: nil, wait: 2.weeks) do
+      group.admins.each do |admin|
+        GroupMailer.destroy_warning(group.id, admin.id, nil, reason).deliver_later
+      end
+      Sentry.metrics.count("group.destroy", attributes: { reason: reason })
+      EventBus.broadcast("group_destroy", group, nil)
+    end
+  end
+
+  def self.destroy_immediately!(group_id, actor:)
+    group = Group.find(group_id)
+    raise CanCan::AccessDenied unless actor.is_admin?
+
+    discard_and_schedule_destruction!(group, actor: actor)
   end
 
   # Capture the specific discard operation under the same lock as discard.

--- a/app/services/group_usage_summary.rb
+++ b/app/services/group_usage_summary.rb
@@ -1,0 +1,17 @@
+# Counts the records that best communicate the scale of a group export. Counts
+# include the complete group tree and discarded content because those records
+# remain part of the pending deletion and export.
+module GroupUsageSummary
+  def self.for(group)
+    group_ids = group.id_and_subgroup_ids
+    topic_ids = Topic.where(group_id: group_ids).select(:id)
+
+    {
+      subgroups: group_ids.size - 1,
+      members: Membership.active.accepted.where(group_id: group_ids).distinct.count(:user_id),
+      discussions: Discussion.where(topic_id: topic_ids).count,
+      polls: Poll.where(topic_id: topic_ids).count,
+      comments: TopicItem.where(topic_id: topic_ids, itemable_type: "Comment").distinct.count(:itemable_id)
+    }
+  end
+end

--- a/app/views/admin/groups/show.rb
+++ b/app/views/admin/groups/show.rb
@@ -94,11 +94,10 @@ class Views::Admin::Groups::Show < Views::Admin::Layout
         operation_form("Change handle", handle_admin_group_path(@group), "handle", @group.handle, "Change handle")
         if @group.discarded?
           button_to "Restore group", undiscard_admin_group_path(@group), method: :post, class: "admin-button"
-        else
-          button_to "Discard group", discard_admin_group_path(@group), method: :post, class: "admin-button admin-button--secondary", form: { data: { confirm: "Discard #{@group.name} and all of its subgroups? Their content will be retained, but the groups will be unavailable until they are restored." } }
         end
         button_to "Export group", export_group_admin_group_path(@group), method: :post, class: "admin-button admin-button--secondary"
-        button_to "Delete group", delete_group_admin_group_path(@group), method: :post, class: "admin-button admin-button--danger", form: { data: { confirm: "Delete #{@group.name} and all of its subgroups? This permanently deletes their memberships and membership requests, topics and discussions, polls, votes and outcomes, topic items and notifications, templates, chatbots, handle redirects, reactions, and file attachments. User accounts and subscriptions are retained. This cannot be undone." } }
+        button_to "Warn then delete", warn_then_destroy_admin_group_path(@group), method: :post, class: "admin-button admin-button--danger", form: { data: { confirm: "Warn the administrators of #{@group.name}, discard its complete group tree now, and permanently delete it in 2 weeks?" } }
+        button_to "Delete immediately", destroy_immediately_admin_group_path(@group), method: :post, class: "admin-button admin-button--danger", form: { data: { confirm: "Permanently delete #{@group.name} and all of its subgroups immediately? This deletes memberships and membership requests, topics and discussions, polls, votes and outcomes, topic items and notifications, templates, chatbots, handle redirects, reactions, and file attachments. User accounts and subscriptions are retained. This cannot be undone." } }
       end
     end
   end

--- a/app/views/group_mailer/destroy_warning.rb
+++ b/app/views/group_mailer/destroy_warning.rb
@@ -2,14 +2,38 @@
 
 class Views::GroupMailer::DestroyWarning < Views::ApplicationMailer::BaseLayout
 
-  def initialize(group:, recipient:, deletor:)
+  def initialize(group:, recipient:, requester:, reason:, usage:)
     @group = group
     @recipient = recipient
-    @deletor = deletor
+    @requester = requester
+    @reason = reason
+    @usage = usage
   end
 
   def view_template
-    p { plain t(:"group_mailer.destroy_warning.body", group: @group.name, deletor: @deletor.name) }
-    p { plain "Group key: #{@group.key}" }
+    p { plain warning_body }
+    p { plain t(:"group_mailer.destroy_warning_with_usage.usage_heading") }
+    ul do
+      %i[subgroups members discussions polls comments].each do |name|
+        li { plain "#{t("group_mailer.destroy_warning_with_usage.#{name}")}: #{@usage.fetch(name)}" }
+      end
+    end
+    p { plain t(:"group_mailer.destroy_warning_with_usage.export") }
+    p do
+      link_to t(:"group_mailer.destroy_warning_with_usage.export_link"),
+              "https://help.loomio.org/en/user_manual/groups/data_export/"
+    end
+    p { plain t(:"group_mailer.destroy_warning_with_usage.group_key", key: @group.key) }
+  end
+
+  private
+
+  def warning_body
+    key = case @reason
+          when "trial_expired" then :trial_expired
+          when "subscription_canceled" then :subscription_canceled
+          else :requested
+          end
+    t("group_mailer.destroy_warning_with_usage.#{key}", group: @group.name, requester: @requester&.name)
   end
 end

--- a/app/workers/cleanup_empty_trials_worker.rb
+++ b/app/workers/cleanup_empty_trials_worker.rb
@@ -1,0 +1,7 @@
+class CleanupEmptyTrialsWorker < ApplicationJob
+  queue_as :low
+
+  def perform
+    EmptyTrialCleanupService.delete!(io: $stdout)
+  end
+end

--- a/app/workers/warn_expired_subscription_groups_worker.rb
+++ b/app/workers/warn_expired_subscription_groups_worker.rb
@@ -1,0 +1,8 @@
+class WarnExpiredSubscriptionGroupsWorker < ApplicationJob
+  queue_as :low
+  BATCH_SIZE = 100
+
+  def perform
+    ExpiredSubscriptionGroupCleanupService.warn_and_schedule!(io: $stdout, limit: BATCH_SIZE)
+  end
+end

--- a/config/locales/server.be.yml
+++ b/config/locales/server.be.yml
@@ -578,7 +578,7 @@ be:
       subject:
         votes_to_cast:
           one: You have 1 vote to cast
-          other: "You have %{count} votes to cast"
+          other: You have %{count} votes to cast
         people_mentioned:
           one: 1 person mentioned you
           other: "%{count} people mentioned you"
@@ -597,12 +597,11 @@ be:
       thanks_for_reading: Дзякуй за чытанне, добрага дня!
       marked_as_read_success: Усё ў электронным лісце пазначана як прачытанае
       click_here: Націсніце тут
-
     digest:
       subject:
         votes_to_cast:
           one: You have 1 vote to cast
-          other: "You have %{count} votes to cast"
+          other: You have %{count} votes to cast
         people_mentioned:
           one: 1 person mentioned you
           other: "%{count} people mentioned you"
@@ -679,6 +678,20 @@ be:
     trial_expired:
       subject: Ваша група Loomio будзе выдалена з-за бяздзейнасці.
       body: Ваша група Loomio "%{group}" была неактыўнай і будзе выдалена праз 2 тыдні. Калі вы не жадаеце, каб ваша група была выдалена, адкажыце на гэты ліст.
+    destroy_warning_with_usage:
+      subject: Ваша група Loomio запланавана да выдалення
+      requested: Ваша група Loomio "%{group}" была выдалена карыстальнікам %{requester}. Яна будзе канчаткова выдалена праз 2 тыдні.
+      trial_expired: Ваша група Loomio "%{group}" знаходзіцца на пробнай версіі, тэрмін дзеяння якой скончыўся, ужо як мінімум 60 дзён. Яна будзе канчаткова выдалена праз 2 тыдні.
+      subscription_canceled: Ваша група Loomio "%{group}" мае адмененую падпіску як мінімум на 60 дзён. Яна будзе канчаткова выдалена праз 2 тыдні.
+      usage_heading: 'Зводка дадзеных групы:'
+      subgroups: Падгрупы
+      members: Дзеючыя ўдзельнікі
+      discussions: Абмеркаванні
+      polls: Апытанні
+      comments: Каментарыі
+      export: Каб захаваць групу або экспартаваць копію яе дадзеных, адкажыце на гэты ліст на працягу 2 тыдняў. Мы можам аднавіць доступ да выдалення.
+      export_link: Даведайцеся пра экспарт дадзеных групы
+      group_key: 'Ключ групы: %{key}'
   forward_mailer:
     bounce:
       subject: Ваша паведамленне для Loomio не было дастаўлена

--- a/config/locales/server.ca.yml
+++ b/config/locales/server.ca.yml
@@ -310,7 +310,7 @@ ca:
       subject:
         votes_to_cast:
           one: You have 1 vote to cast
-          other: "You have %{count} votes to cast"
+          other: You have %{count} votes to cast
         people_mentioned:
           one: 1 person mentioned you
           other: "%{count} people mentioned you"
@@ -329,12 +329,11 @@ ca:
       thanks_for_reading: Gràcies per llegir, que passeu un bon dia!
       marked_as_read_success: Tot el que apareix al correu electrònic s'ha marcat com a llegit
       click_here: Fes click aquí
-
     digest:
       subject:
         votes_to_cast:
           one: You have 1 vote to cast
-          other: "You have %{count} votes to cast"
+          other: You have %{count} votes to cast
         people_mentioned:
           one: 1 person mentioned you
           other: "%{count} people mentioned you"
@@ -415,6 +414,20 @@ ca:
     trial_expired:
       subject: El vostre grup de Loomio s'eliminarà per inactivitat.
       body: El vostre grup de Loomio "%{group}" ha estat inactiu i s'eliminarà en 2 setmanes. Si no voleu que s'elimini el vostre grup, responeu a aquest correu electrònic.
+    destroy_warning_with_usage:
+      subject: El vostre grup de Loomio està programat per a la supressió.
+      requested: '%{requester} ha programat l''eliminació del vostre grup de Loomio "%{group}". S''eliminarà permanentment en 2 setmanes.'
+      trial_expired: El vostre grup de Loomio "%{group}" ha estat en una prova caducada durant almenys 60 dies. S'eliminarà permanentment en 2 setmanes.
+      subscription_canceled: El vostre grup de Loomio "%{group}" ha tingut una subscripció cancel·lada durant almenys 60 dies. S'eliminarà permanentment en 2 setmanes.
+      usage_heading: 'Resum de dades del grup:'
+      subgroups: Subgrups
+      members: Membres actuals
+      discussions: Debats
+      polls: Enquestes
+      comments: Comentaris
+      export: Per conservar el grup o exportar una còpia de les seves dades, responeu a aquest correu electrònic en un termini de 2 setmanes. Podem restaurar l'accés abans de suprimir-lo.
+      export_link: Més informació sobre l'exportació de dades de grup
+      group_key: 'Clau de grup: %{key}'
   poll_mailer:
     common:
       why_send_this: Esteu rebent aquest correu electrònic perquè %{reason}

--- a/config/locales/server.da.yml
+++ b/config/locales/server.da.yml
@@ -314,7 +314,7 @@ da:
       subject:
         votes_to_cast:
           one: You have 1 vote to cast
-          other: "You have %{count} votes to cast"
+          other: You have %{count} votes to cast
         people_mentioned:
           one: 1 person mentioned you
           other: "%{count} people mentioned you"
@@ -333,12 +333,11 @@ da:
       thanks_for_reading: Tak fordi du læste, hav en god dag!
       marked_as_read_success: Alt fra e-mailen er blevet markeret som læst
       click_here: Klik her
-
     digest:
       subject:
         votes_to_cast:
           one: You have 1 vote to cast
-          other: "You have %{count} votes to cast"
+          other: You have %{count} votes to cast
         people_mentioned:
           one: 1 person mentioned you
           other: "%{count} people mentioned you"
@@ -419,6 +418,20 @@ da:
     trial_expired:
       subject: Din Loomio-gruppe vil blive slettet på grund af inaktivitet.
       body: Din Loomio-gruppe "%{group}" har været inaktiv og vil blive slettet om 2 uger. Hvis du ikke ønsker, at din gruppe skal slettes, bedes du besvare denne e-mail.
+    destroy_warning_with_usage:
+      subject: Din Loomio-gruppe er planlagt til sletning
+      requested: Din Loomio-gruppe "%{group}" blev planlagt til sletning af %{requester}. Den vil blive permanent slettet om 2 uger.
+      trial_expired: Din Loomio-gruppe "%{group}" har haft en udløbet prøveperiode i mindst 60 dage. Den vil blive slettet permanent om 2 uger.
+      subscription_canceled: Din Loomio-gruppe "%{group}" har haft et annulleret abonnement i mindst 60 dage. Det vil blive slettet permanent om 2 uger.
+      usage_heading: 'Oversigt over gruppedata:'
+      subgroups: Undergrupper
+      members: Nuværende medlemmer
+      discussions: Diskussioner
+      polls: Afstemninger
+      comments: Kommentarer
+      export: For at beholde gruppen eller eksportere en kopi af dens data, bedes du besvare denne e-mail inden for 2 uger. Vi kan gendanne adgangen før sletning.
+      export_link: Lær om eksport af gruppedata
+      group_key: 'Gruppenøgle: %{key}'
   poll_mailer:
     common:
       why_send_this: Du modtager denne email fordi %{reason}

--- a/config/locales/server.de.yml
+++ b/config/locales/server.de.yml
@@ -334,7 +334,7 @@ de:
       subject:
         votes_to_cast:
           one: You have 1 vote to cast
-          other: "You have %{count} votes to cast"
+          other: You have %{count} votes to cast
         people_mentioned:
           one: 1 person mentioned you
           other: "%{count} people mentioned you"
@@ -353,12 +353,11 @@ de:
       thanks_for_reading: Vielen Dank für's Lesen, wir wünschen noch einen schönen Tag!
       marked_as_read_success: Alles aus der E-Mail wurde als gelesen markiert
       click_here: Hier klicken
-
     digest:
       subject:
         votes_to_cast:
           one: You have 1 vote to cast
-          other: "You have %{count} votes to cast"
+          other: You have %{count} votes to cast
         people_mentioned:
           one: 1 person mentioned you
           other: "%{count} people mentioned you"
@@ -445,6 +444,20 @@ de:
     trial_expired:
       subject: Deine Loomio-Gruppe wird aufgrund von Inaktivität gelöscht.
       body: Deine Loomio-Gruppe „%{group}“ ist inaktiv und wird in zwei Wochen gelöscht. Falls du die Löschung deiner Gruppe verhindern möchtest, antworte bitte auf diese E-Mail.
+    destroy_warning_with_usage:
+      subject: Ihre Loomio-Gruppe ist zur Löschung vorgesehen.
+      requested: Ihre Loomio-Gruppe "%{group}" wurde von %{requester} zur Löschung vorgesehen. Sie wird in 2 Wochen endgültig gelöscht.
+      trial_expired: Ihre Loomio-Gruppe "%{group}" befindet sich seit mindestens 60 Tagen in der abgelaufenen Testphase. Sie wird in 2 Wochen endgültig gelöscht.
+      subscription_canceled: Ihre Loomio-Gruppe "%{group}" hat seit mindestens 60 Tagen ein gekündigtes Abonnement. Sie wird in 2 Wochen endgültig gelöscht.
+      usage_heading: 'Zusammenfassung der Gruppendaten:'
+      subgroups: Untergruppen
+      members: Aktuelle Mitglieder
+      discussions: Diskussionen
+      polls: Umfragen
+      comments: Kommentare
+      export: Um die Gruppe zu behalten oder eine Kopie ihrer Daten zu exportieren, antworten Sie bitte innerhalb von zwei Wochen auf diese E-Mail. Wir können den Zugriff vor der Löschung wiederherstellen.
+      export_link: Erfahren Sie mehr über den Export von Gruppendaten
+      group_key: 'Gruppenschlüssel: %{key}'
   poll_mailer:
     common:
       why_send_this: Du erhältst diese E-Mail weil %{reason}

--- a/config/locales/server.el.yml
+++ b/config/locales/server.el.yml
@@ -308,7 +308,7 @@ el:
       subject:
         votes_to_cast:
           one: You have 1 vote to cast
-          other: "You have %{count} votes to cast"
+          other: You have %{count} votes to cast
         people_mentioned:
           one: 1 person mentioned you
           other: "%{count} people mentioned you"
@@ -327,12 +327,11 @@ el:
       thanks_for_reading: Ευχαριστούμε που διαβάζετε, να έχετε μια υπέροχη μέρα!
       marked_as_read_success: Όλα έχουν σημαδευτεί ως διαβασμένα από το ηλεκτρονικό ταχυδρομείο
       click_here: Πατήστε εδώ
-
     digest:
       subject:
         votes_to_cast:
           one: You have 1 vote to cast
-          other: "You have %{count} votes to cast"
+          other: You have %{count} votes to cast
         people_mentioned:
           one: 1 person mentioned you
           other: "%{count} people mentioned you"
@@ -413,6 +412,20 @@ el:
     trial_expired:
       subject: Η ομάδα σας Loomio θα διαγραφεί λόγω αδράνειας.
       body: Η ομάδα σας Loomio "%{group}" είναι ανενεργή και θα διαγραφεί σε 2 εβδομάδες. Εάν δεν θέλετε να διαγραφεί η ομάδα σας, απαντήστε σε αυτό το μήνυμα ηλεκτρονικού ταχυδρομείου.
+    destroy_warning_with_usage:
+      subject: Η ομάδα σας Loomio έχει προγραμματιστεί για διαγραφή
+      requested: Η ομάδα σας Loomio "%{group}" είχε προγραμματιστεί για διαγραφή από τον %{requester}. Θα διαγραφεί οριστικά σε 2 εβδομάδες.
+      trial_expired: Η ομάδα Loomio σας "%{group}" βρίσκεται σε δοκιμαστική περίοδο που έχει λήξει για τουλάχιστον 60 ημέρες. Θα διαγραφεί οριστικά σε 2 εβδομάδες.
+      subscription_canceled: Η συνδρομή της ομάδας σας Loomio "%{group}" έχει ακυρωθεί για τουλάχιστον 60 ημέρες. Θα διαγραφεί οριστικά σε 2 εβδομάδες.
+      usage_heading: 'Σύνοψη δεδομένων ομάδας:'
+      subgroups: Υποομάδες
+      members: Τρέχοντα μέλη
+      discussions: Συζητήσεις
+      polls: Δημοσκοπήσεις
+      comments: Σχόλια
+      export: Για να διατηρήσετε την ομάδα ή να εξαγάγετε ένα αντίγραφο των δεδομένων της, απαντήστε σε αυτό το μήνυμα ηλεκτρονικού ταχυδρομείου εντός 2 εβδομάδων. Μπορούμε να επαναφέρουμε την πρόσβαση πριν από τη διαγραφή.
+      export_link: Μάθετε σχετικά με την εξαγωγή δεδομένων ομάδας
+      group_key: 'Κλειδί ομάδας: %{key}'
   poll_mailer:
     common:
       why_send_this: Λαμβάνετε αυτό το μήνυμα ηλεκτρονικού ταχυδρομείου επειδή %{reason}

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -708,6 +708,20 @@ en:
         If you do not want your group to be deleted, please reply to this email.
         If you're sure you want to delete the group, you do not need to do anything.
         Thank you.
+    destroy_warning_with_usage:
+      subject: Your Loomio group is scheduled for deletion
+      requested: Your Loomio group "%{group}" was scheduled for deletion by %{requester}. It will be permanently deleted in 2 weeks.
+      trial_expired: Your Loomio group "%{group}" has been on an expired trial for at least 60 days. It will be permanently deleted in 2 weeks.
+      subscription_canceled: Your Loomio group "%{group}" has had a cancelled subscription for at least 60 days. It will be permanently deleted in 2 weeks.
+      usage_heading: "Group data summary:"
+      subgroups: Subgroups
+      members: Current members
+      discussions: Discussions
+      polls: Polls
+      comments: Comments
+      export: To keep the group or export a copy of its data, reply to this email within 2 weeks. We can restore access before deletion.
+      export_link: Learn about exporting group data
+      group_key: "Group key: %{key}"
     trial_expired:
       subject: Your Loomio group will be deleted due to inactivity.
       body: |

--- a/config/locales/server.es.yml
+++ b/config/locales/server.es.yml
@@ -326,7 +326,7 @@ es:
       subject:
         votes_to_cast:
           one: You have 1 vote to cast
-          other: "You have %{count} votes to cast"
+          other: You have %{count} votes to cast
         people_mentioned:
           one: 1 person mentioned you
           other: "%{count} people mentioned you"
@@ -345,12 +345,11 @@ es:
       thanks_for_reading: Gracias por leer, ¡que tengas un buen día!
       marked_as_read_success: Todo el contenido del correo ha sido marcado como leído
       click_here: Haz clic aquí
-
     digest:
       subject:
         votes_to_cast:
           one: You have 1 vote to cast
-          other: "You have %{count} votes to cast"
+          other: You have %{count} votes to cast
         people_mentioned:
           one: 1 person mentioned you
           other: "%{count} people mentioned you"
@@ -437,6 +436,20 @@ es:
     trial_expired:
       subject: Tu grupo de Loomio será eliminado por inactividad.
       body: Tu grupo de Loomio "%{group}" está inactivo y se eliminará en dos semanas. Si no quieres que se elimine, responde a este correo electrónico.
+    destroy_warning_with_usage:
+      subject: Tu grupo de Loomio está programado para ser eliminado.
+      requested: Tu grupo de Loomio "%{group}" fue programado para ser eliminado por %{requester}. Se eliminará permanentemente en 2 semanas.
+      trial_expired: Tu grupo de Loomio "%{group}" ha estado en período de prueba caducado durante al menos 60 días. Se eliminará permanentemente en 2 semanas.
+      subscription_canceled: Tu grupo de Loomio "%{group}" tiene la suscripción cancelada desde hace al menos 60 días. Se eliminará permanentemente en 2 semanas.
+      usage_heading: 'Resumen de datos del grupo:'
+      subgroups: Subgrupos
+      members: Miembros actuales
+      discussions: Discusiones
+      polls: Centro
+      comments: Comentarios
+      export: Para conservar el grupo o exportar una copia de sus datos, responda a este correo electrónico en un plazo de dos semanas. Podemos restablecer el acceso antes de su eliminación.
+      export_link: Aprenda a exportar datos de grupo
+      group_key: 'Clave de grupo: %{key}'
   poll_mailer:
     common:
       why_send_this: Recibes este correo porque %{reason}

--- a/config/locales/server.fi.yml
+++ b/config/locales/server.fi.yml
@@ -308,7 +308,7 @@ fi:
       subject:
         votes_to_cast:
           one: You have 1 vote to cast
-          other: "You have %{count} votes to cast"
+          other: You have %{count} votes to cast
         people_mentioned:
           one: 1 person mentioned you
           other: "%{count} people mentioned you"
@@ -327,12 +327,11 @@ fi:
       thanks_for_reading: Kiitos kun luit, mukavaa päivää!
       marked_as_read_success: Kaikki sähköpostista on merkitty luetuksi
       click_here: Klikkaa tästä
-
     digest:
       subject:
         votes_to_cast:
           one: You have 1 vote to cast
-          other: "You have %{count} votes to cast"
+          other: You have %{count} votes to cast
         people_mentioned:
           one: 1 person mentioned you
           other: "%{count} people mentioned you"
@@ -413,6 +412,20 @@ fi:
     trial_expired:
       subject: Loomio-ryhmäsi poistetaan käyttämättömyyden vuoksi.
       body: Loomio-ryhmäsi "%{group}" on ollut passiivinen ja se poistetaan kahden viikon kuluttua. Jos et halua ryhmäsi poistettavan, vastaa tähän sähköpostiin.
+    destroy_warning_with_usage:
+      subject: Loomio-ryhmäsi on ajoitettu poistettavaksi
+      requested: Loomio-ryhmäsi "%{group}" on ajoitettu poistettavaksi käyttäjän %{requester toimesta. Se poistetaan pysyvästi kahden viikon kuluttua.
+      trial_expired: Loomio-ryhmäsi "%{group}" on ollut vanhentuneessa kokeilujaksossa vähintään 60 päivää. Se poistetaan pysyvästi kahden viikon kuluttua.
+      subscription_canceled: Loomio-ryhmäsi "%{group}" tilaus on ollut peruutettuna vähintään 60 päivää. Se poistetaan pysyvästi kahden viikon kuluttua.
+      usage_heading: 'Ryhmätietojen yhteenveto:'
+      subgroups: Alaryhmät
+      members: Nykyiset jäsenet
+      discussions: Keskustelut
+      polls: Kyselyt
+      comments: Kommentit
+      export: Jos haluat säilyttää ryhmän tai viedä kopion sen tiedoista, vastaa tähän sähköpostiin kahden viikon kuluessa. Voimme palauttaa käyttöoikeudet ennen poistamista.
+      export_link: Lisätietoja ryhmätietojen viennistä
+      group_key: 'Ryhmän avain: %{key}'
   poll_mailer:
     common:
       why_send_this: Saat tämän sähköpostin, koska %{reason}

--- a/config/locales/server.fr.yml
+++ b/config/locales/server.fr.yml
@@ -332,7 +332,7 @@ fr:
       subject:
         votes_to_cast:
           one: You have 1 vote to cast
-          other: "You have %{count} votes to cast"
+          other: You have %{count} votes to cast
         people_mentioned:
           one: 1 person mentioned you
           other: "%{count} people mentioned you"
@@ -351,12 +351,11 @@ fr:
       thanks_for_reading: Merci pour ta lecture, passe une bonne journée !
       marked_as_read_success: Tout le contenu de ce courriel a été marqué comme lu
       click_here: Cliquer ici
-
     digest:
       subject:
         votes_to_cast:
           one: You have 1 vote to cast
-          other: "You have %{count} votes to cast"
+          other: You have %{count} votes to cast
         people_mentioned:
           one: 1 person mentioned you
           other: "%{count} people mentioned you"
@@ -443,6 +442,20 @@ fr:
     trial_expired:
       subject: Ton groupe Loomio sera supprimé en raison de son inactivité.
       body: Ton groupe Loomio « %{group} » est inactif et sera supprimé dans deux semaines. Si tu ne souhaites pas qu'il soit supprimé, réponds à ce courriel.
+    destroy_warning_with_usage:
+      subject: Votre groupe Loomio est programmé pour être supprimé.
+      requested: Votre groupe Loomio « %{group} » a été programmé pour suppression par %{requester}. Il sera supprimé définitivement dans 2 semaines.
+      trial_expired: Votre groupe Loomio « %{group} » est en période d'essai expirée depuis au moins 60 jours. Il sera définitivement supprimé dans 2 semaines.
+      subscription_canceled: Votre groupe Loomio « %{group} » a un abonnement annulé depuis au moins 60 jours. Il sera définitivement supprimé dans 2 semaines.
+      usage_heading: 'Résumé des données du groupe :'
+      subgroups: Sous-groupes
+      members: Membres actuels
+      discussions: Discussions
+      polls: Sondages
+      comments: Commentaires
+      export: Pour conserver le groupe ou exporter une copie de ses données, veuillez répondre à ce courriel dans un délai de deux semaines. Nous pouvons rétablir l'accès avant la suppression.
+      export_link: Découvrez comment exporter les données de groupe
+      group_key: 'Clé du groupe : %{key}'
   poll_mailer:
     common:
       why_send_this: Tu reçois ce courriel parce que %{reason}

--- a/config/locales/server.he.yml
+++ b/config/locales/server.he.yml
@@ -318,7 +318,7 @@ he:
       subject:
         votes_to_cast:
           one: You have 1 vote to cast
-          other: "You have %{count} votes to cast"
+          other: You have %{count} votes to cast
         people_mentioned:
           one: 1 person mentioned you
           other: "%{count} people mentioned you"
@@ -337,12 +337,11 @@ he:
       thanks_for_reading: תודה שקראת. יום טוב!
       marked_as_read_success: כל הדברים במייל סומנו כנקראו
       click_here: הקליקו כאן
-
     digest:
       subject:
         votes_to_cast:
           one: You have 1 vote to cast
-          other: "You have %{count} votes to cast"
+          other: You have %{count} votes to cast
         people_mentioned:
           one: 1 person mentioned you
           other: "%{count} people mentioned you"
@@ -425,6 +424,20 @@ he:
     trial_expired:
       subject: קבוצת Loomio שלך תימחק עקב חוסר פעילות.
       body: קבוצת Loomio שלך "%{group}" אינה פעילה ותימחק בעוד שבועיים. אם אינך מעוניין שהקבוצה שלך תימחק, אנא השב למייל זה.
+    destroy_warning_with_usage:
+      subject: קבוצת Loomio שלך מתוכננת למחיקה
+      requested: קבוצת Loomio שלך "%{group}" תוכננה למחיקה על ידי %{requester}. היא תימחק לצמיתות בעוד שבועיים.
+      trial_expired: קבוצת ה-Loomio שלך "%{group}" נמצאת בתקופת ניסיון שפג תוקפה במשך 60 יום לפחות. היא תימחק לצמיתות בעוד שבועיים.
+      subscription_canceled: מנוי לקבוצת Loomio שלך "%{group}" בוטל במשך 60 יום לפחות. הוא יימחק לצמיתות בעוד שבועיים.
+      usage_heading: 'סיכום נתוני הקבוצה:'
+      subgroups: תת-קבוצות
+      members: חברים נוכחיים
+      discussions: דיונים
+      polls: סקרים
+      comments: הערות
+      export: כדי לשמור את הקבוצה או לייצא עותק של הנתונים שלה, יש להשיב לאימייל זה תוך שבועיים. נוכל לשחזר את הגישה לפני המחיקה.
+      export_link: למד על ייצוא נתוני קבוצה
+      group_key: 'מפתח קבוצה: %{key}'
   poll_mailer:
     common:
       why_send_this: אתה מקבל את המייל הזה בגלל %{reason}

--- a/config/locales/server.hr.yml
+++ b/config/locales/server.hr.yml
@@ -308,7 +308,7 @@ hr:
       subject:
         votes_to_cast:
           one: You have 1 vote to cast
-          other: "You have %{count} votes to cast"
+          other: You have %{count} votes to cast
         people_mentioned:
           one: 1 person mentioned you
           other: "%{count} people mentioned you"
@@ -327,12 +327,11 @@ hr:
       thanks_for_reading: Hvala na čitanju, ugodan dan!
       marked_as_read_success: Sve iz e-pošte označeno je kao pročitano
       click_here: Kliknite ovdje
-
     digest:
       subject:
         votes_to_cast:
           one: You have 1 vote to cast
-          other: "You have %{count} votes to cast"
+          other: You have %{count} votes to cast
         people_mentioned:
           one: 1 person mentioned you
           other: "%{count} people mentioned you"
@@ -413,6 +412,20 @@ hr:
     trial_expired:
       subject: Vaša Loomio grupa bit će izbrisana zbog neaktivnosti.
       body: Vaša Loomio grupa "%{group}" je neaktivna i bit će izbrisana za 2 tjedna. Ako ne želite da vaša grupa bude izbrisana, odgovorite na ovu e-poštu.
+    destroy_warning_with_usage:
+      subject: Vaša Loomio grupa je planirana za brisanje
+      requested: Vaša Loomio grupa "%{group}" je zakazana za brisanje od strane %{requester}. Bit će trajno izbrisana za 2 tjedna.
+      trial_expired: Vaša Loomio grupa "%{group}" je na istekloj probnoj verziji najmanje 60 dana. Bit će trajno izbrisana za 2 tjedna.
+      subscription_canceled: Vaša Loomio grupa "%{group}" ima otkazanu pretplatu najmanje 60 dana. Bit će trajno izbrisana za 2 tjedna.
+      usage_heading: 'Sažetak podataka grupe:'
+      subgroups: Podgrupe
+      members: Trenutni članovi
+      discussions: Rasprave
+      polls: Ankete
+      comments: Komentari
+      export: Da biste zadržali grupu ili izvezli kopiju njezinih podataka, odgovorite na ovu e-poruku u roku od 2 tjedna. Možemo vratiti pristup prije brisanja.
+      export_link: Saznajte više o izvozu podataka grupe
+      group_key: 'Grupni ključ: %{key}'
   poll_mailer:
     common:
       why_send_this: Primili ste ovu e-poruku jer %{reason}

--- a/config/locales/server.hu.yml
+++ b/config/locales/server.hu.yml
@@ -318,7 +318,7 @@ hu:
       subject:
         votes_to_cast:
           one: You have 1 vote to cast
-          other: "You have %{count} votes to cast"
+          other: You have %{count} votes to cast
         people_mentioned:
           one: 1 person mentioned you
           other: "%{count} people mentioned you"
@@ -337,12 +337,11 @@ hu:
       thanks_for_reading: Köszönjük, hogy elolvastad, szép napot kívánunk!
       marked_as_read_success: Az e-mail teljes tartalma meg lett jelölve olvasottként.
       click_here: Kattints ide
-
     digest:
       subject:
         votes_to_cast:
           one: You have 1 vote to cast
-          other: "You have %{count} votes to cast"
+          other: You have %{count} votes to cast
         people_mentioned:
           one: 1 person mentioned you
           other: "%{count} people mentioned you"
@@ -425,6 +424,20 @@ hu:
     trial_expired:
       subject: A Loomio csoportod inaktivitás miatt törlésre kerül.
       body: A(z) „%{group}” nevű Loomio csoportod inaktív volt, és 2 hét múlva törlésre kerül. Ha nem szeretnéd, hogy a csoportodat töröljék, kérlek válaszolj erre az e-mailre.
+    destroy_warning_with_usage:
+      subject: A Loomio-csoportod törlése ütemezve van.
+      requested: A(z) „%{group}” nevű Loomio csoportodat törlésre ütemezte %{requester}. A csoport 2 hét múlva véglegesen törlésre kerül.
+      trial_expired: A(z) „%{group}” nevű Loomio csoportod legalább 60 napja lejárt próbaidőszakban van. 2 hét múlva véglegesen törlésre kerül.
+      subscription_canceled: A(z) „%{group}” nevű Loomio csoportod legalább 60 napja lemondott előfizetéssel rendelkezik. 2 hét múlva véglegesen törlésre kerül.
+      usage_heading: 'Csoportadatok összefoglalása:'
+      subgroups: Alcsoportok
+      members: Jelenlegi tagok
+      discussions: Beszélgetések
+      polls: Szavazások
+      comments: Hozzászólások
+      export: A csoport megtartásához vagy az adatainak másolatának exportálásához válaszoljon erre az e-mailre 2 héten belül. A törlés előtt vissza tudjuk állítani a hozzáférést.
+      export_link: Tudjon meg többet a csoportadatok exportálásáról
+      group_key: 'Csoportkulcs: %{key}'
   poll_mailer:
     common:
       why_send_this: Azért kapja ezt az e-mailt, mert %{reason}

--- a/config/locales/server.it.yml
+++ b/config/locales/server.it.yml
@@ -319,7 +319,7 @@ it:
       subject:
         votes_to_cast:
           one: You have 1 vote to cast
-          other: "You have %{count} votes to cast"
+          other: You have %{count} votes to cast
         people_mentioned:
           one: 1 person mentioned you
           other: "%{count} people mentioned you"
@@ -338,12 +338,11 @@ it:
       thanks_for_reading: Grazie per aver letto, buona giornata!
       marked_as_read_success: Tutte le email sono state contrassegnate come lette
       click_here: Clicca qui
-
     digest:
       subject:
         votes_to_cast:
           one: You have 1 vote to cast
-          other: "You have %{count} votes to cast"
+          other: You have %{count} votes to cast
         people_mentioned:
           one: 1 person mentioned you
           other: "%{count} people mentioned you"
@@ -424,6 +423,20 @@ it:
     trial_expired:
       subject: Il tuo gruppo Loomio verrà eliminato per inattività.
       body: Il tuo gruppo Loomio "%{group}" è inattivo e verrà eliminato tra 2 settimane. Se non desideri che il gruppo venga eliminato, rispondi a questa email.
+    destroy_warning_with_usage:
+      subject: Il tuo gruppo Loomio è programmato per la cancellazione.
+      requested: Il tuo gruppo Loomio "%{group}" è stato programmato per la cancellazione da %{requester}. Verrà eliminato definitivamente tra 2 settimane.
+      trial_expired: Il tuo gruppo Loomio "%{group}" è attivo in versione di prova scaduta da almeno 60 giorni. Verrà eliminato definitivamente tra 2 settimane.
+      subscription_canceled: Il tuo gruppo Loomio "%{group}" ha un abbonamento annullato da almeno 60 giorni. Verrà eliminato definitivamente tra 2 settimane.
+      usage_heading: 'Riepilogo dei dati di gruppo:'
+      subgroups: Sottogruppi
+      members: Membri attuali
+      discussions: Discussioni
+      polls: Sondaggi
+      comments: Commenti
+      export: Per mantenere il gruppo o esportarne una copia dei dati, rispondi a questa email entro 2 settimane. Possiamo ripristinare l'accesso prima della cancellazione.
+      export_link: Scopri come esportare i dati di gruppo
+      group_key: 'Chiave del gruppo: %{key}'
   poll_mailer:
     common:
       why_send_this: Ricevi questa email perché %{reason}

--- a/config/locales/server.ja.yml
+++ b/config/locales/server.ja.yml
@@ -303,7 +303,7 @@ ja:
       subject:
         votes_to_cast:
           one: You have 1 vote to cast
-          other: "You have %{count} votes to cast"
+          other: You have %{count} votes to cast
         people_mentioned:
           one: 1 person mentioned you
           other: "%{count} people mentioned you"
@@ -322,12 +322,11 @@ ja:
       thanks_for_reading: 読んでいただきありがとうございます、良い一日をお過ごしください!
       marked_as_read_success: メールのすべてが既読としてマークされています
       click_here: ここをクリック
-
     digest:
       subject:
         votes_to_cast:
           one: You have 1 vote to cast
-          other: "You have %{count} votes to cast"
+          other: You have %{count} votes to cast
         people_mentioned:
           one: 1 person mentioned you
           other: "%{count} people mentioned you"
@@ -408,6 +407,20 @@ ja:
     trial_expired:
       subject: あなたのLoomioグループは、活動がないため削除されます。
       body: あなたのLoomioグループ「%{group}」は非アクティブ状態のため、2週間後に削除されます。グループの削除を希望されない場合は、このメールにご返信ください。
+    destroy_warning_with_usage:
+      subject: あなたのLoomioグループは削除予定です。
+      requested: あなたのLoomioグループ「%{group}」は、%{requester}によって削除予定となりました。2週間後に完全に削除されます。
+      trial_expired: あなたのLoomioグループ「%{group}」は、少なくとも60日間のトライアル期間が終了しています。2週間後に完全に削除されます。
+      subscription_canceled: あなたのLoomioグループ「%{group}」は、少なくとも60日間購読がキャンセルされています。2週間後に完全に削除されます。
+      usage_heading: グループデータの概要：
+      subgroups: サブグループ
+      members: 現在のメンバー
+      discussions: 議論
+      polls: 世論調査
+      comments: コメント
+      export: グループを維持するため、またはデータのコピーをエクスポートするためには、2週間以内にこのメールに返信してください。削除前にアクセスを復元することが可能です。
+      export_link: グループデータのエクスポートについて学ぶ
+      group_key: 'グループキー: %{key}'
   poll_mailer:
     common:
       why_send_this: このメールを受け取った理由は %{reason}

--- a/config/locales/server.nl_NL.yml
+++ b/config/locales/server.nl_NL.yml
@@ -333,7 +333,7 @@ nl_NL:
       subject:
         votes_to_cast:
           one: You have 1 vote to cast
-          other: "You have %{count} votes to cast"
+          other: You have %{count} votes to cast
         people_mentioned:
           one: 1 person mentioned you
           other: "%{count} people mentioned you"
@@ -352,12 +352,11 @@ nl_NL:
       thanks_for_reading: Bedankt voor het lezen, een fijne dag toegewenst!
       marked_as_read_success: Alles uit de e-mail werd gemarkeerd als gelezen
       click_here: Klik hier
-
     digest:
       subject:
         votes_to_cast:
           one: You have 1 vote to cast
-          other: "You have %{count} votes to cast"
+          other: You have %{count} votes to cast
         people_mentioned:
           one: 1 person mentioned you
           other: "%{count} people mentioned you"
@@ -440,6 +439,20 @@ nl_NL:
     trial_expired:
       subject: Je Loomio-groep wordt verwijderd vanwege inactiviteit.
       body: Je Loomio-groep "%{group}" is inactief en wordt over 2 weken verwijderd. Als je niet wilt dat je groep wordt verwijderd, beantwoord dan deze e-mail.
+    destroy_warning_with_usage:
+      subject: Je Loomio-groep staat gepland om verwijderd te worden.
+      requested: Je Loomio-groep "%{group}" stond op de planning om verwijderd te worden door %{requester}. Deze wordt over 2 weken definitief verwijderd.
+      trial_expired: Je Loomio-groep "%{group}" heeft een verlopen proefperiode van minimaal 60 dagen. Deze wordt over 2 weken definitief verwijderd.
+      subscription_canceled: Je Loomio-groep "%{group}" heeft al minstens 60 dagen een opgezegd abonnement. Deze groep wordt over 2 weken definitief verwijderd.
+      usage_heading: 'Samenvatting van de groepsgegevens:'
+      subgroups: Subgroepen
+      members: Huidige leden
+      discussions: Discussies
+      polls: Peilingen
+      comments: Opmerkingen
+      export: Om de groep te behouden of een kopie van de gegevens te exporteren, kunt u binnen twee weken op deze e-mail reageren. We kunnen de toegang herstellen voordat de groep wordt verwijderd.
+      export_link: Leer meer over het exporteren van groepsgegevens.
+      group_key: 'Groepssleutel: %{key}'
   poll_mailer:
     common:
       why_send_this: Je ontvangt deze e-mail omdat %{reason}

--- a/config/locales/server.pl.yml
+++ b/config/locales/server.pl.yml
@@ -333,7 +333,7 @@ pl:
       subject:
         votes_to_cast:
           one: You have 1 vote to cast
-          other: "You have %{count} votes to cast"
+          other: You have %{count} votes to cast
         people_mentioned:
           one: 1 person mentioned you
           other: "%{count} people mentioned you"
@@ -352,12 +352,11 @@ pl:
       thanks_for_reading: Dziękujemy za przeczytanie, miłego dnia!
       marked_as_read_success: Wszystko z wiadomości e-mail zostało oznaczone jako przeczytane
       click_here: Kliknij tutaj
-
     digest:
       subject:
         votes_to_cast:
           one: You have 1 vote to cast
-          other: "You have %{count} votes to cast"
+          other: You have %{count} votes to cast
         people_mentioned:
           one: 1 person mentioned you
           other: "%{count} people mentioned you"
@@ -440,6 +439,20 @@ pl:
     trial_expired:
       subject: Twoja grupa Loomio zostanie usunięta z powodu braku aktywności.
       body: Twoja grupa Loomio „%{group}” jest nieaktywna i zostanie usunięta za 2 tygodnie. Jeśli nie chcesz, aby Twoja grupa została usunięta, odpowiedz na tego e-maila.
+    destroy_warning_with_usage:
+      subject: Twoja grupa Loomio jest przeznaczona do usunięcia
+      requested: Twoja grupa Loomio „%{group}” została zaplanowana do usunięcia przez %{requester}. Zostanie trwale usunięta za 2 tygodnie.
+      trial_expired: Twoja grupa Loomio „%{group}” jest na okresie próbnym, który wygasł od co najmniej 60 dni. Zostanie trwale usunięta za 2 tygodnie.
+      subscription_canceled: Subskrypcja Twojej grupy Loomio „%{group}” została anulowana na co najmniej 60 dni. Zostanie ona trwale usunięta za 2 tygodnie.
+      usage_heading: 'Podsumowanie danych grupowych:'
+      subgroups: Podgrupy
+      members: Obecni członkowie
+      discussions: Dyskusje
+      polls: Ankiety
+      comments: Uwagi
+      export: Aby zachować grupę lub wyeksportować kopię jej danych, odpowiedz na tego e-maila w ciągu 2 tygodni. Możemy przywrócić dostęp przed usunięciem.
+      export_link: Dowiedz się więcej o eksportowaniu danych grupowych
+      group_key: 'Klucz grupy: %{key}'
   poll_mailer:
     common:
       why_send_this: Otrzymujesz tę wiadomość e-mail, ponieważ %{reason}

--- a/config/locales/server.pt_BR.yml
+++ b/config/locales/server.pt_BR.yml
@@ -332,7 +332,7 @@ pt_BR:
       subject:
         votes_to_cast:
           one: You have 1 vote to cast
-          other: "You have %{count} votes to cast"
+          other: You have %{count} votes to cast
         people_mentioned:
           one: 1 person mentioned you
           other: "%{count} people mentioned you"
@@ -351,12 +351,11 @@ pt_BR:
       thanks_for_reading: Obrigado por ler, tenha um ótimo dia!
       marked_as_read_success: Tudo no e-mail foi marcado como lido
       click_here: Clique aqui
-
     digest:
       subject:
         votes_to_cast:
           one: You have 1 vote to cast
-          other: "You have %{count} votes to cast"
+          other: You have %{count} votes to cast
         people_mentioned:
           one: 1 person mentioned you
           other: "%{count} people mentioned you"
@@ -443,6 +442,20 @@ pt_BR:
     trial_expired:
       subject: Seu grupo no Loomio será excluído devido à inatividade.
       body: Seu grupo no Loomio "%{group}" está inativo e será excluído em 2 semanas. Se você não deseja que seu grupo seja excluído, responda a este e-mail.
+    destroy_warning_with_usage:
+      subject: Seu grupo no Loomio está programado para ser excluído.
+      requested: Seu grupo no Loomio "%{group}" foi programado para exclusão por %{requester}. Ele será excluído permanentemente em 2 semanas.
+      trial_expired: Seu grupo no Loomio "%{group}" está em período de teste expirado há pelo menos 60 dias. Ele será excluído permanentemente em 2 semanas.
+      subscription_canceled: Seu grupo Loomio "%{group}" teve uma assinatura cancelada há pelo menos 60 dias. Ele será excluído permanentemente em 2 semanas.
+      usage_heading: 'Resumo dos dados do grupo:'
+      subgroups: Subgrupos
+      members: Membros atuais
+      discussions: Discussões
+      polls: Pesquisas
+      comments: Comentários
+      export: Para manter o grupo ou exportar uma cópia dos seus dados, responda a este e-mail dentro de 2 semanas. Podemos restaurar o acesso antes da exclusão.
+      export_link: Saiba mais sobre como exportar dados de grupo.
+      group_key: 'Chave do grupo: %{key}'
   poll_mailer:
     common:
       why_send_this: 'Você está recebendo este e-mail pelo seguinte motivo: %{reason}'

--- a/config/locales/server.ro.yml
+++ b/config/locales/server.ro.yml
@@ -308,7 +308,7 @@ ro:
       subject:
         votes_to_cast:
           one: You have 1 vote to cast
-          other: "You have %{count} votes to cast"
+          other: You have %{count} votes to cast
         people_mentioned:
           one: 1 person mentioned you
           other: "%{count} people mentioned you"
@@ -327,12 +327,11 @@ ro:
       thanks_for_reading: Multumesc pentru lectura, o zi buna!
       marked_as_read_success: Tot continutul acestui email a fost marcat ca fiind citit
       click_here: Apasa aici
-
     digest:
       subject:
         votes_to_cast:
           one: You have 1 vote to cast
-          other: "You have %{count} votes to cast"
+          other: You have %{count} votes to cast
         people_mentioned:
           one: 1 person mentioned you
           other: "%{count} people mentioned you"
@@ -413,6 +412,20 @@ ro:
     trial_expired:
       subject: Grupul tău Loomio va fi șters din cauza inactivității.
       body: Grupul dumneavoastră Loomio „%{group}” a fost inactiv și va fi șters în 2 săptămâni. Dacă nu doriți ca grupul dumneavoastră să fie șters, vă rugăm să răspundeți la acest e-mail.
+    destroy_warning_with_usage:
+      subject: Grupul tău Loomio este programat pentru ștergere
+      requested: Grupul dumneavoastră Loomio „%{group}” a fost programat pentru ștergere de către %{requester}. Acesta va fi șters definitiv în 2 săptămâni.
+      trial_expired: Grupul dvs. Loomio „%{group}” se află într-o perioadă de probă expirată de cel puțin 60 de zile. Acesta va fi șters definitiv în 2 săptămâni.
+      subscription_canceled: Grupul dvs. Loomio „%{group}” a avut un abonament anulat de cel puțin 60 de zile. Acesta va fi șters definitiv în 2 săptămâni.
+      usage_heading: 'Rezumatul datelor de grup:'
+      subgroups: Subgrupuri
+      members: Membri actuali
+      discussions: Discuții
+      polls: Sondaje
+      comments: Comentarii
+      export: Pentru a păstra grupul sau a exporta o copie a datelor sale, răspundeți la acest e-mail în termen de 2 săptămâni. Putem restabili accesul înainte de ștergere.
+      export_link: Aflați despre exportul datelor de grup
+      group_key: 'Cheie de grup: %{key}'
   poll_mailer:
     common:
       why_send_this: Primiți acest e-mail deoarece %{reason}

--- a/config/locales/server.ru.yml
+++ b/config/locales/server.ru.yml
@@ -317,7 +317,7 @@ ru:
       subject:
         votes_to_cast:
           one: You have 1 vote to cast
-          other: "You have %{count} votes to cast"
+          other: You have %{count} votes to cast
         people_mentioned:
           one: 1 person mentioned you
           other: "%{count} people mentioned you"
@@ -336,12 +336,11 @@ ru:
       thanks_for_reading: Спасибо, что прочли и удачного дня!
       marked_as_read_success: Все в этом письме отмечено прочитанным
       click_here: Кликните здесь
-
     digest:
       subject:
         votes_to_cast:
           one: You have 1 vote to cast
-          other: "You have %{count} votes to cast"
+          other: You have %{count} votes to cast
         people_mentioned:
           one: 1 person mentioned you
           other: "%{count} people mentioned you"
@@ -424,6 +423,20 @@ ru:
     trial_expired:
       subject: Ваша группа в Loomio будет удалена из-за неактивности.
       body: Ваша группа Loomio "%{group}" неактивна и будет удалена через 2 недели. Если вы не хотите, чтобы ваша группа была удалена, пожалуйста, ответьте на это письмо.
+    destroy_warning_with_usage:
+      subject: Ваша группа в Loomio запланирована к удалению.
+      requested: Ваша группа Loomio "%{group}" была запланирована к удалению пользователем %{requester}. Она будет безвозвратно удалена через 2 недели.
+      trial_expired: Ваша группа Loomio "%{group}" находится в режиме истекшего пробного периода как минимум 60 дней. Она будет безвозвратно удалена через 2 недели.
+      subscription_canceled: В вашей группе Loomio "%{group}" была отменена подписка как минимум 60 дней назад. Она будет безвозвратно удалена через 2 недели.
+      usage_heading: 'Сводные данные по группе:'
+      subgroups: Подгруппы
+      members: Действующие члены
+      discussions: Обсуждения
+      polls: Опросы
+      comments: Комментарии
+      export: Чтобы сохранить группу или экспортировать копию ее данных, ответьте на это письмо в течение 2 недель. Мы сможем восстановить доступ до удаления.
+      export_link: Узнайте об экспорте групповых данных.
+      group_key: 'Ключ группы: %{key}'
   poll_mailer:
     common:
       why_send_this: Вы получили это письмо, потому что %{reason}

--- a/config/locales/server.sl.yml
+++ b/config/locales/server.sl.yml
@@ -308,7 +308,7 @@ sl:
       subject:
         votes_to_cast:
           one: You have 1 vote to cast
-          other: "You have %{count} votes to cast"
+          other: You have %{count} votes to cast
         people_mentioned:
           one: 1 person mentioned you
           other: "%{count} people mentioned you"
@@ -327,12 +327,11 @@ sl:
       thanks_for_reading: Super, prebral/a si vse novice. Lep dan!
       marked_as_read_success: Vse iz emaila je bilo označeno kot prebrano
       click_here: Klikni sem
-
     digest:
       subject:
         votes_to_cast:
           one: You have 1 vote to cast
-          other: "You have %{count} votes to cast"
+          other: You have %{count} votes to cast
         people_mentioned:
           one: 1 person mentioned you
           other: "%{count} people mentioned you"
@@ -413,6 +412,20 @@ sl:
     trial_expired:
       subject: Vaša skupina Loomio bo izbrisana zaradi neaktivnosti.
       body: Vaša skupina Loomio »%{group}« je bila neaktivna in bo izbrisana čez 2 tedna. Če ne želite, da se vaša skupina izbriše, odgovorite na to e-poštno sporočilo.
+    destroy_warning_with_usage:
+      subject: Vaša skupina Loomio je načrtovana za brisanje
+      requested: Vaša skupina Loomio »%{group}« je bila načrtovana za brisanje s strani %{requester}. Trajno bo izbrisana čez 2 tedna.
+      trial_expired: Vaša skupina Loomio »%{group}« je že vsaj 60 dni v potečeni preizkusni različici. Čez 2 tedna bo trajno izbrisana.
+      subscription_canceled: Vaša skupina Loomio »%{group}« ima že vsaj 60 dni preklicano naročnino. Trajno bo izbrisana čez 2 tedna.
+      usage_heading: 'Povzetek podatkov skupine:'
+      subgroups: Podskupine
+      members: Trenutni člani
+      discussions: Razprave
+      polls: Ankete
+      comments: Komentarji
+      export: Če želite obdržati skupino ali izvoziti kopijo njenih podatkov, odgovorite na to e-poštno sporočilo v dveh tednih. Dostop lahko obnovimo pred izbrisom.
+      export_link: Več o izvozu podatkov skupine
+      group_key: 'Ključ skupine: %{key}'
   poll_mailer:
     common:
       why_send_this: To e-pošto ste prejeli, ker %{reason}

--- a/config/locales/server.sv.yml
+++ b/config/locales/server.sv.yml
@@ -308,7 +308,7 @@ sv:
       subject:
         votes_to_cast:
           one: You have 1 vote to cast
-          other: "You have %{count} votes to cast"
+          other: You have %{count} votes to cast
         people_mentioned:
           one: 1 person mentioned you
           other: "%{count} people mentioned you"
@@ -327,12 +327,11 @@ sv:
       thanks_for_reading: Tack för läsning, ha en bra dag!
       marked_as_read_success: Allt från mail har markerats som läst
       click_here: Klicka här
-
     digest:
       subject:
         votes_to_cast:
           one: You have 1 vote to cast
-          other: "You have %{count} votes to cast"
+          other: You have %{count} votes to cast
         people_mentioned:
           one: 1 person mentioned you
           other: "%{count} people mentioned you"
@@ -413,6 +412,20 @@ sv:
     trial_expired:
       subject: Din Loomio-grupp kommer att raderas på grund av inaktivitet.
       body: Din Loomio-grupp "%{group}" har varit inaktiv och kommer att raderas om 2 veckor. Om du inte vill att din grupp ska raderas, vänligen svara på det här e-postmeddelandet.
+    destroy_warning_with_usage:
+      subject: Din Loomio-grupp är schemalagd för radering
+      requested: Din Loomio-grupp "%{group}" var schemalagd för radering av %{requester}. Den kommer att raderas permanent om 2 veckor.
+      trial_expired: Din Loomio-grupp "%{group}" har haft en utgången provperiod i minst 60 dagar. Den kommer att raderas permanent om 2 veckor.
+      subscription_canceled: Din Loomio-grupp "%{group}" har haft en avbruten prenumeration i minst 60 dagar. Den kommer att raderas permanent om 2 veckor.
+      usage_heading: 'Sammanfattning av gruppdata:'
+      subgroups: Undergrupper
+      members: Nuvarande medlemmar
+      discussions: Diskussioner
+      polls: Opinionsundersökningar
+      comments: Kommentarer
+      export: För att behålla gruppen eller exportera en kopia av dess data, svara på det här e-postmeddelandet inom två veckor. Vi kan återställa åtkomsten innan raderingen.
+      export_link: Läs mer om att exportera gruppdata
+      group_key: 'Gruppnyckel: %{key}'
   poll_mailer:
     common:
       why_send_this: Du får det här e-postmeddelandet eftersom %{reason}

--- a/config/locales/server.tr.yml
+++ b/config/locales/server.tr.yml
@@ -308,7 +308,7 @@ tr:
       subject:
         votes_to_cast:
           one: You have 1 vote to cast
-          other: "You have %{count} votes to cast"
+          other: You have %{count} votes to cast
         people_mentioned:
           one: 1 person mentioned you
           other: "%{count} people mentioned you"
@@ -327,12 +327,11 @@ tr:
       thanks_for_reading: Okuduğunuz için teşekkürler. Güzel günler dileriz!
       marked_as_read_success: E-posta'daki herşey okundu olarak isaretlendi
       click_here: Buraya tıkla
-
     digest:
       subject:
         votes_to_cast:
           one: You have 1 vote to cast
-          other: "You have %{count} votes to cast"
+          other: You have %{count} votes to cast
         people_mentioned:
           one: 1 person mentioned you
           other: "%{count} people mentioned you"
@@ -413,6 +412,20 @@ tr:
     trial_expired:
       subject: Loomio grubunuz, uzun süredir aktif olmamanız nedeniyle silinecektir.
       body: Loomio grubunuz "%{group}" pasif durumda ve 2 hafta içinde silinecektir. Grubunuzun silinmesini istemiyorsanız, lütfen bu e-postaya yanıt verin.
+    destroy_warning_with_usage:
+      subject: Loomio grubunuz silinmek üzere planlandı.
+      requested: Loomio grubunuz "%{group}", %{requester} tarafından silinmek üzere planlandı. 2 hafta içinde kalıcı olarak silinecektir.
+      trial_expired: Loomio grubunuz "%{group}" en az 60 gündür deneme sürümünde bulunuyor ve bu süre dolmuştur. Grup 2 hafta içinde kalıcı olarak silinecektir.
+      subscription_canceled: Loomio grubunuz "%{group}" en az 60 gündür iptal edilmiş bir aboneliğe sahip. 2 hafta içinde kalıcı olarak silinecektir.
+      usage_heading: 'Grup verilerinin özeti:'
+      subgroups: Alt gruplar
+      members: Mevcut üyeler
+      discussions: Tartışmalar
+      polls: Anketler
+      comments: Yorumlar
+      export: Grubu korumak veya verilerinin bir kopyasını dışa aktarmak için, bu e-postaya 2 hafta içinde yanıt verin. Silinmeden önce erişimi geri yükleyebiliriz.
+      export_link: Grup verilerini dışa aktarma hakkında bilgi edinin.
+      group_key: 'Grup anahtarı: %{key}'
   poll_mailer:
     common:
       why_send_this: Bu e-postayı %{reason} nedeniyle alıyorsunuz

--- a/config/locales/server.uk.yml
+++ b/config/locales/server.uk.yml
@@ -320,7 +320,7 @@ uk:
       subject:
         votes_to_cast:
           one: You have 1 vote to cast
-          other: "You have %{count} votes to cast"
+          other: You have %{count} votes to cast
         people_mentioned:
           one: 1 person mentioned you
           other: "%{count} people mentioned you"
@@ -339,12 +339,11 @@ uk:
       thanks_for_reading: Дякуємо за читання, гарного дня!
       marked_as_read_success: Все в листі було позначено як прочитане
       click_here: Натисніть тут
-
     digest:
       subject:
         votes_to_cast:
           one: You have 1 vote to cast
-          other: "You have %{count} votes to cast"
+          other: You have %{count} votes to cast
         people_mentioned:
           one: 1 person mentioned you
           other: "%{count} people mentioned you"
@@ -427,6 +426,20 @@ uk:
     trial_expired:
       subject: Вашу групу Loomio буде видалено через неактивність.
       body: Ваша група Loomio "%{group}" була неактивною та буде видалена через 2 тижні. Якщо ви не хочете, щоб вашу групу видалили, будь ласка, дайте відповідь на цей електронний лист.
+    destroy_warning_with_usage:
+      subject: Вашу групу Loomio заплановано на видалення
+      requested: Вашу групу Loomio "%{group}" було заплановано на видалення користувачем %{requester}. Її буде видалено назавжди через 2 тижні.
+      trial_expired: Ваша група Loomio "%{group}" перебуває на пробній версії, термін дії якої закінчився, щонайменше 60 днів. Її буде остаточно видалено через 2 тижні.
+      subscription_canceled: Ваша група Loomio "%{group}" має скасовану підписку щонайменше 60 днів тому. Її буде остаточно видалено через 2 тижні.
+      usage_heading: 'Зведена інформація про групу:'
+      subgroups: Підгрупи
+      members: Поточні члени
+      discussions: Обговорення
+      polls: Опитування
+      comments: Коментарі
+      export: Щоб зберегти групу або експортувати копію її даних, дайте відповідь на цей електронний лист протягом 2 тижнів. Ми можемо відновити доступ до видалення.
+      export_link: Дізнайтеся про експорт даних групи
+      group_key: 'Ключ групи: %{key}'
   poll_mailer:
     common:
       why_send_this: Ви отримали цей лист, тому що %{reason}

--- a/config/locales/server.zh_CN.yml
+++ b/config/locales/server.zh_CN.yml
@@ -576,7 +576,7 @@ zh_CN:
       subject:
         votes_to_cast:
           one: You have 1 vote to cast
-          other: "You have %{count} votes to cast"
+          other: You have %{count} votes to cast
         people_mentioned:
           one: 1 person mentioned you
           other: "%{count} people mentioned you"
@@ -595,12 +595,11 @@ zh_CN:
       thanks_for_reading: 感谢阅读，祝您度过美好的一天！
       marked_as_read_success: 邮件中的所有内容均已标记为已读
       click_here: 点击这里
-
     digest:
       subject:
         votes_to_cast:
           one: You have 1 vote to cast
-          other: "You have %{count} votes to cast"
+          other: You have %{count} votes to cast
         people_mentioned:
           one: 1 person mentioned you
           other: "%{count} people mentioned you"
@@ -677,6 +676,20 @@ zh_CN:
     trial_expired:
       subject: 由于长时间未活动，您的 Loomio 群组将被删除。
       body: 您的 Loomio 群组“%{group}”已处于不活跃状态，将在两周后被删除。如果您不希望您的群组被删除，请回复此邮件。
+    destroy_warning_with_usage:
+      subject: 您的 Loomio 群组已被安排删除
+      requested: 您的 Loomio 群组“%{group}”已被 %{requester} 安排删除。该群组将在 2 周后永久删除。
+      trial_expired: 您的 Loomio 群组“%{group}”已处于试用期至少 60 天，试用期已过期。该群组将在 2 周后被永久删除。
+      subscription_canceled: 您的 Loomio 群组“%{group}”的订阅已取消至少 60 天。它将在 2 周后被永久删除。
+      usage_heading: 组数据汇总：
+      subgroups: 亚组
+      members: 现任成员
+      discussions: 讨论
+      polls: 民意调查
+      comments: 评论
+      export: 如需保留该群组或导出其数据副本，请在两周内回复此邮件。我们可以在删除前恢复访问权限。
+      export_link: 了解如何导出群组数据
+      group_key: 组键：%{key}
   forward_mailer:
     bounce:
       subject: 您发送给 Loomio 的消息未送达

--- a/config/locales/server.zh_TW.yml
+++ b/config/locales/server.zh_TW.yml
@@ -332,7 +332,7 @@ zh_TW:
       subject:
         votes_to_cast:
           one: You have 1 vote to cast
-          other: "You have %{count} votes to cast"
+          other: You have %{count} votes to cast
         people_mentioned:
           one: 1 person mentioned you
           other: "%{count} people mentioned you"
@@ -351,12 +351,11 @@ zh_TW:
       thanks_for_reading: 感謝您的閱讀，祝您有美好的一天！
       marked_as_read_success: 電子郵件所列的討論串現在設為已讀了
       click_here: 點這邊
-
     digest:
       subject:
         votes_to_cast:
           one: You have 1 vote to cast
-          other: "You have %{count} votes to cast"
+          other: You have %{count} votes to cast
         people_mentioned:
           one: 1 person mentioned you
           other: "%{count} people mentioned you"
@@ -443,6 +442,20 @@ zh_TW:
     trial_expired:
       subject: 由於長時間未活動，您的 Loomio 群組將被刪除。
       body: 您的 Loomio 群組「%{group}」已處於不活躍狀態，將在兩週後被刪除。如果您不希望您的群組被刪除，請回覆此郵件。
+    destroy_warning_with_usage:
+      subject: 您的 Loomio 群組已被安排刪除
+      requested: 您的 Loomio 群組「%{group}」已被 %{requester} 安排刪除。該群組將在 2 週後永久刪除。
+      trial_expired: 您的 Loomio 群組「%{group}」已處於試用期至少 60 天，試用期已過期。該群組將在 2 週後永久刪除。
+      subscription_canceled: 您的 Loomio 群組「%{group}」的訂閱已取消至少 60 天。它將在 2 週後永久刪除。
+      usage_heading: 群組資料匯總：
+      subgroups: 亞組
+      members: 現任成員
+      discussions: 討論
+      polls: 民調
+      comments: 評論
+      export: 如需保留該群組或匯出其資料副本，請在兩週內回覆此郵件。我們可以在刪除前恢復存取權限。
+      export_link: 了解如何匯出群組數據
+      group_key: 組鍵：%{key}
   poll_mailer:
     common:
       why_send_this: 因為 %{reason}，您收到了這封電子郵件

--- a/config/locales/translation_corrections.md
+++ b/config/locales/translation_corrections.md
@@ -345,3 +345,11 @@ languages in the Nov 2025 pass.
 | `config/locales/client.tr.yml` | `change_volume_form.apply_to_all_threads_in_group` | `Bu ayarları %{group} içindeki tüm iş parçacıklarına uygulayın.` | `Bu ayarları %{group} içindeki tüm konulara uygula` | Formal imperative, software-thread terminology, and final full stop |
 | `config/locales/client.zh_CN.yml` | `change_volume_form.apply_to_all_threads_in_group` | `将这些设置应用于 %{group} 中的所有线程` | `将这些设置应用于 %{group} 中的所有讨论主题` | Used software-execution-thread terminology instead of discussion topics |
 | `config/locales/client.zh_TW.yml` | `change_volume_form.apply_to_all_threads_in_group` | `將這些設定應用於 %{group} 中的所有線程` | `將這些設定套用至 %{group} 中的所有討論串` | Used software-execution-thread terminology instead of discussion threads |
+
+## 2026-09-09 — Group deletion warnings
+
+| File | Key | Before | After | Why it was wrong |
+|------|-----|--------|-------|------------------|
+| `config/locales/server.it.yml` | `group_mailer.destroy_warning_with_usage.group_key` | `%{chiave}` | `%{key}` | Translation renamed the interpolation variable, which would raise when rendering the email |
+| `config/locales/server.nl_NL.yml` | `group_mailer.destroy_warning_with_usage.group_key` | `%{sleutel}` | `%{key}` | Translation renamed the interpolation variable, which would raise when rendering the email |
+| `config/locales/server.ru.yml` | `group_mailer.destroy_warning_with_usage.group_key` | `%{ключ}` | `%{key}` | Translation renamed the interpolation variable, which would raise when rendering the email |

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -56,9 +56,9 @@ Rails.application.routes.draw do
       member do
         post :move
         post :handle
-        post :discard
         post :undiscard
-        post :delete_group
+        post :warn_then_destroy
+        post :destroy_immediately
         post :export_group
       end
     end

--- a/docs/cleanup_safety.md
+++ b/docs/cleanup_safety.md
@@ -27,3 +27,23 @@ New `DestroyGroupWorker` jobs carry the exact discard timestamp recorded when de
 Account-merge duplicate removal, reference migration, credential revocation, and search updates are transactional. Avatar purges, newsletter changes, and email are deferred until commit. Blocklist and email-routing replacements retain the previous table contents if replacement fails. Concurrent group exports use separate temporary paths.
 
 Demo expiry is unchanged while the replacement demo system is being developed. Deployment scripts are outside this change.
+
+Inactive orphan-user cleanup processes at most 100 accounts per daily run. Its reference columns are indexed so the eligibility query and the write-locked per-account recheck do not repeatedly scan large tables. A backlog is drained over multiple days instead of creating an unbounded maintenance run.
+
+## Daily empty expired-trial cleanup
+
+`HourlyTaskJob` enqueues `CleanupEmptyTrialsWorker` at midnight UTC each day, enabled by default. It deletes trial organisations whose subscription expired at least 60 days ago and whose entire group tree contains no topics. Root or subgroup discard status does not affect eligibility because expiry and emptiness independently authorize this cleanup. Actual topic rows determine emptiness, including discarded topics and topics in discarded descendants; counter caches are not used. Standalone polls count as topics. Direct topics and user accounts are preserved. Memberships, templates and uploads do not prevent deletion of a topic-free trial.
+
+Billing references, subscriptions shared by root organisations, and descendants with a different subscription exclude the tree. Each tree is rechecked immediately before normal group destruction, without explicit table or row locks. The worker logs its candidate IDs, before/after counts and individual deletion results as JSON lines. Remaining orphan metadata is handled by orphan cleanup. This does not enable warning or scheduled deletion of trials containing topics.
+
+For a read-only inventory, run `bin/rails loomio:audit_empty_expired_trials`. For a manual run, use `AUDIT_PATH=/private/path/empty-trials.jsonl bin/rails loomio:delete_empty_expired_trials`; the audit file must not already exist. Either task accepts an optional positive `LIMIT` of root organisations. Keep audit files private and confirm the database connection before deletion. Seeded topics must be cleaned separately before they can stop counting against eligibility.
+
+The tests reuse the lifecycle group fixture matrix and extend it with trial expiry, billing, shared-subscription and standalone-poll cases. They compare exact surviving group, topic and user IDs after the daily worker runs.
+
+## Daily expired-subscription warnings
+
+`HourlyTaskJob` also enqueues `WarnExpiredSubscriptionGroupsWorker` at midnight UTC. It processes up to 100 undiscarded root groups per day. A group becomes eligible when its trial expired at least 60 days ago or its subscription was cancelled at least 60 days ago. An expired trial that is eligible for immediate topic-free cleanup is excluded from the warning path, so the two daily tasks cannot act on the same group.
+
+Each eligible group is discarded once, its administrators are emailed, and permanent deletion is scheduled for two weeks later using the exact discard timestamp. The email explains why deletion was scheduled, gives tree-wide counts for subgroups, current members, discussions, polls and comments, and directs the recipient to reply if they need access restored before exporting their data. The worker records the full plan, usage counts, warnings, skips and completion totals as JSON lines.
+
+Run `bin/rails loomio:audit_expired_subscription_groups` for a read-only inventory. Set a positive `LIMIT` to inspect the same leading batch the worker would process.

--- a/docs/user_manual/changelog/2026-09-08_empty_trial_cleanup.md
+++ b/docs/user_manual/changelog/2026-09-08_empty_trial_cleanup.md
@@ -1,0 +1,3 @@
+## Empty expired trial groups
+
+Empty trial groups are now deleted automatically once their trial has been expired for at least 60 days. A group is eligible only when it and all its subgroups contain no discussions or polls, including discarded topics. User accounts and direct discussions are kept.

--- a/docs/user_manual/groups/deleting_your_group/index.md
+++ b/docs/user_manual/groups/deleting_your_group/index.md
@@ -12,6 +12,8 @@ Groups awaiting deletion and their subgroups are unavailable for viewing or part
 
 Discarding the group stops pending activity notifications and poll reminders for the group and its subgroups. Messages already being sent may still arrive.
 
+The warning email includes counts for the group's subgroups, members, discussions, polls and comments. If you need to keep the group or [export its data](/en/user_manual/groups/data_export/), reply within two weeks so access can be restored before deletion.
+
 Deleting your group will also cancel your Loomio subscription.
 
 ![Delete group action in the Oatmilk Cooperative menu](group_delete_group.png)

--- a/lib/tasks/loomio.rake
+++ b/lib/tasks/loomio.rake
@@ -352,6 +352,24 @@ namespace :loomio do
     SeededContentCleanupService.audit
   end
 
+  desc "Report topic-free trial trees expired at least 60 days ago (optional LIMIT)"
+  task audit_empty_expired_trials: :environment do
+    puts EmptyTrialCleanupService.audit(limit: ENV['LIMIT'].presence&.to_i).to_json
+  end
+
+  desc "Audit groups due for an expired-subscription deletion warning"
+  task audit_expired_subscription_groups: :environment do
+    limit = ENV["LIMIT"].present? ? Integer(ENV["LIMIT"], 10) : nil
+    puts JSON.pretty_generate(ExpiredSubscriptionGroupCleanupService.audit(limit: limit))
+  end
+
+  desc "Delete topic-free trial trees expired at least 60 days ago; requires a new AUDIT_PATH (optional LIMIT)"
+  task delete_empty_expired_trials: :environment do
+    File.open(ENV.fetch('AUDIT_PATH'), File::WRONLY | File::CREAT | File::EXCL, 0600) do |io|
+      puts EmptyTrialCleanupService.delete!(io: io, limit: ENV['LIMIT'].presence&.to_i).to_json
+    end
+  end
+
   desc "Delete untouched legacy seeded discussions and polls. Supports LIMIT, SEEDED_CONTENT_TYPE, SHARD_COUNT, and SHARD_INDEX."
   task delete_unused_seeded_content: :environment do
     limit = ENV["LIMIT"].presence&.to_i

--- a/test/controllers/admin/groups_controller_test.rb
+++ b/test/controllers/admin/groups_controller_test.rb
@@ -44,7 +44,8 @@ class Admin::GroupsControllerTest < ActionController::TestCase
     assert_includes response.body, 'class="admin-operation-list"'
     assert_includes response.body, 'class="admin-panel admin-panel--operations"'
     assert_includes response.body, "Parent group ID or key"
-    assert_includes response.body, "Discard group"
+    assert_includes response.body, "Warn then delete"
+    assert_includes response.body, "Delete immediately"
     assert_includes response.body, "all of its subgroups"
     assert_includes response.body, "memberships and membership requests"
     assert_includes response.body, "User accounts and subscriptions are retained"
@@ -119,12 +120,9 @@ class Admin::GroupsControllerTest < ActionController::TestCase
     end
   end
 
-  test "admin can discard and restore a group" do
+  test "admin can restore a discarded group" do
     sign_in @admin
-    post :discard, params: { id: @group.id }
-    assert @group.reload.discarded_at
-    assert_equal @admin.id, @group.discarded_by
-
+    @group.discard!(actor: @admin)
     post :undiscard, params: { id: @group.id }
     assert_nil @group.reload.discarded_at
     assert_nil @group.discarded_by
@@ -133,18 +131,25 @@ class Admin::GroupsControllerTest < ActionController::TestCase
   test "admin group operations call the group service" do
     sign_in @admin
     moved = false
-    destroyed_id = nil
+    warned = false
+    destroyed_immediately = false
 
     GroupService.stub(:move, ->(group:, parent:, actor:) { moved = group == @group && parent == groups(:public_group) && actor == @admin }) do
       post :move, params: { id: @group.id, parent_id: groups(:public_group).id }
     end
     assert moved
 
-    GroupService.stub(:destroy_without_warning!, ->(id, actor:) { destroyed_id = id if actor == @admin }) do
-      post :delete_group, params: { id: @group.id }
+    GroupService.stub(:warn_then_destroy, ->(group:, actor:) { warned = group == @group && actor == @admin }) do
+      post :warn_then_destroy, params: { id: @group.id }
     end
-    assert_equal @group.id, destroyed_id
-    assert_equal "Group deletion scheduled", flash[:notice]
+    assert warned
+    assert_equal "Group administrators warned; deletion scheduled in 2 weeks", flash[:notice]
+
+    GroupService.stub(:destroy_immediately!, ->(id, actor:) { destroyed_immediately = id == @group.id && actor == @admin }) do
+      post :destroy_immediately, params: { id: @group.id }
+    end
+    assert destroyed_immediately
+    assert_equal "Group deletion scheduled immediately", flash[:notice]
   end
 
   test "admin can schedule trial groups for spam deletion" do

--- a/test/fixtures/groups.yml
+++ b/test/fixtures/groups.yml
@@ -218,3 +218,65 @@ used_recent_subgroup:
   parent: used_recent_subgroup_tree
   created_at: <%= 1.day.ago %>
   updated_at: <%= 1.day.ago %>
+
+# Daily empty-trial cleanup eligibility matrix.
+trial_cleanup_recent:
+  name: Trial cleanup recent
+  creator: user
+  created_at: <%= 2.years.ago %>
+  subscription: trial_cleanup_recent
+
+trial_cleanup_no_expiry:
+  name: Trial cleanup no_expiry
+  creator: user
+  created_at: <%= 2.years.ago %>
+  subscription: trial_cleanup_no_expiry
+
+trial_cleanup_discarded:
+  name: Trial cleanup discarded
+  creator: user
+  created_at: <%= 2.years.ago %>
+  subscription: trial_cleanup_discarded
+  discarded_at: <%= 1.day.ago %>
+
+trial_cleanup_poll:
+  name: Trial cleanup poll
+  creator: user
+  created_at: <%= 2.years.ago %>
+  subscription: trial_cleanup_poll
+
+trial_cleanup_billing:
+  name: Trial cleanup billing
+  creator: user
+  created_at: <%= 2.years.ago %>
+  subscription: trial_cleanup_billing
+
+trial_cleanup_chargify:
+  name: Trial cleanup chargify
+  creator: user
+  created_at: <%= 2.years.ago %>
+  subscription: trial_cleanup_chargify
+
+trial_cleanup_shared:
+  name: Trial cleanup shared
+  creator: user
+  created_at: <%= 2.years.ago %>
+  subscription: trial_cleanup_shared
+
+trial_cleanup_shared_other:
+  name: Trial cleanup shared_other
+  creator: user
+  created_at: <%= 2.years.ago %>
+  subscription: trial_cleanup_shared
+
+trial_cleanup_child_subscription:
+  name: Trial cleanup child_subscription
+  creator: user
+  created_at: <%= 2.years.ago %>
+  subscription: trial_cleanup_child_subscription
+
+trial_cleanup_subscribed_child:
+  name: Trial cleanup subscribed_child
+  parent: trial_cleanup_child_subscription
+  creator: user
+  subscription: cleanup_active_paid

--- a/test/fixtures/polls.yml
+++ b/test/fixtures/polls.yml
@@ -1,1 +1,7 @@
 # Polls are created in tests via PollService.create
+
+trial_cleanup_poll:
+  key: trclpoll
+  title: Trial cleanup standalone poll
+  poll_type: proposal
+  author: user

--- a/test/fixtures/subscriptions.yml
+++ b/test/fixtures/subscriptions.yml
@@ -27,3 +27,37 @@ cleanup_canceled_free:
   canceled_at: <%= 1.year.ago %>
   created_at: <%= 2.years.ago %>
   updated_at: <%= 1.year.ago %>
+
+# Daily empty-trial cleanup eligibility matrix.
+trial_cleanup_recent:
+  plan: trial
+  expires_at: <%= 59.days.ago %>
+
+trial_cleanup_no_expiry:
+  plan: trial
+
+trial_cleanup_discarded:
+  plan: trial
+  expires_at: <%= 60.days.ago.beginning_of_day %>
+
+trial_cleanup_poll:
+  plan: trial
+  expires_at: <%= 60.days.ago.beginning_of_day %>
+
+trial_cleanup_billing:
+  plan: trial
+  expires_at: <%= 60.days.ago.beginning_of_day %>
+  billing_service_subscription_id: trial-cleanup-billing
+
+trial_cleanup_chargify:
+  plan: trial
+  expires_at: <%= 60.days.ago.beginning_of_day %>
+  chargify_subscription_id: 123456
+
+trial_cleanup_shared:
+  plan: trial
+  expires_at: <%= 60.days.ago.beginning_of_day %>
+
+trial_cleanup_child_subscription:
+  plan: trial
+  expires_at: <%= 60.days.ago.beginning_of_day %>

--- a/test/fixtures/topics.yml
+++ b/test/fixtures/topics.yml
@@ -76,3 +76,8 @@ cleanup_discarded_topic:
   discarded_at: <%= 1.year.ago %>
   created_at: <%= 2.years.ago %>
   updated_at: <%= 1.year.ago %>
+
+trial_cleanup_poll:
+  topicable: trial_cleanup_poll (Poll)
+  group: trial_cleanup_poll
+  private: true

--- a/test/jobs/hourly_task_job_test.rb
+++ b/test/jobs/hourly_task_job_test.rb
@@ -32,4 +32,17 @@ class HourlyTaskJobTest < ActiveSupport::TestCase
       end
     end
   end
+
+  test "enqueues empty trial cleanup only at midnight UTC" do
+    travel_to Time.utc(2026, 9, 8) do
+      assert_enqueued_with(job: WarnExpiredSubscriptionGroupsWorker) do
+        assert_enqueued_with(job: CleanupEmptyTrialsWorker) { HourlyTaskJob.perform_now }
+      end
+    end
+    travel_to Time.utc(2026, 9, 8, 12) do
+      assert_no_enqueued_jobs(only: WarnExpiredSubscriptionGroupsWorker) do
+        assert_no_enqueued_jobs(only: CleanupEmptyTrialsWorker) { HourlyTaskJob.perform_now }
+      end
+    end
+  end
 end

--- a/test/mailers/group_mailer_test.rb
+++ b/test/mailers/group_mailer_test.rb
@@ -1,0 +1,31 @@
+require "test_helper"
+
+class GroupMailerTest < ActionMailer::TestCase
+  test "deletion warning includes usage and export instructions" do
+    group = groups(:group)
+    recipient = users(:admin)
+    usage = GroupUsageSummary.for(group)
+
+    email = GroupMailer.destroy_warning(group.id, recipient.id, nil, "trial_expired")
+    body = email.body.decoded
+
+    assert_equal "Your Loomio group is scheduled for deletion", email.subject
+    assert_includes body, "expired trial for at least 60 days"
+    assert_includes body, "Subgroups: #{usage[:subgroups]}"
+    assert_includes body, "Current members: #{usage[:members]}"
+    assert_includes body, "Discussions: #{usage[:discussions]}"
+    assert_includes body, "Polls: #{usage[:polls]}"
+    assert_includes body, "Comments: #{usage[:comments]}"
+    assert_includes body, "reply to this email within 2 weeks"
+    assert_includes body, "https://help.loomio.org/en/user_manual/groups/data_export/"
+  end
+
+  test "requested deletion warning identifies the requester" do
+    group = groups(:group)
+    requester = users(:admin)
+
+    email = GroupMailer.destroy_warning(group.id, requester.id, requester.id)
+
+    assert_includes email.body.decoded, "scheduled for deletion by #{requester.name}"
+  end
+end

--- a/test/services/empty_trial_cleanup_service_test.rb
+++ b/test/services/empty_trial_cleanup_service_test.rb
@@ -1,0 +1,93 @@
+require 'test_helper'
+require 'stringio'
+
+class EmptyTrialCleanupServiceTest < ActiveSupport::TestCase
+  setup do
+    @cutoff = subscriptions(:trial_cleanup_discarded).expires_at
+    # Reuse the lifecycle matrix, assigning expired trials only within this test.
+    @root = groups(:orphan_group_tree)
+    @child = groups(:orphan_subgroup)
+    @child.update_columns(discarded_at: 1.day.ago)
+    @eligible_names = [:orphan_group_tree, :used_multiple_members_group,
+                       :used_revoked_membership_tree, :used_discussion_template_group,
+                       :used_poll_template_group, :used_attachment_group]
+    (@eligible_names + [:used_topic_group, :used_discarded_topic_tree]).each do |name|
+      groups(name).update_columns(subscription_id: Subscription.create!(plan: 'trial', expires_at: @cutoff).id)
+    end
+    groups(:used_recent_subgroup).update_columns(parent_id: groups(:used_discarded_topic_tree).id)
+    groups(:used_discarded_topic_subgroup).update_columns(discarded_at: 1.day.ago, parent_id: groups(:used_recent_subgroup).id)
+    [:cleanup_active_free, :cleanup_active_paid, :cleanup_canceled_free].each do |name|
+      subscriptions(name).update_columns(expires_at: @cutoff)
+    end
+    @tree_ids = [@root.id, @child.id].sort
+    @eligible_ids = (@eligible_names.map { |name| groups(name).id } + [groups(:trial_cleanup_discarded).id]).sort
+    @deleted_ids = (@eligible_ids + [@child.id, groups(:used_revoked_membership_subgroup).id]).sort
+  end
+
+  test 'fixture matrix excludes every ineligible tree using actual topics rather than counters' do
+    plan = EmptyTrialCleanupService.audit(expires_before: @cutoff)
+    assert_equal @eligible_ids, plan[:root_ids].sort
+    assert_equal @tree_ids, plan[:trees][@root.id]
+    assert_equal 0, groups(:used_topic_group).discussions_count
+    assert_equal 0, groups(:trial_cleanup_poll).polls_count
+    assert topics(:cleanup_discarded_topic).discarded_at
+    assert groups(:trial_cleanup_discarded).discarded_at
+    assert Group.exists?(@root.id), 'audit must not delete'
+  end
+
+  test 'daily worker deletes only eligible groups and memberships while preserving other groups accounts and direct topics' do
+    membership = @root.add_member!(users(:user))
+    @child.add_member!(users(:member))
+    groups_before = Group.ids.sort
+    users_before = User.ids.sort
+    topics_before = Topic.ids.sort
+    assert_no_enqueued_jobs(only: ActionMailer::MailDeliveryJob) do
+      capture_io { CleanupEmptyTrialsWorker.perform_now }
+    end
+    assert_equal groups_before - @deleted_ids, Group.ids.sort
+    assert_not Membership.exists?(membership.id)
+    assert_equal users_before, User.ids.sort
+    assert_equal topics_before, Topic.ids.sort
+    assert Topic.exists?(topics(:direct_topic).id)
+  end
+
+  test 'eligibility starts exactly sixty days after expiry' do
+    travel_to @cutoff + 60.days - 1.second do
+      assert_not_includes EmptyTrialCleanupService.audit[:root_ids], @root.id
+    end
+    travel_to @cutoff + 60.days do
+      assert_includes EmptyTrialCleanupService.audit[:root_ids], @root.id
+    end
+  end
+
+  test 'rechecks eligibility and preserves a tree that gains a topic after planning' do
+    original = EmptyTrialCleanupService.method(:audit)
+    replacement = lambda do |**args|
+      plan = original.call(**args)
+      discussions(:discussion).topic.update_columns(group_id: @root.id)
+      plan
+    end
+    io = StringIO.new
+    result = EmptyTrialCleanupService.stub(:audit, replacement) do
+      EmptyTrialCleanupService.delete!(io: io, expires_before: @cutoff)
+    end
+    assert Group.exists?(@root.id)
+    assert_equal 1, result[:skipped_roots]
+    assert io.string.lines.map { |line| JSON.parse(line) }.any? { |entry| entry['type'] == 'skipped' && entry['root_id'] == @root.id }
+  end
+
+  test 'manual deletion honors limits and records exact deleted tree IDs' do
+    plan = EmptyTrialCleanupService.audit(expires_before: @cutoff, limit: 1)
+    tree_ids = plan[:group_ids]
+    groups_before = Group.ids.sort
+    io = StringIO.new
+    result = EmptyTrialCleanupService.delete!(io: io, expires_before: @cutoff, limit: 1)
+    assert_equal({deleted_roots: 1, deleted_groups: tree_ids.size, skipped_roots: 0}, result)
+    assert_equal groups_before - tree_ids, Group.ids.sort
+    entries = io.string.lines.map { |line| JSON.parse(line) }
+    assert_equal tree_ids, entries.find { |e| e['type'] == 'deleted' }['group_ids']
+    assert_equal 'plan', entries.first['type']
+    assert_equal 'complete', entries.last['type']
+    assert_raises(ArgumentError) { EmptyTrialCleanupService.audit(limit: 0) }
+  end
+end

--- a/test/services/expired_subscription_group_cleanup_service_test.rb
+++ b/test/services/expired_subscription_group_cleanup_service_test.rb
@@ -1,0 +1,96 @@
+require "test_helper"
+require "stringio"
+
+class ExpiredSubscriptionGroupCleanupServiceTest < ActiveSupport::TestCase
+  test "fixture matrix selects old expired trials and cancellations without overlapping empty trial deletion" do
+    expected = groups(
+      :used_canceled_free_group,
+      :trial_cleanup_poll,
+      :trial_cleanup_billing,
+      :trial_cleanup_chargify,
+      :trial_cleanup_shared,
+      :trial_cleanup_shared_other,
+      :trial_cleanup_child_subscription
+    ).map(&:id).sort
+
+    plan = ExpiredSubscriptionGroupCleanupService.audit
+
+    assert_equal expected, plan[:groups].pluck(:group_id).sort
+    reasons = plan[:groups].to_h { |entry| [entry[:group_id], entry[:reason]] }
+    assert_equal "subscription_canceled", reasons.fetch(groups(:used_canceled_free_group).id)
+    (expected - [groups(:used_canceled_free_group).id]).each do |group_id|
+      assert_equal "trial_expired", reasons.fetch(group_id)
+    end
+    assert_not_includes expected, groups(:trial_cleanup_recent).id
+    assert_not_includes expected, groups(:trial_cleanup_no_expiry).id
+    assert_not_includes expected, groups(:trial_cleanup_discarded).id
+  end
+
+  test "eligibility starts sixty days after trial expiry or cancellation" do
+    as_of = Time.current
+    trial_group = groups(:trial_cleanup_recent)
+    topics(:direct_topic).update!(group_id: trial_group.id)
+    canceled_group = groups(:used_canceled_free_group)
+
+    trial_group.subscription.update!(expires_at: as_of - 60.days + 1.second)
+    canceled_group.subscription.update!(canceled_at: as_of - 60.days + 1.second)
+    assert_not_includes ExpiredSubscriptionGroupCleanupService.audit(as_of: as_of)[:groups].pluck(:group_id), trial_group.id
+    assert_not_includes ExpiredSubscriptionGroupCleanupService.audit(as_of: as_of)[:groups].pluck(:group_id), canceled_group.id
+
+    trial_group.subscription.update!(expires_at: as_of - 60.days)
+    canceled_group.subscription.update!(canceled_at: as_of - 60.days)
+    assert_includes ExpiredSubscriptionGroupCleanupService.audit(as_of: as_of)[:groups].pluck(:group_id), trial_group.id
+    assert_includes ExpiredSubscriptionGroupCleanupService.audit(as_of: as_of)[:groups].pluck(:group_id), canceled_group.id
+
+    canceled_group.subscription.update!(canceled_at: nil)
+    assert_not_includes ExpiredSubscriptionGroupCleanupService.audit(as_of: as_of)[:groups].pluck(:group_id), canceled_group.id
+  end
+
+  test "warns once, records the plan, and schedules exact deletion and email jobs" do
+    plan = ExpiredSubscriptionGroupCleanupService.audit(limit: 1)
+    group = Group.find(plan[:groups].first.fetch(:group_id))
+    group.add_admin!(users(:admin))
+    clear_enqueued_jobs
+    io = StringIO.new
+
+    assert_enqueued_with(job: ActionMailer::MailDeliveryJob) do
+      assert_enqueued_with(job: DestroyGroupWorker) do
+        result = ExpiredSubscriptionGroupCleanupService.warn_and_schedule!(io: io, limit: 1)
+        assert_equal({ warned_groups: 1, skipped_groups: 0 }, result)
+      end
+    end
+
+    assert group.reload.discarded?
+    assert_nil group.discarded_by
+    assert_equal %w[plan warned complete], io.string.lines.map { |line| JSON.parse(line).fetch("type") }
+    assert_empty ExpiredSubscriptionGroupCleanupService.audit[:groups].select { |entry| entry[:group_id] == group.id }
+  end
+
+  test "rechecks eligibility before warning" do
+    original = ExpiredSubscriptionGroupCleanupService.method(:audit)
+    replacement = lambda do |**args|
+      plan = original.call(**args.merge(limit: 1))
+      Group.find(plan[:groups].first.fetch(:group_id)).subscription.update!(expires_at: 1.year.from_now, state: "active", canceled_at: nil)
+      plan
+    end
+    io = StringIO.new
+
+    result = ExpiredSubscriptionGroupCleanupService.stub(:audit, replacement) do
+      ExpiredSubscriptionGroupCleanupService.warn_and_schedule!(io: io)
+    end
+
+    assert_equal({ warned_groups: 0, skipped_groups: 1 }, result)
+    assert io.string.lines.map { |line| JSON.parse(line) }.any? { |entry| entry["type"] == "skipped" }
+  end
+
+  test "subscription warning cannot discard active or permanent free groups" do
+    [groups(:used_paid_group), groups(:orphan_group)].each do |group|
+      assert_no_enqueued_jobs(only: DestroyGroupWorker) do
+        assert_raises(CanCan::AccessDenied) do
+          GroupService.warn_then_destroy_subscription(group: group, reason: "subscription_canceled")
+        end
+      end
+      assert group.reload.kept?
+    end
+  end
+end

--- a/test/services/group_usage_summary_test.rb
+++ b/test/services/group_usage_summary_test.rb
@@ -1,0 +1,24 @@
+require "test_helper"
+
+class GroupUsageSummaryTest < ActiveSupport::TestCase
+  test "counts exportable activity across the complete group tree" do
+    admin = users(:admin)
+    member = users(:member)
+    group = Group.create!(name: "Usage summary root", group_privacy: "secret", creator: admin)
+    group.add_admin!(admin)
+    subgroup = Group.create!(name: "Usage summary child", group_privacy: "secret", creator: admin, parent: group)
+    subgroup.add_member!(member)
+    discussion = DiscussionService.create(params: { title: "Usage discussion", group_id: group.id }, actor: admin)
+    CommentService.create(comment: Comment.new(parent: discussion, body: "Usage comment"), actor: admin)
+    PollService.create(
+      params: {
+        title: "Usage poll", poll_type: "proposal", poll_option_names: %w[Yes No],
+        closing_at: 1.day.from_now, topic_id: discussion.topic_id
+      },
+      actor: admin
+    )
+
+    assert_equal({ subgroups: 1, members: 2, discussions: 1, polls: 1, comments: 1 },
+                 GroupUsageSummary.for(group))
+  end
+end

--- a/test/workers/destroy_group_worker_test.rb
+++ b/test/workers/destroy_group_worker_test.rb
@@ -35,11 +35,11 @@ class DestroyGroupWorkerTest < ActiveSupport::TestCase
     assert Group.exists?(group.id)
   end
 
-  test "immediate deletion schedules the discard it actually performed" do
+  test "immediate administrative deletion schedules the discard it actually performed" do
     group = groups(:orphan_group)
     actor = users(:admin)
     assert_enqueued_with(job: DestroyGroupWorker, args: ->(args) { args == [ group.id, group.reload.discarded_at.iso8601(6) ] }) do
-      GroupService.destroy_without_warning!(group.id, actor: actor)
+      GroupService.destroy_immediately!(group.id, actor: actor)
     end
     assert_equal actor.id, group.reload.discarded_by
   end
@@ -69,13 +69,13 @@ class DestroyGroupWorkerTest < ActiveSupport::TestCase
     assert_equal actor.id, group.reload.discarded_by
   end
 
-  test "instance administrators can schedule group deletion" do
+  test "instance administrators can use the warning deletion path" do
     actor = users(:alien)
     actor.update!(is_admin: true)
     group = topics(:discussion_topic).group
 
     assert_enqueued_with(job: DestroyGroupWorker) do
-      GroupService.destroy(group: group, actor: actor)
+      GroupService.warn_then_destroy(group: group, actor: actor)
     end
     assert_equal actor.id, group.reload.discarded_by
   end

--- a/test/workers/warn_expired_subscription_groups_worker_test.rb
+++ b/test/workers/warn_expired_subscription_groups_worker_test.rb
@@ -1,0 +1,16 @@
+require "test_helper"
+
+class WarnExpiredSubscriptionGroupsWorkerTest < ActiveSupport::TestCase
+  test "processes a bounded daily batch" do
+    called = false
+    replacement = lambda do |io:, limit:|
+      called = io == $stdout && limit == WarnExpiredSubscriptionGroupsWorker::BATCH_SIZE
+    end
+
+    ExpiredSubscriptionGroupCleanupService.stub(:warn_and_schedule!, replacement) do
+      WarnExpiredSubscriptionGroupsWorker.perform_now
+    end
+
+    assert called
+  end
+end


### PR DESCRIPTION
Expired trial cleanup needs two paths based on whether the group tree contains user content. Topic-free trial trees are deleted automatically 60 days after expiry; trials with topics and subscriptions cancelled for 60 days are discarded, their administrators are warned, and permanent deletion is scheduled two weeks later.

Warning emails include tree-wide counts for subgroups, current members, discussions, polls, and comments, plus data-export guidance and a reply path for restoration. The daily workers recheck eligibility before acting, exclude billed/shared subscription trees from empty cleanup, process warning candidates oldest-first in bounded batches, and write structured audit records. Instance administrators retain an immediate deletion option.

This PR is stacked on #12835 because it uses the new group discard lifecycle and availability contract.

Validation:

- 206 focused Rails tests, 1,955 assertions
- Fixture matrix covers recent/no-expiry/discarded/content-bearing/billed/shared/child-subscription groups
- Direct discussion and `NullGroup` behavior remains covered by #12835
- RuboCop syntax checks on all warning and cleanup paths
- User manual build: 94 pages and 10,623 internal links/assets
- Brakeman: 0 warnings
- Bundler Audit: no vulnerabilities
- New server strings translated across all supported locales; interpolation variables verified
