### PR TITLE
Enforce membership user and group references

### DIFF
--- a/app/services/cleanup_service.rb
+++ b/app/services/cleanup_service.rb
@@ -7,7 +7,6 @@
 # The following audits are temporary and should be removed after the named
 # foreign keys have been deployed and validated:
 # - groups_missing_parent: groups.parent_id -> groups.id
-# - memberships_missing_group: memberships.group_id -> groups.id
 # - membership_requests_missing_group: membership_requests.group_id -> groups.id
 # - discussions_missing_group and polls_missing_group: the topics.group_id key
 #   plus cascading topicable lifecycle keys
@@ -116,7 +115,6 @@ module CleanupService
 
   DANGLING_RECORD_SCOPES = {
     "Group.missing_parent" => :groups_missing_parent,
-    "Membership.missing_group" => :memberships_missing_group,
     "MembershipRequest.missing_group" => :membership_requests_missing_group,
     "GroupSurvey.missing_group" => :group_surveys_missing_group,
     "ReceivedEmail.missing_group" => :received_emails_missing_group,
@@ -336,12 +334,6 @@ module CleanupService
     Group
       .joins('LEFT JOIN groups parents ON parents.id = groups.parent_id')
       .where('groups.parent_id IS NOT NULL AND parents.id IS NULL')
-  end
-
-  def self.memberships_missing_group
-    Membership
-      .joins('LEFT JOIN groups g ON memberships.group_id = g.id')
-      .where('memberships.group_id IS NOT NULL AND g.id IS NULL')
   end
 
   def self.membership_requests_missing_group

--- a/db/migrate/20260909000001_normalize_membership_reference_integrity.rb
+++ b/db/migrate/20260909000001_normalize_membership_reference_integrity.rb
@@ -1,0 +1,40 @@
+require_relative "support/membership_reference_integrity_cleanup"
+
+class NormalizeMembershipReferenceIntegrity < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def up
+    add_foreign_key :memberships,
+                    :groups,
+                    column: :group_id,
+                    on_delete: :cascade,
+                    validate: false,
+                    if_not_exists: true
+    add_foreign_key :memberships,
+                    :users,
+                    column: :user_id,
+                    on_delete: :cascade,
+                    validate: false,
+                    if_not_exists: true
+
+    add_check_constraint :memberships,
+                         "group_id IS NOT NULL",
+                         name: "memberships_group_id_not_null",
+                         validate: false,
+                         if_not_exists: true
+    add_check_constraint :memberships,
+                         "user_id IS NOT NULL",
+                         name: "memberships_user_id_not_null",
+                         validate: false,
+                         if_not_exists: true
+
+    MembershipReferenceIntegrityCleanup.run!(connection)
+  end
+
+  def down
+    remove_check_constraint :memberships, name: "memberships_user_id_not_null", if_exists: true
+    remove_check_constraint :memberships, name: "memberships_group_id_not_null", if_exists: true
+    remove_foreign_key :memberships, column: :user_id, if_exists: true
+    remove_foreign_key :memberships, column: :group_id, if_exists: true
+  end
+end

--- a/db/migrate/20260909000002_validate_membership_reference_integrity.rb
+++ b/db/migrate/20260909000002_validate_membership_reference_integrity.rb
@@ -1,0 +1,19 @@
+class ValidateMembershipReferenceIntegrity < ActiveRecord::Migration[8.1]
+  def up
+    validate_foreign_key :memberships, :groups, column: :group_id
+    validate_foreign_key :memberships, :users, column: :user_id
+    validate_check_constraint :memberships, name: "memberships_group_id_not_null"
+    validate_check_constraint :memberships, name: "memberships_user_id_not_null"
+
+    change_column_null :memberships, :group_id, false
+    change_column_null :memberships, :user_id, false
+
+    remove_check_constraint :memberships, name: "memberships_group_id_not_null"
+    remove_check_constraint :memberships, name: "memberships_user_id_not_null"
+  end
+
+  def down
+    change_column_null :memberships, :user_id, true
+    change_column_null :memberships, :group_id, true
+  end
+end

--- a/db/migrate/support/membership_reference_integrity_cleanup.rb
+++ b/db/migrate/support/membership_reference_integrity_cleanup.rb
@@ -1,0 +1,98 @@
+# Migration-owned cleanup for making every membership belong to an existing
+# user and group. Refresh the counters affected by callbackless deletion before
+# the foreign keys and non-null checks are validated.
+module MembershipReferenceIntegrityCleanup
+  def self.run!(connection)
+    connection.execute(<<~SQL)
+      CREATE TEMPORARY TABLE membership_reference_integrity_invalid AS
+      SELECT memberships.id, memberships.group_id, memberships.user_id
+      FROM memberships
+      WHERE memberships.group_id IS NULL
+         OR memberships.user_id IS NULL
+         OR NOT EXISTS (SELECT 1 FROM groups WHERE groups.id = memberships.group_id)
+         OR NOT EXISTS (SELECT 1 FROM users WHERE users.id = memberships.user_id)
+    SQL
+
+    connection.execute(<<~SQL)
+      DELETE FROM memberships
+      WHERE memberships.id IN (SELECT id FROM membership_reference_integrity_invalid)
+    SQL
+
+    refresh_group_counters!(connection)
+    refresh_user_counters!(connection)
+    refresh_organisation_counters!(connection)
+  ensure
+    connection.execute("DROP TABLE IF EXISTS membership_reference_integrity_invalid")
+  end
+
+  def self.refresh_group_counters!(connection)
+    connection.execute(<<~SQL)
+      UPDATE groups
+      SET memberships_count = (
+            SELECT COUNT(*) FROM memberships
+            WHERE memberships.group_id = groups.id AND memberships.revoked_at IS NULL
+          ),
+          pending_memberships_count = (
+            SELECT COUNT(*) FROM memberships
+            WHERE memberships.group_id = groups.id
+              AND memberships.revoked_at IS NULL
+              AND memberships.accepted_at IS NULL
+          ),
+          admin_memberships_count = (
+            SELECT COUNT(*) FROM memberships
+            WHERE memberships.group_id = groups.id
+              AND memberships.revoked_at IS NULL
+              AND memberships.admin = TRUE
+          ),
+          delegates_count = (
+            SELECT COUNT(*) FROM memberships
+            WHERE memberships.group_id = groups.id
+              AND memberships.revoked_at IS NULL
+              AND memberships.delegate = TRUE
+          )
+      WHERE groups.id IN (
+        SELECT DISTINCT group_id
+        FROM membership_reference_integrity_invalid
+        WHERE group_id IS NOT NULL
+      )
+    SQL
+  end
+  private_class_method :refresh_group_counters!
+
+  def self.refresh_user_counters!(connection)
+    connection.execute(<<~SQL)
+      UPDATE users
+      SET memberships_count = (
+        SELECT COUNT(*) FROM memberships
+        WHERE memberships.user_id = users.id AND memberships.revoked_at IS NULL
+      )
+      WHERE users.id IN (
+        SELECT DISTINCT user_id
+        FROM membership_reference_integrity_invalid
+        WHERE user_id IS NOT NULL
+      )
+    SQL
+  end
+  private_class_method :refresh_user_counters!
+
+  def self.refresh_organisation_counters!(connection)
+    connection.execute(<<~SQL)
+      WITH affected_roots AS (
+        SELECT DISTINCT COALESCE(groups.parent_id, groups.id) AS id
+        FROM groups
+        INNER JOIN membership_reference_integrity_invalid invalid
+          ON invalid.group_id = groups.id
+      )
+      UPDATE groups roots
+      SET org_members_count = (
+        SELECT COUNT(DISTINCT memberships.user_id)
+        FROM memberships
+        INNER JOIN groups member_groups ON member_groups.id = memberships.group_id
+        WHERE memberships.revoked_at IS NULL
+          AND (member_groups.id = roots.id OR member_groups.parent_id = roots.id)
+      )
+      WHERE roots.id IN (SELECT id FROM affected_roots)
+    SQL
+  end
+  private_class_method :refresh_organisation_counters!
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_09_09_000000) do
+ActiveRecord::Schema[8.1].define(version: 2026_09_09_000002) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "hstore"
@@ -493,7 +493,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_09_000000) do
     t.datetime "created_at", precision: nil
     t.boolean "delegate", default: false, null: false
     t.jsonb "experiences", default: {}, null: false
-    t.integer "group_id"
+    t.integer "group_id", null: false
     t.integer "inbox_position", default: 0
     t.integer "invitation_id"
     t.integer "inviter_id"
@@ -503,7 +503,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_09_000000) do
     t.string "title"
     t.string "token"
     t.datetime "updated_at", precision: nil
-    t.integer "user_id"
+    t.integer "user_id", null: false
     t.integer "volume_email", default: 2, null: false
     t.integer "volume_push", default: 2, null: false
     t.index ["created_at"], name: "index_memberships_on_created_at"
@@ -1499,6 +1499,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_09_000000) do
   add_foreign_key "discussions", "topics", deferrable: :deferred
   add_foreign_key "group_handle_redirects", "groups"
   add_foreign_key "legacy_anonymous_vote_reasons", "anonymous_ballots", on_delete: :cascade
+  add_foreign_key "memberships", "groups", on_delete: :cascade
+  add_foreign_key "memberships", "users", on_delete: :cascade
   add_foreign_key "mobile_access_tokens", "mobile_devices", on_delete: :cascade
   add_foreign_key "mobile_authorization_codes", "users", on_delete: :cascade
   add_foreign_key "mobile_devices", "users", on_delete: :cascade

--- a/test/controllers/admin/users_controller_test.rb
+++ b/test/controllers/admin/users_controller_test.rb
@@ -34,17 +34,6 @@ class Admin::UsersControllerTest < ActionController::TestCase
     refute_includes response.body, ">Edit</a>"
   end
 
-  test "show renders memberships with a missing group" do
-    membership = memberships(:user_membership)
-    missing_group_id = Group.maximum(:id) + 100
-    membership.update_columns(group_id: missing_group_id)
-
-    get :show, params: { id: @user.id }
-
-    assert_response :success
-    assert_includes response.body, "Missing group ##{missing_group_id}"
-  end
-
   test "show uses Sign in as wording and native confirmation" do
     get :show, params: { id: @user.id }
 

--- a/test/controllers/api_access_controller_test.rb
+++ b/test/controllers/api_access_controller_test.rb
@@ -58,24 +58,6 @@ class ApiAccessControllerTest < ActionController::TestCase
     assert_select "a[href='/g/#{pending_group.key}']", count: 0
   end
 
-  test "signed in user can open the page with a dangling membership" do
-    dangling_membership = Membership.create!(
-      user: @user,
-      group: groups(:public_group),
-      inviter: @alien,
-      accepted_at: Time.current
-    )
-    dangling_membership.update_columns(group_id: -1)
-    sign_in @user
-
-    get :show
-
-    assert_response :success
-    assert_select "code.api-access__key", @user.api_key
-    assert_select "a[href='/g/#{@group.key}']", @group.name
-    assert_select "a[href='/g/#{@subgroup.key}']", @subgroup.name
-  end
-
   test "API access page is not cached and does not load JavaScript" do
     sign_in @user
 

--- a/test/migrations/membership_reference_integrity_cleanup_test.rb
+++ b/test/migrations/membership_reference_integrity_cleanup_test.rb
@@ -1,0 +1,49 @@
+require "test_helper"
+require Rails.root.join("db/migrate/support/membership_reference_integrity_cleanup")
+
+class MembershipReferenceIntegrityCleanupTest < ActiveSupport::TestCase
+  test "deletes invalid memberships and refreshes affected counters" do
+    group = groups(:group)
+    user = users(:user)
+    missing_group_id = Group.maximum(:id) + 1
+    missing_user_id = User.maximum(:id) + 1
+    now = Time.current
+    attributes = {
+      accepted_at: now,
+      admin: true,
+      created_at: now,
+      delegate: true,
+      group_id: group.id,
+      updated_at: now,
+      user_id: missing_user_id,
+      volume_email: Membership.volume_emails.fetch("normal"),
+      volume_push: Membership.volume_pushes.fetch("normal")
+    }
+
+    invalid_ids = ActiveRecord::Base.connection.disable_referential_integrity do
+      Membership.insert_all!([
+        attributes,
+        attributes.merge(group_id: missing_group_id, user_id: user.id)
+      ]).rows.flatten
+    end
+    group.update_columns(
+      memberships_count: 99,
+      pending_memberships_count: 99,
+      admin_memberships_count: 99,
+      delegates_count: 99,
+      org_members_count: 99
+    )
+    user.update_columns(memberships_count: 99)
+
+    MembershipReferenceIntegrityCleanup.run!(ActiveRecord::Base.connection)
+
+    assert_not Membership.where(id: invalid_ids).exists?
+    group.reload
+    assert_equal group.memberships.count, group.memberships_count
+    assert_equal group.memberships.pending.count, group.pending_memberships_count
+    assert_equal group.admin_memberships.count, group.admin_memberships_count
+    assert_equal group.memberships.delegates.count, group.delegates_count
+    assert_equal Membership.active.where(group_id: group.id_and_subgroup_ids).distinct.count(:user_id), group.org_members_count
+    assert_equal user.memberships.count, user.reload.memberships_count
+  end
+end

--- a/test/models/membership_reference_integrity_test.rb
+++ b/test/models/membership_reference_integrity_test.rb
@@ -1,0 +1,49 @@
+require "test_helper"
+
+class MembershipReferenceIntegrityTest < ActiveSupport::TestCase
+  test "memberships require existing users and groups" do
+    attributes = {
+      accepted_at: Time.current,
+      admin: false,
+      created_at: Time.current,
+      delegate: false,
+      group_id: groups(:group).id,
+      updated_at: Time.current,
+      user_id: users(:user).id,
+      volume_email: Membership.volume_emails.fetch("normal"),
+      volume_push: Membership.volume_pushes.fetch("normal")
+    }
+
+    assert_raises(ActiveRecord::NotNullViolation) do
+      Membership.transaction(requires_new: true) do
+        Membership.insert_all!([ attributes.merge(group_id: nil) ])
+      end
+    end
+    assert_raises(ActiveRecord::NotNullViolation) do
+      Membership.transaction(requires_new: true) do
+        Membership.insert_all!([ attributes.merge(user_id: nil) ])
+      end
+    end
+    assert_raises(ActiveRecord::InvalidForeignKey) do
+      Membership.transaction(requires_new: true) do
+        Membership.insert_all!([ attributes.merge(group_id: Group.maximum(:id) + 1) ])
+      end
+    end
+    assert_raises(ActiveRecord::InvalidForeignKey) do
+      Membership.transaction(requires_new: true) do
+        Membership.insert_all!([ attributes.merge(user_id: User.maximum(:id) + 1) ])
+      end
+    end
+  end
+
+  test "database cascades remove memberships with deleted users and groups" do
+    group_membership = memberships(:member_membership)
+    user_membership = memberships(:admin_membership)
+
+    Group.where(id: group_membership.group_id).delete_all
+    User.where(id: user_membership.user_id).delete_all
+
+    assert_not Membership.exists?(group_membership.id)
+    assert_not Membership.exists?(user_membership.id)
+  end
+end

--- a/test/services/cleanup_service_test.rb
+++ b/test/services/cleanup_service_test.rb
@@ -74,9 +74,9 @@ class CleanupServiceTest < ActiveSupport::TestCase
 
     audit = CleanupService.audit_orphan_records
 
-    assert_equal 1, audit[:dangling_records]["Membership.missing_group"]
+    assert_not_includes audit[:dangling_records], "Membership.missing_group"
     assert_equal 1, audit[:dangling_records]["Subscription.missing_group"]
-    assert Membership.exists?(membership.id)
+    assert_not Membership.exists?(membership.id)
     assert Subscription.exists?(subscription.id)
   end
 


### PR DESCRIPTION
Membership rows currently rely on application validation: both reference columns are nullable and neither has a database foreign key. The production snapshot contained 334 historic memberships whose users no longer exist.

This removes invalid membership rows, refreshes the affected group and user counters, and then enforces `user_id` and `group_id` with `NOT NULL` plus validated cascading foreign keys. The constraints are installed unvalidated first so new violations stop immediately while the existing table is normalized, then validated in a second migration. The now-impossible `Membership.missing_group` orphan-cleanup category is removed.

Production-snapshot rehearsal:

- memberships: 593,491 before, 593,157 after
- invalid references: 334 before, 0 after
- normalization migration: 3.02 seconds
- validation migration: 0.28 seconds
- full Rails migration command: 5.34 seconds

Validation:

- `bin/rails test test/migrations/membership_reference_integrity_cleanup_test.rb test/models/membership_reference_integrity_test.rb test/models/membership_test.rb test/services/membership_service_test.rb test/services/cleanup_service_test.rb test/workers/destroy_group_worker_test.rb`
- 53 runs, 317 assertions, 0 failures
- both migrations tested down and up
- RuboCop, Brakeman, Bundler Audit, and translation checks pass
