### PR TITLE
Make topic tree repairs atomic

### DIFF
--- a/app/services/topic_service.rb
+++ b/app/services/topic_service.rb
@@ -298,25 +298,27 @@ class TopicService
     topic = Topic.find_by(id: topic_id)
     return unless topic
 
-    repair(topic.id)
-    topic.reload
+    Topic.transaction do
+      repair(topic.id)
+      topic.reload
 
-    root_topic_item = topic.topicable.created_topic_item
-    return unless root_topic_item
+      root_topic_item = topic.topicable.created_topic_item
+      next unless root_topic_item
 
-    topic_item_ids = TopicItem.where(topic_id: topic.id)
-                     .where.not(id: root_topic_item.id)
-                     .order(:created_at, :id)
-                     .pluck(:id)
+      topic_item_ids = TopicItem.where(topic_id: topic.id)
+                       .where.not(id: root_topic_item.id)
+                       .order(:created_at, :id)
+                       .pluck(:id)
 
-    TopicItem.where(topic_id: topic.id).update_all(sequence_id: nil, position: 0, position_key: nil)
-    TopicItem.where(id: root_topic_item.id).update_all(sequence_id: 0, position: 0, depth: 0, parent_id: nil, position_key: '00000', topic_id: topic.id)
+      TopicItem.where(topic_id: topic.id).update_all(sequence_id: nil, position: 0, position_key: nil)
+      TopicItem.where(id: root_topic_item.id).update_all(sequence_id: 0, position: 0, depth: 0, parent_id: nil, position_key: '00000', topic_id: topic.id)
 
-    topic_item_ids.each.with_index(1) do |topic_item_id, sequence_id|
-      TopicItem.where(id: topic_item_id).update_all(sequence_id: sequence_id)
+      topic_item_ids.each.with_index(1) do |topic_item_id, sequence_id|
+        TopicItem.where(id: topic_item_id).update_all(sequence_id: sequence_id)
+      end
+
+      repair(topic.id)
     end
-
-    repair(topic.id)
   end
 
   def self.repair(topic_id)
@@ -325,6 +327,10 @@ class TopicService
     topicable = topic.topicable
     return unless topicable
 
+    Topic.transaction { repair_topic(topic, topicable) }
+  end
+
+  def self.repair_topic(topic, topicable)
     # ensure topicable.created_topic_item exists
     unless topicable.created_topic_item
       TopicItem.import [TopicItem.new(kind: topicable.created_topic_item_kind.to_s,
@@ -385,6 +391,8 @@ class TopicService
       )
     end
   end
+
+  private_class_method :repair_topic
 
   def self.verify_integrity!(topic_id)
     topic_items = TopicItem.where(topic_id: topic_id).to_a

--- a/test/services/topic_service_test.rb
+++ b/test/services/topic_service_test.rb
@@ -116,6 +116,16 @@ class TopicServiceTest < ActiveSupport::TestCase
     refute_equal 999, @discussion_event.reload.child_count
   end
 
+  test "repair does not retain a partially rebuilt topic tree" do
+    original_positions = @topic.items.order(:id).pluck(:id, :parent_id, :position, :position_key, :depth)
+
+    TopicService.stub(:reset_child_positions, ->(*) { raise "repair interrupted" }) do
+      assert_raises(RuntimeError) { TopicService.repair(@topic.id) }
+    end
+
+    assert_equal original_positions, @topic.items.reload.order(:id).pluck(:id, :parent_id, :position, :position_key, :depth)
+  end
+
   test "database rejects a child whose parent belongs to another topic" do
     target = DiscussionService.create(
       params: {title: "Target discussion", group_id: @group.id},


### PR DESCRIPTION
## Summary

- Wrap topic tree repair in a transaction
- Keep chronological resequencing atomic across both repair passes
- Add regression coverage proving interrupted repairs roll back partial position changes

## Why

Topic repair temporarily clears `position_key` while rebuilding a tree. Without a transaction, concurrent API requests can serialize that intermediate state and the client later fails when it calls `.split()` on the null key (LOOMIO-CT / LOOMIO-AW).

A production diagnostic found zero persistently null `position_key` values, including in the affected topic, which is consistent with a transient repair state.

## Verification

- `mise exec -- bin/rails test test/services/topic_service_test.rb`
- 20 runs, 63 assertions, 0 failures, 0 errors
- Pre-push Brakeman and bundler-audit checks passed
